### PR TITLE
Feature/allow multiple filters on same field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "d2-api",
     "description": "Typed wrapper over DHIS2 API",
-    "version": "0.0.2-beta.15",
+    "version": "0.0.2-beta.17",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "repository": {

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -45,7 +45,7 @@ type FilterValue = Partial<
 >;
 
 export interface Filter {
-    [property: string]: undefined | FilterValue | FilterValue[];
+    [property: string]: FilterValue | FilterValue[] | undefined;
 }
 
 function applyFieldTransformers(key: string, value: any) {


### PR DESCRIPTION
Required by:
- https://github.com/EyeSeeTea/project-monitoring-app/pull/145
- https://github.com/EyeSeeTea/metadata-synchronization/pull/318 (https://github.com/EyeSeeTea/metadata-synchronization/pull/318/commits/b91484bcd081dfaea214a814ca6b536c2ec839d8)

Previously, we only supported a filter for the same field/operator. Example: 

`{name: {like: "abc", ilike: "ab"}, code: {eq: "XYZ"}}`. 

This works just fine when applying AND filters (which is the default), but when using OR filters (`rootJunction=OR`), we should be able to pass a different filter for same field and operator. We can now pass also an array:

`.get({rootJunction: "OR", {code: [{eq: "C1"}, {eq: "C2"}]}})`

which generates `filter=code:eq:C1&filter=code:eq:C2&rootJunction=OR`. 

Deployed: 0.0.2-beta.17