### PR TITLE
Allow getting programmatically the D2Api instance

### DIFF
--- a/src/api/d2-api.ts
+++ b/src/api/d2-api.ts
@@ -56,11 +56,20 @@ export default class D2Api {
         if (D2Api.instances.length === 0) {
             throw "D2Api has not been initialized yet, please make sure you have already called createInstance()";
         }
+
         return [...D2Api.instances];
     }
 
-    public static getInstance(): D2Api {
-        return D2Api.getInstances()[0];
+    public static getInstance(alias?: string): D2Api {
+        const found = _.find(D2Api.instances, ["options.alias", alias])
+        
+        if (D2Api.instances.length === 0) {
+            throw "D2Api has not been initialized yet, please make sure you have already called createInstance()";
+        } else if (alias && !found) {
+            throw "Invalid alias for an existing D2Api instance, please make sure you have created such instance";
+        }
+
+        return found || D2Api.getInstances()[0];
     }
 
     public request<T>(config: AxiosRequestConfig): D2ApiResponse<T> {


### PR DESCRIPTION
### Motivation

- I find it would be helpful to initialize the ``D2Api`` from index.ts or App.tsx.
- Instead of passing down the instance object everywhere or being forced to use the react context outside of components, we can create a pseudo-singleton pattern.
- For apps like metadata sync we would like to allow having multiple instances running at the same time for synchronization between them.
- When you introduce multiple instances, aliasing them makes it easier to find and use the correct instance
- Exposing the original ``options`` could be helpful also and allows to be transparent about what the API is receiving. I do not like to leak the password through the object though.

### Limitations

- We might need to force that ``React.context`` only uses the first initialized instance.

### Example usage

index.ts
```ts
D2Api.createInstance({ baseUrl, alias: "main" });
```

context.ts
```ts
export const D2ApiContext = React.createContext<D2Api>(D2Api.getInstance());
```

logic/sync.ts
```ts
const defaultInstance = D2Api.getInstance();
const namedInstance = D2Api.getInstance("main");
const allInstances = D2Api.getInstances();
```