### PR TITLE
Origin/feature/complete current user

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,21 @@
+/** @format */
+
+module.exports = {
+    extends: [
+        "eslint:recommended",
+        "plugin:@typescript-eslint/recommended",
+        "prettier/@typescript-eslint",
+        "plugin:prettier/recommended",
+    ],
+    rules: {
+        "no-console": "off",
+        "@typescript-eslint/explicit-function-return-type": ["off"],
+        "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+        "@typescript-eslint/no-use-before-define": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-empty-interface": "off",
+        "@typescript-eslint/ban-ts-ignore": "off",
+        "@typescript-eslint/prefer-interface": "off",
+        "no-dupe-class-members": "off",
+    },
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "d2-api",
     "description": "Typed wrapper over DHIS2 API",
-    "version": "0.1.0",
+    "version": "0.1.1-beta.1",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "repository": {

--- a/src/api/current-user.ts
+++ b/src/api/current-user.ts
@@ -2,10 +2,52 @@ import { SelectedPick } from "./inference";
 import { D2ApiResponse, processFieldsFilterParams } from "./common";
 import { D2Api } from "./d2-api";
 import { Selector } from "./inference";
-import { D2UserSchema } from "./../schemas/models";
+import {
+    D2UserSchema,
+    D2DataSet,
+    D2Program,
+    D2DataSetSchema,
+    D2ProgramSchema,
+} from "./../schemas/models";
+
+interface ExtraModelAttributes {
+    authorities: string[];
+    dataSets: D2DataSet;
+    programs: D2Program;
+    settings: Settings;
+}
+
+type ExtraProperties = keyof ExtraModelAttributes;
+type RemovedProperties = "href";
+
+export interface Settings {
+    keyMessageSmsNotification: boolean;
+    keyDbLocale: string;
+    keyStyle: string;
+    keyUiLocale: string;
+    keyAnalysisDisplayProperty: string;
+    keyMessageEmailNotification: boolean;
+}
+
+interface MeSchema {
+    model: Omit<D2UserSchema["model"], RemovedProperties> & ExtraModelAttributes;
+    fields: Omit<D2UserSchema["fields"], RemovedProperties> & {
+        authorities: string[];
+        dataSets: D2DataSetSchema;
+        programs: D2ProgramSchema;
+        settings: Settings;
+    };
+    fieldPresets: {
+        $all: D2UserSchema["fieldPresets"]["$all"] & ExtraProperties;
+        $identifiable: D2UserSchema["fieldPresets"]["$identifiable"] & ExtraProperties;
+        $nameable: D2UserSchema["fieldPresets"]["$nameable"] & ExtraProperties;
+        $persisted: D2UserSchema["fieldPresets"]["$persisted"] & ExtraProperties;
+        $owner: D2UserSchema["fieldPresets"]["$owner"] & ExtraProperties;
+    };
+}
 
 interface GetOptions {
-    fields: Selector<D2UserSchema>;
+    fields: Selector<MeSchema>;
 }
 
 export default class D2ApiCurrentUser {
@@ -13,7 +55,7 @@ export default class D2ApiCurrentUser {
         this.api = api;
     }
 
-    get<Options extends GetOptions, User = SelectedPick<D2UserSchema, Options["fields"]>>(
+    get<Options extends GetOptions, User = SelectedPick<MeSchema, Options["fields"]>>(
         options: Options
     ): D2ApiResponse<User> {
         const params = processFieldsFilterParams(options as any);

--- a/src/api/d2-api.ts
+++ b/src/api/d2-api.ts
@@ -4,7 +4,7 @@ import _ from "lodash";
 import { D2ModelSchemas, D2ModelEnum } from "./../schemas/models";
 import { joinPath, prepareConnection } from "../utils/connection";
 import Metadata from "./metadata";
-import Models from "./models";
+import Model from "./model";
 
 import { Params, D2ApiResponse } from "./common";
 import CurrentUser from "./current-user";
@@ -18,7 +18,7 @@ export interface D2ApiOptions {
     auth?: AxiosBasicCredentials;
 }
 
-type IndexedModels = { [ModelName in keyof D2ModelSchemas]: Models<ModelName> };
+type IndexedModels = { [ModelName in keyof D2ModelSchemas]: Model<ModelName> };
 
 export class D2ApiDefault {
     public baseUrl: string;
@@ -42,7 +42,7 @@ export class D2ApiDefault {
         this.analytics = new Analytics(this);
         this.dataValues = new DataValues(this);
         this.models = _(Object.keys(D2ModelEnum))
-            .map((modelName: keyof D2ModelSchemas) => [modelName, new Models(this, modelName)])
+            .map((modelName: keyof D2ModelSchemas) => [modelName, new Model(this, modelName)])
             .fromPairs()
             .value() as IndexedModels;
     }

--- a/src/api/inference.ts
+++ b/src/api/inference.ts
@@ -1,4 +1,4 @@
-import { FieldPreset } from "./../schemas/base";
+import { FieldPreset, Ref } from "./../schemas/base";
 
 /* Generic Helpers */
 
@@ -93,8 +93,14 @@ type SelectorKey<
     : ModelSelector[K] extends true
     ? (IsLiteral<Model["fields"][K]> extends true
           ? Model["fields"][K]
-          : (Model["fields"] extends { id: string } ? { id: string } : never))
+          : GetTrueSelectionOnNonLiteral<Model["fields"][K]>)
     : never;
+
+type GetTrueSelectionOnNonLiteral<SchemaValue> = SchemaValue extends Array<infer T>
+    ? (T extends { fieldPresets: any } ? Ref[] : T[])
+    : SchemaValue extends { fieldPresets: any }
+    ? Ref
+    : SchemaValue;
 
 export type SelectedPickFields<
     Model extends ModelInfoBase,

--- a/src/api/model.ts
+++ b/src/api/model.ts
@@ -62,7 +62,7 @@ type GetObject<ModelKey extends keyof D2ModelSchemas, Options> = SelectedPick<
     GetFields<Options>
 >;
 
-export default class D2ApiModel<ModelKey extends keyof D2ModelSchemas> {
+export default class Model<ModelKey extends keyof D2ModelSchemas> {
     d2Api: D2Api;
     modelName: ModelKey;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,10 @@ export {
     NonPaginatedObjects,
     GetParams,
     UpdateOptions,
-} from "./api/models";
+} from "./api/model";
+
+import Model from "./api/model";
+export { Model };
 
 export { Id, Ref } from "./schemas/base";
 export { Selector, SelectedPick } from "./api/inference";


### PR DESCRIPTION
Fixes #9, #24 

Notes:

- The response to `/api/me` is similar to a `User` (what we were using), but not quite. Now we have the real response typed.

Required by https://github.com/EyeSeeTea/Bulk-Load/issues/22

@SferaDev This should fix the problem you had with coc->categoryOptions being {id: string} instead of Array<{id: string}>. Also, I renamed Models->Model and exported it, the thing we were discussing before.