### PR TITLE
[Fix] Bump beta version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "d2-api",
     "description": "Typed wrapper over DHIS2 API",
-    "version": "0.0.2-beta.15",
+    "version": "0.0.2-beta.16",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "repository": {


### PR DESCRIPTION
On the last merge of #17 we forgot to release a beta. Updating so the build on travis for ``metadata-sync`` works properly.