### PR TITLE
Implement /api/system endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "d2-api",
     "description": "Typed wrapper over DHIS2 API",
-    "version": "0.2.1",
+    "version": "0.2.2-beta.1",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "repository": {

--- a/src/api/d2-api.ts
+++ b/src/api/d2-api.ts
@@ -11,6 +11,7 @@ import CurrentUser from "./current-user";
 import DataStore from "./dataStore";
 import Analytics from "./analytics";
 import DataValues from "./dataValues";
+import System from "./system";
 
 export interface D2ApiOptions {
     baseUrl?: string;
@@ -30,6 +31,7 @@ export class D2ApiDefault {
     public currentUser: CurrentUser;
     public analytics: Analytics;
     public dataValues: DataValues;
+    public system: System;
 
     public constructor(options?: D2ApiOptions) {
         const { baseUrl = "http://localhost:8080", apiVersion, auth } = options || {};
@@ -41,6 +43,7 @@ export class D2ApiDefault {
         this.currentUser = new CurrentUser(this);
         this.analytics = new Analytics(this);
         this.dataValues = new DataValues(this);
+        this.system = new System(this);
         this.models = _(Object.keys(D2ModelEnum))
             .map((modelName: keyof D2ModelSchemas) => [modelName, new Model(this, modelName)])
             .fromPairs()

--- a/src/api/system.ts
+++ b/src/api/system.ts
@@ -14,12 +14,12 @@ export default class System {
     }
 
     get info(): D2ApiResponse<SystemInfo> {
-        return this.d2Api.request<SystemInfo>({ method: "GET", url: `/system/info` });
+        return this.d2Api.request({ method: "GET", url: `/system/info` });
     }
 
     ping(): D2ApiResponse<boolean> {
         return this.d2Api
-            .request<unknown>({
+            .request({
                 method: "GET",
                 url: `/system/info`,
                 validateStatus: (status: number) => [200, 302, 401].includes(status),
@@ -28,22 +28,22 @@ export default class System {
     }
 
     getTaskEntries(selector: TaskSelector): D2ApiResponse<TaskEntry[]> {
-        return this.d2Api.request<TaskEntry[]>({
+        return this.d2Api.request({
             method: "GET",
             url: _.compact(["/system/tasks", selector.category, selector.id]).join("/"),
         });
     }
 
     get tasks(): D2ApiResponse<Tasks> {
-        return this.d2Api.request<Tasks>({ method: "GET", url: `/system/tasks` });
+        return this.d2Api.request({ method: "GET", url: `/system/tasks` });
     }
 
     get flags(): D2ApiResponse<SystemItem[]> {
-        return this.d2Api.request<SystemItem[]>({ method: "GET", url: `/system/flags` });
+        return this.d2Api.request({ method: "GET", url: `/system/flags` });
     }
 
     get styles(): D2ApiResponse<SystemItem[]> {
-        return this.d2Api.request<SystemItem[]>({ method: "GET", url: `/system/styles` });
+        return this.d2Api.request({ method: "GET", url: `/system/styles` });
     }
 }
 

--- a/src/api/system.ts
+++ b/src/api/system.ts
@@ -1,0 +1,162 @@
+import _ from "lodash";
+
+import { D2ApiResponse } from "./common";
+import { D2Api } from "./d2-api";
+import { Id } from "../schemas";
+
+export default class System {
+    constructor(public d2Api: D2Api) {}
+
+    getIds(options: { limit?: number }): D2ApiResponse<Id[]> {
+        return this.d2Api
+            .request<{ codes: Id[] }>({ method: "GET", url: `/system/id`, params: options })
+            .map(res => (res.data && res.data.codes) || []);
+    }
+
+    get info(): D2ApiResponse<SystemInfo> {
+        return this.d2Api.request<SystemInfo>({ method: "GET", url: `/system/info` });
+    }
+
+    ping(): D2ApiResponse<boolean> {
+        return this.d2Api
+            .request<unknown>({
+                method: "GET",
+                url: `/system/info`,
+                validateStatus: (status: number) => [200, 302, 401].includes(status),
+            })
+            .map(res => res.status === 200);
+    }
+
+    getTaskEntries(selector: TaskSelector): D2ApiResponse<TaskEntry[]> {
+        return this.d2Api.request<TaskEntry[]>({
+            method: "GET",
+            url: _.compact(["/system/tasks", selector.category, selector.id]).join("/"),
+        });
+    }
+
+    get tasks(): D2ApiResponse<Tasks> {
+        return this.d2Api.request<Tasks>({ method: "GET", url: `/system/tasks` });
+    }
+
+    get flags(): D2ApiResponse<SystemItem[]> {
+        return this.d2Api.request<SystemItem[]>({ method: "GET", url: `/system/flags` });
+    }
+
+    get styles(): D2ApiResponse<SystemItem[]> {
+        return this.d2Api.request<SystemItem[]>({ method: "GET", url: `/system/styles` });
+    }
+}
+
+export interface SystemItem {
+    name: string;
+    key: string;
+    path: string;
+}
+
+export type Tasks = Record<TaskCategory, Record<Id, TaskEntry[]>>;
+
+export type TaskCategory =
+    | "ANALYTICSTABLE_UPDATE"
+    | "ANALYTICS_TABLE"
+    | "COMPLETE_DATA_SET_REGISTRATION_IMPORT"
+    | "CREDENTIALS_EXPIRY_ALERT"
+    | "DATAVALUE_IMPORT"
+    | "DATAVALUE_IMPORT_INTERNAL"
+    | "DATA_INTEGRITY"
+    | "DATA_SET_NOTIFICATION"
+    | "DATA_STATISTICS"
+    | "DATA_SYNC"
+    | "ENROLLMENT_IMPORT"
+    | "EVENT_IMPORT"
+    | "FILE_RESOURCE_CLEANUP"
+    | "GML_IMPORT"
+    | "LEADER_ELECTION"
+    | "LEADER_RENEWAL"
+    | "METADATA_IMPORT"
+    | "META_DATA_SYNC"
+    | "MOCK"
+    | "MONITORING"
+    | "PREDICTOR"
+    | "PROGRAM_DATA_SYNC"
+    | "PROGRAM_NOTIFICATIONS"
+    | "PUSH_ANALYSIS"
+    | "REMOVE_EXPIRED_RESERVED_VALUES"
+    | "RESOURCE_TABLE"
+    | "SEND_SCHEDULED_MESSAGE"
+    | "SMS_SEND"
+    | "TEI_IMPORT"
+    | "VALIDATION_RESULTS_NOTIFICATION";
+
+export interface TaskSelector {
+    category: TaskCategory;
+    id?: Id;
+}
+
+export interface TaskEntry {
+    uid: Id;
+    level: string;
+    category: TaskCategory;
+    time: string;
+    message: string;
+    completed: boolean;
+}
+
+export interface SystemInfo {
+    // Docs: If the user who is requesting this resource does not have full authority in the
+    // system then only the first seven properties will be included, as this information is
+    // security sensitive.
+    contextPath: string;
+    userAgent: string;
+    version: string;
+    revision: string;
+    buildTime: Date;
+    serverDate: Date;
+    environmentVariable: string;
+
+    javaVersion?: string;
+    javaVendor?: string;
+    calendar?: string;
+    dateFormat?: string;
+    lastAnalyticsTableSuccess?: Date;
+    intervalSinceLastAnalyticsTableSuccess?: string;
+    lastAnalyticsTableRuntime?: string;
+    jasperReportsVersion?: string;
+    fileStoreProvider?: string;
+    readOnlyMode?: string;
+    nodeId?: string;
+    osName?: string;
+    osArchitecture?: string;
+    osVersion?: string;
+    externalDirectory?: string;
+    databaseInfo?: {
+        name: string;
+        user: string;
+        spatialSupport: boolean;
+    };
+    readReplicaCount?: number;
+    memoryInfo?: string;
+    cpuCores?: number;
+    encryption?: boolean;
+    emailConfigured?: boolean;
+    redisEnabled?: boolean;
+    systemId?: string;
+    systemName?: string;
+    clusterHostname?: string;
+    isMetadataVersionEnabled?: boolean;
+    metadataAudit?: {
+        persist: boolean;
+        log: boolean;
+    };
+    logging?: {
+        level: string;
+        format: string;
+        consoleEnabled: boolean;
+        consoleLevel: string;
+        consoleFormat: string;
+        fileEnabled: boolean;
+        fileName: string;
+        fileLevel: string;
+        fileFormat: string;
+    };
+    metadataSyncEnabled?: boolean;
+}


### PR DESCRIPTION
Closes #37 
Published: https://www.npmjs.com/package/d2-api/v/0.2.2-beta.1

I have implemented all `/api/system` endpoints except for `taskSummaries`, as it always returns `null` (tested in different dhis2 versions in play, also dev). I'd need to debug dhis2-core to be sure what the problem is, and open a JIRA issue if necessary. Since we don't use that endpoint (for now), I've done no further research.

OK: https://play.dhis2.org/2.32.4/api/system/tasks/DATA_SET_NOTIFICATION
Fail: https://play.dhis2.org/2.32.4/api/system/taskSummaries/DATA_SET_NOTIFICATION