### PR TITLE
Add support for version 2.34 [NOT FOR 1.1.0]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "d2-api",
     "description": "Typed wrapper over DHIS2 API",
-    "version": "1.4.2-beta.1",
+    "version": "1.5.0-beta.1",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "repository": {

--- a/src/2.32/schemas.ts
+++ b/src/2.32/schemas.ts
@@ -13,22 +13,21 @@ import {
     D2DimensionalKeywords,
     D2Expression,
     D2RelationshipConstraint,
+    D2ReportingParams,
+    D2Axis,
 } from "../schemas/base";
 
-export type D2AttributeValue = {
-    attribute: D2Attribute;
-    created: string;
-    lastUpdated: string;
-    value: string;
-};
-
-export type D2UserAuthorityGroup = {
+export type D2AnalyticsPeriodBoundary = {
     access: D2Access;
+    analyticsPeriodBoundaryType:
+        | "BEFORE_START_OF_REPORTING_PERIOD"
+        | "BEFORE_END_OF_REPORTING_PERIOD"
+        | "AFTER_START_OF_REPORTING_PERIOD"
+        | "AFTER_END_OF_REPORTING_PERIOD";
     attributeValues: D2AttributeValue[];
-    authorities: string[];
+    boundaryTarget: string;
     code: Id;
     created: string;
-    description: string;
     displayName: string;
     externalAccess: boolean;
     favorite: boolean;
@@ -38,12 +37,58 @@ export type D2UserAuthorityGroup = {
     lastUpdated: string;
     lastUpdatedBy: D2User;
     name: string;
+    offsetPeriodType: string;
+    offsetPeriods: number;
     publicAccess: string;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
-    users: D2User[];
+};
+
+export type D2AnalyticsTableHook = {
+    access: D2Access;
+    analyticsTableType:
+        | "DATA_VALUE"
+        | "COMPLETENESS"
+        | "COMPLETENESS_TARGET"
+        | "ORG_UNIT_TARGET"
+        | "EVENT"
+        | "ENROLLMENT"
+        | "VALIDATION_RESULT";
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    phase: "RESOURCE_TABLE_POPULATED" | "ANALYTICS_TABLE_POPULATED";
+    publicAccess: string;
+    resourceTableType:
+        | "ORG_UNIT_STRUCTURE"
+        | "DATA_SET_ORG_UNIT_CATEGORY"
+        | "CATEGORY_OPTION_COMBO_NAME"
+        | "DATA_ELEMENT_GROUP_SET_STRUCTURE"
+        | "INDICATOR_GROUP_SET_STRUCTURE"
+        | "ORG_UNIT_GROUP_SET_STRUCTURE"
+        | "CATEGORY_STRUCTURE"
+        | "DATA_ELEMENT_STRUCTURE"
+        | "PERIOD_STRUCTURE"
+        | "DATE_PERIOD_STRUCTURE"
+        | "DATA_ELEMENT_CATEGORY_OPTION_COMBO"
+        | "DATA_APPROVAL_REMAP_LEVEL"
+        | "DATA_APPROVAL_MIN_LEVEL";
+    sql: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
 };
 
 export type D2Attribute = {
@@ -133,334 +178,14 @@ export type D2Attribute = {
         | "IMAGE";
 };
 
-export type D2User = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    avatar: D2FileResource;
-    birthday: string;
-    code: Id;
+export type D2AttributeValue = {
+    attribute: D2Attribute;
     created: string;
-    dataViewOrganisationUnits: D2OrganisationUnit[];
-    displayName: string;
-    education: string;
-    email: string;
-    employer: string;
-    externalAccess: boolean;
-    facebookMessenger: string;
-    favorite: boolean;
-    favorites: string[];
-    firstName: string;
-    gender: string;
-    href: string;
-    id: Id;
-    interests: string;
-    introduction: string;
-    jobTitle: string;
-    languages: string;
-    lastCheckedInterpretations: string;
     lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    nationality: string;
-    organisationUnits: D2OrganisationUnit[];
-    phoneNumber: string;
-    publicAccess: string;
-    skype: string;
-    surname: string;
-    teiSearchOrganisationUnits: D2OrganisationUnit[];
-    telegram: string;
-    translations: D2Translation[];
-    twitter: string;
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userCredentials: D2UserCredentials;
-    userGroupAccesses: D2UserGroupAccess[];
-    userGroups: D2UserGroup[];
-    welcomeMessage: string;
-    whatsApp: string;
+    value: string;
 };
 
-export type D2UserGroup = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    managedByGroups: D2UserGroup[];
-    managedGroups: D2UserGroup[];
-    name: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    users: D2User[];
-};
-
-export type D2Expression = {
-    description: string;
-    expression: string;
-    missingValueStrategy: "SKIP_IF_ANY_VALUE_MISSING" | "SKIP_IF_ALL_VALUES_MISSING" | "NEVER_SKIP";
-    slidingWindow: boolean;
-};
-
-export type D2ExternalFileResource = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2SqlView = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    cacheStrategy:
-        | "NO_CACHE"
-        | "CACHE_15_MINUTES"
-        | "CACHE_30_MINUTES"
-        | "CACHE_1_HOUR"
-        | "CACHE_6AM_TOMORROW"
-        | "CACHE_TWO_WEEKS"
-        | "RESPECT_SYSTEM_SETTING";
-    code: Id;
-    created: string;
-    description: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    sqlQuery: string;
-    translations: D2Translation[];
-    type: "VIEW" | "MATERIALIZED_VIEW" | "QUERY";
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2OAuth2Client = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    cid: Id;
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    grantTypes: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    redirectUris: string[];
-    secret: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2Constant = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    shortName: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    value: number;
-};
-
-export type D2JobConfiguration = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    configurable: boolean;
-    continuousExecution: boolean;
-    created: string;
-    cronExpression: string;
-    displayName: string;
-    enabled: boolean;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    jobParameters: string;
-    jobStatus: "RUNNING" | "COMPLETED" | "STOPPED" | "SCHEDULED" | "DISABLED" | "FAILED";
-    jobType:
-        | "DATA_STATISTICS"
-        | "DATA_INTEGRITY"
-        | "RESOURCE_TABLE"
-        | "ANALYTICS_TABLE"
-        | "DATA_SYNC"
-        | "PROGRAM_DATA_SYNC"
-        | "FILE_RESOURCE_CLEANUP"
-        | "META_DATA_SYNC"
-        | "SMS_SEND"
-        | "SEND_SCHEDULED_MESSAGE"
-        | "PROGRAM_NOTIFICATIONS"
-        | "VALIDATION_RESULTS_NOTIFICATION"
-        | "CREDENTIALS_EXPIRY_ALERT"
-        | "MONITORING"
-        | "PUSH_ANALYSIS"
-        | "PREDICTOR"
-        | "DATA_SET_NOTIFICATION"
-        | "REMOVE_EXPIRED_RESERVED_VALUES"
-        | "MOCK"
-        | "DATAVALUE_IMPORT"
-        | "ANALYTICSTABLE_UPDATE"
-        | "METADATA_IMPORT"
-        | "GML_IMPORT"
-        | "DATAVALUE_IMPORT_INTERNAL"
-        | "EVENT_IMPORT"
-        | "ENROLLMENT_IMPORT"
-        | "TEI_IMPORT"
-        | "LEADER_ELECTION"
-        | "LEADER_RENEWAL"
-        | "COMPLETE_DATA_SET_REGISTRATION_IMPORT";
-    lastExecuted: string;
-    lastExecutedStatus: "RUNNING" | "COMPLETED" | "STOPPED" | "SCHEDULED" | "DISABLED" | "FAILED";
-    lastRuntimeExecution: string;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    leaderOnlyJob: boolean;
-    name: string;
-    nextExecutionTime: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    userUid: string;
-};
-
-export type D2Option = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: string;
-    created: string;
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    optionSet: D2OptionSet;
-    publicAccess: string;
-    shortName: string;
-    sortOrder: number;
-    style: D2Style;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2OptionSet = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    options: D2Option[];
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    valueType:
-        | "TEXT"
-        | "LONG_TEXT"
-        | "LETTER"
-        | "PHONE_NUMBER"
-        | "EMAIL"
-        | "BOOLEAN"
-        | "TRUE_ONLY"
-        | "DATE"
-        | "DATETIME"
-        | "TIME"
-        | "NUMBER"
-        | "UNIT_INTERVAL"
-        | "PERCENTAGE"
-        | "INTEGER"
-        | "INTEGER_POSITIVE"
-        | "INTEGER_NEGATIVE"
-        | "INTEGER_ZERO_OR_POSITIVE"
-        | "TRACKER_ASSOCIATE"
-        | "USERNAME"
-        | "COORDINATE"
-        | "ORGANISATION_UNIT"
-        | "AGE"
-        | "URL"
-        | "FILE_RESOURCE"
-        | "IMAGE";
-    version: number;
-};
-
-export type D2OptionGroupSet = {
+export type D2Category = {
     access: D2Access;
     aggregationType:
         | "SUM"
@@ -478,6 +203,8 @@ export type D2OptionGroupSet = {
         | "DEFAULT";
     allItems: boolean;
     attributeValues: D2AttributeValue[];
+    categoryCombos: D2CategoryCombo[];
+    categoryOptions: D2CategoryOption[];
     code: Id;
     created: string;
     dataDimension: boolean;
@@ -520,8 +247,6 @@ export type D2OptionGroupSet = {
     lastUpdatedBy: D2User;
     legendSet: D2LegendSet;
     name: string;
-    optionGroups: D2OptionGroup[];
-    optionSet: D2OptionSet;
     publicAccess: string;
     shortName: string;
     translations: D2Translation[];
@@ -530,349 +255,35 @@ export type D2OptionGroupSet = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2OptionGroup = {
-    access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
-    name: string;
-    optionSet: D2OptionSet;
-    options: D2Option[];
-    publicAccess: string;
-    shortName: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2ColorSet = {
+export type D2CategoryCombo = {
     access: D2Access;
     attributeValues: D2AttributeValue[];
-    code: Id;
-    colors: D2Color[];
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2LegendSet = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
+    categories: D2Category[];
+    categoryOptionCombos: D2CategoryOptionCombo[];
     code: Id;
     created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    legends: D2Legend[];
-    name: string;
-    publicAccess: string;
-    symbolizer: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2OrganisationUnit = {
-    access: D2Access;
-    address: string;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    ancestors: D2OrganisationUnit[];
-    attributeValues: D2AttributeValue[];
-    children: D2OrganisationUnit[];
-    closedDate: string;
-    code: Id;
-    comment: string;
-    contactPerson: string;
-    created: string;
-    dataSets: D2DataSet[];
-    description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    email: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    geometry: D2Geometry;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    leaf: boolean;
-    legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
-    level: number;
-    memberCount: number;
-    name: string;
-    openingDate: string;
-    organisationUnitGroups: D2OrganisationUnitGroup[];
-    parent: D2OrganisationUnit;
-    path: string;
-    phoneNumber: string;
-    programs: D2Program[];
-    publicAccess: string;
-    shortName: string;
-    translations: D2Translation[];
-    type: string;
-    url: string;
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    users: D2User[];
-};
-
-export type D2OrganisationUnitLevel = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    level: number;
-    name: string;
-    offlineLevels: number;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2OrganisationUnitGroup = {
-    access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    color: string;
-    created: string;
-    description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
-    formName: string;
-    geometry: D2Geometry;
-    groupSets: D2OrganisationUnitGroupSet[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
-    name: string;
-    organisationUnits: D2OrganisationUnit[];
-    publicAccess: string;
-    shortName: string;
-    symbol: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2OrganisationUnitGroupSet = {
-    access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    allItems: boolean;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    compulsory: boolean;
-    created: string;
-    dataDimension: boolean;
     dataDimensionType: "DISAGGREGATION" | "ATTRIBUTE";
-    description: string;
-    dimension: string;
-    dimensionType:
-        | "DATA_X"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "DATA_COLLAPSED"
-        | "CATEGORY_OPTION_COMBO"
-        | "ATTRIBUTE_OPTION_COMBO"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION_GROUP_SET"
-        | "DATA_ELEMENT_GROUP_SET"
-        | "ORGANISATION_UNIT_GROUP_SET"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY"
-        | "OPTION_GROUP_SET"
-        | "VALIDATION_RULE"
-        | "STATIC"
-        | "ORGANISATION_UNIT_LEVEL";
-    dimensionalKeywords: D2DimensionalKeywords;
-    displayDescription: string;
-    displayFormName: string;
     displayName: string;
-    displayShortName: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
-    filter: string;
-    formName: string;
     href: string;
     id: Id;
-    includeSubhierarchyInAnalytics: boolean;
-    items: any[];
+    isDefault: boolean;
     lastUpdated: string;
     lastUpdatedBy: D2User;
-    legendSet: D2LegendSet;
     name: string;
-    organisationUnitGroups: D2OrganisationUnitGroup[];
     publicAccess: string;
-    shortName: string;
+    skipTotal: boolean;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2CategoryDimension = {
+    category: D2Category;
+    categoryOptions: D2CategoryOption[];
 };
 
 export type D2CategoryOption = {
@@ -936,6 +347,68 @@ export type D2CategoryOption = {
     shortName: string;
     startDate: string;
     style: D2Style;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2CategoryOptionCombo = {
+    access: D2Access;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    attributeValues: D2AttributeValue[];
+    categoryCombo: D2CategoryCombo;
+    categoryOptions: D2CategoryOption[];
+    code: Id;
+    created: string;
+    description: string;
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    ignoreApproval: boolean;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
+    name: string;
+    publicAccess: string;
+    shortName: string;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
@@ -1073,7 +546,12 @@ export type D2CategoryOptionGroupSet = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2Category = {
+export type D2CategoryOptionGroupSetDimension = {
+    categoryOptionGroupSet: D2CategoryOptionGroupSet;
+    categoryOptionGroups: D2CategoryOptionGroup[];
+};
+
+export type D2Chart = {
     access: D2Access;
     aggregationType:
         | "SUM"
@@ -1089,36 +567,153 @@ export type D2Category = {
         | "NONE"
         | "CUSTOM"
         | "DEFAULT";
-    allItems: boolean;
+    attributeDimensions: any[];
     attributeValues: D2AttributeValue[];
-    categoryCombos: D2CategoryCombo[];
-    categoryOptions: D2CategoryOption[];
+    baseLineLabel: string;
+    baseLineValue: number;
+    category: string;
+    categoryDimensions: D2CategoryDimension[];
+    categoryOptionGroupSetDimensions: D2CategoryOptionGroupSetDimension[];
+    code: Id;
+    colorSet: D2ColorSet;
+    columns: any[];
+    completedOnly: boolean;
+    created: string;
+    cumulativeValues: boolean;
+    dataDimensionItems: any[];
+    dataElementDimensions: D2TrackedEntityDataElementDimension[];
+    dataElementGroupSetDimensions: D2DataElementGroupSetDimension[];
+    description: string;
+    digitGroupSeparator: "COMMA" | "SPACE" | "NONE";
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    domainAxisLabel: string;
+    endDate: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    filterDimensions: string[];
+    filters: any[];
+    formName: string;
+    hideEmptyRowItems: "NONE" | "BEFORE_FIRST" | "AFTER_LAST" | "BEFORE_FIRST_AFTER_LAST" | "ALL";
+    hideLegend: boolean;
+    hideSubtitle: boolean;
+    hideTitle: boolean;
+    href: string;
+    id: Id;
+    interpretations: D2Interpretation[];
+    itemOrganisationUnitGroups: D2OrganisationUnitGroup[];
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendDisplayStrategy: "FIXED" | "BY_DATA_ITEM";
+    legendSet: D2LegendSet;
+    name: string;
+    noSpaceBetweenColumns: boolean;
+    orgUnitField: string;
+    organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimension[];
+    organisationUnitLevels: number[];
+    organisationUnits: D2OrganisationUnit[];
+    parentGraphMap: D2Map;
+    percentStackedValues: boolean;
+    periods: any[];
+    programIndicatorDimensions: D2TrackedEntityProgramIndicatorDimension[];
+    publicAccess: string;
+    rangeAxisDecimals: number;
+    rangeAxisLabel: string;
+    rangeAxisMaxValue: number;
+    rangeAxisMinValue: number;
+    rangeAxisSteps: number;
+    regressionType: "NONE" | "LINEAR" | "POLYNOMIAL" | "LOESS";
+    relativePeriods: any;
+    rows: any[];
+    series: string;
+    seriesItems: any[];
+    shortName: string;
+    showData: boolean;
+    sortOrder: number;
+    startDate: string;
+    subscribed: boolean;
+    subscribers: string[];
+    subtitle: string;
+    targetLineLabel: string;
+    targetLineValue: number;
+    timeField: string;
+    title: string;
+    topLimit: number;
+    translations: D2Translation[];
+    type:
+        | "COLUMN"
+        | "STACKED_COLUMN"
+        | "BAR"
+        | "STACKED_BAR"
+        | "LINE"
+        | "AREA"
+        | "PIE"
+        | "RADAR"
+        | "GAUGE"
+        | "YEAR_OVER_YEAR_LINE"
+        | "YEAR_OVER_YEAR_COLUMN";
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    userOrganisationUnit: boolean;
+    userOrganisationUnitChildren: boolean;
+    userOrganisationUnitGrandChildren: boolean;
+    yearlySeries: string[];
+};
+
+export type D2Color = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    color: string;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ColorSet = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    colors: D2Color[];
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2Constant = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
     code: Id;
     created: string;
-    dataDimension: boolean;
-    dataDimensionType: "DISAGGREGATION" | "ATTRIBUTE";
     description: string;
-    dimension: string;
-    dimensionType:
-        | "DATA_X"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "DATA_COLLAPSED"
-        | "CATEGORY_OPTION_COMBO"
-        | "ATTRIBUTE_OPTION_COMBO"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION_GROUP_SET"
-        | "DATA_ELEMENT_GROUP_SET"
-        | "ORGANISATION_UNIT_GROUP_SET"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY"
-        | "OPTION_GROUP_SET"
-        | "VALIDATION_RULE"
-        | "STATIC"
-        | "ORGANISATION_UNIT_LEVEL";
-    dimensionalKeywords: D2DimensionalKeywords;
     displayDescription: string;
     displayFormName: string;
     displayName: string;
@@ -1126,14 +721,41 @@ export type D2Category = {
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
-    filter: string;
     formName: string;
     href: string;
     id: Id;
-    items: any[];
     lastUpdated: string;
     lastUpdatedBy: D2User;
-    legendSet: D2LegendSet;
+    name: string;
+    publicAccess: string;
+    shortName: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    value: number;
+};
+
+export type D2Dashboard = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    created: string;
+    dashboardItems: D2DashboardItem[];
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    itemCount: number;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
     name: string;
     publicAccess: string;
     shortName: string;
@@ -1143,88 +765,102 @@ export type D2Category = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2CategoryCombo = {
+export type D2DashboardItem = {
+    access: D2Access;
+    appKey: string;
+    attributeValues: D2AttributeValue[];
+    chart: D2Chart;
+    code: Id;
+    contentCount: number;
+    created: string;
+    displayName: string;
+    eventChart: D2EventChart;
+    eventReport: D2EventReport;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    height: number;
+    href: string;
+    id: Id;
+    interpretationCount: number;
+    interpretationLikeCount: number;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    map: D2Map;
+    messages: boolean;
+    name: string;
+    publicAccess: string;
+    reportTable: D2ReportTable;
+    reports: D2Report[];
+    resources: D2Document[];
+    shape: "NORMAL" | "DOUBLE_WIDTH" | "FULL_WIDTH";
+    text: string;
+    translations: D2Translation[];
+    type:
+        | "CHART"
+        | "EVENT_CHART"
+        | "MAP"
+        | "REPORT_TABLE"
+        | "EVENT_REPORT"
+        | "USERS"
+        | "REPORTS"
+        | "RESOURCES"
+        | "TEXT"
+        | "MESSAGES"
+        | "APP";
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    users: D2User[];
+    width: number;
+    x: number;
+    y: number;
+};
+
+export type D2DataApprovalLevel = {
     access: D2Access;
     attributeValues: D2AttributeValue[];
-    categories: D2Category[];
-    categoryOptionCombos: D2CategoryOptionCombo[];
+    categoryOptionGroupSet: D2CategoryOptionGroupSet;
     code: Id;
     created: string;
-    dataDimensionType: "DISAGGREGATION" | "ATTRIBUTE";
     displayName: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
     href: string;
     id: Id;
-    isDefault: boolean;
     lastUpdated: string;
     lastUpdatedBy: D2User;
+    level: number;
     name: string;
+    orgUnitLevel: number;
+    orgUnitLevelName: string;
     publicAccess: string;
-    skipTotal: boolean;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2CategoryOptionCombo = {
+export type D2DataApprovalWorkflow = {
     access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
     attributeValues: D2AttributeValue[];
     categoryCombo: D2CategoryCombo;
-    categoryOptions: D2CategoryOption[];
     code: Id;
     created: string;
-    description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
-    displayDescription: string;
-    displayFormName: string;
+    dataApprovalLevels: D2DataApprovalLevel[];
+    dataSets: D2DataSet[];
     displayName: string;
-    displayShortName: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
-    formName: string;
     href: string;
     id: Id;
-    ignoreApproval: boolean;
     lastUpdated: string;
     lastUpdatedBy: D2User;
-    legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
     name: string;
+    periodType: string;
     publicAccess: string;
-    shortName: string;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
@@ -1459,78 +1095,13 @@ export type D2DataElementGroupSet = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2IndicatorType = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    factor: number;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    number: boolean;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
+export type D2DataElementGroupSetDimension = {
+    dataElementGroupSet: D2DataElementGroupSet;
+    dataElementGroups: D2DataElementGroup[];
 };
 
-export type D2AnalyticsTableHook = {
+export type D2DataElementOperand = {
     access: D2Access;
-    analyticsTableType:
-        | "DATA_VALUE"
-        | "COMPLETENESS"
-        | "COMPLETENESS_TARGET"
-        | "ORG_UNIT_TARGET"
-        | "EVENT"
-        | "ENROLLMENT"
-        | "VALIDATION_RESULT";
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    phase: "RESOURCE_TABLE_POPULATED" | "ANALYTICS_TABLE_POPULATED";
-    publicAccess: string;
-    resourceTableType:
-        | "ORG_UNIT_STRUCTURE"
-        | "DATA_SET_ORG_UNIT_CATEGORY"
-        | "CATEGORY_OPTION_COMBO_NAME"
-        | "DATA_ELEMENT_GROUP_SET_STRUCTURE"
-        | "INDICATOR_GROUP_SET_STRUCTURE"
-        | "ORG_UNIT_GROUP_SET_STRUCTURE"
-        | "CATEGORY_STRUCTURE"
-        | "DATA_ELEMENT_STRUCTURE"
-        | "PERIOD_STRUCTURE"
-        | "DATE_PERIOD_STRUCTURE"
-        | "DATA_ELEMENT_CATEGORY_OPTION_COMBO"
-        | "DATA_APPROVAL_REMAP_LEVEL"
-        | "DATA_APPROVAL_MIN_LEVEL";
-    sql: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2Indicator = {
-    access: D2Access;
-    aggregateExportAttributeOptionCombo: string;
-    aggregateExportCategoryOptionCombo: string;
     aggregationType:
         | "SUM"
         | "AVERAGE"
@@ -1545,14 +1116,12 @@ export type D2Indicator = {
         | "NONE"
         | "CUSTOM"
         | "DEFAULT";
-    annualized: boolean;
+    attributeOptionCombo: D2CategoryOptionCombo;
     attributeValues: D2AttributeValue[];
+    categoryOptionCombo: D2CategoryOptionCombo;
     code: Id;
     created: string;
-    dataSets: D2DataSet[];
-    decimals: number;
-    denominator: string;
-    denominatorDescription: string;
+    dataElement: D2DataElement;
     description: string;
     dimensionItem: string;
     dimensionItemType:
@@ -1570,11 +1139,9 @@ export type D2Indicator = {
         | "DATA_ELEMENT_GROUP"
         | "ORGANISATION_UNIT_GROUP"
         | "CATEGORY_OPTION_GROUP";
-    displayDenominatorDescription: string;
     displayDescription: string;
     displayFormName: string;
     displayName: string;
-    displayNumeratorDescription: string;
     displayShortName: string;
     externalAccess: boolean;
     favorite: boolean;
@@ -1582,66 +1149,13 @@ export type D2Indicator = {
     formName: string;
     href: string;
     id: Id;
-    indicatorGroups: D2IndicatorGroup[];
-    indicatorType: D2IndicatorType;
     lastUpdated: string;
     lastUpdatedBy: D2User;
     legendSet: D2LegendSet;
     legendSets: D2LegendSet[];
     name: string;
-    numerator: string;
-    numeratorDescription: string;
     publicAccess: string;
     shortName: string;
-    style: D2Style;
-    translations: D2Translation[];
-    url: string;
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2IndicatorGroup = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    indicatorGroupSet: D2IndicatorGroupSet;
-    indicators: D2Indicator[];
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2IndicatorGroupSet = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    compulsory: boolean;
-    created: string;
-    description: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    indicatorGroups: D2IndicatorGroup[];
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
@@ -1670,6 +1184,12 @@ export type D2DataEntryForm = {
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2DataInputPeriod = {
+    closingDate: string;
+    openingDate: string;
+    period: any;
 };
 
 export type D2DataSet = {
@@ -1759,6 +1279,12 @@ export type D2DataSet = {
     workflow: D2DataApprovalWorkflow;
 };
 
+export type D2DataSetElement = {
+    categoryCombo: D2CategoryCombo;
+    dataElement: D2DataElement;
+    dataSet: D2DataSet;
+};
+
 export type D2DataSetNotificationTemplate = {
     access: D2Access;
     attributeValues: D2AttributeValue[];
@@ -1791,172 +1317,15 @@ export type D2DataSetNotificationTemplate = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2Section = {
+export type D2Document = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
-    categoryCombos: D2CategoryCombo[];
-    code: Id;
-    created: string;
-    dataElements: D2DataElement[];
-    dataSet: D2DataSet;
-    description: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    greyedFields: D2DataElementOperand[];
-    href: string;
-    id: Id;
-    indicators: D2Indicator[];
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    showColumnTotals: boolean;
-    showRowTotals: boolean;
-    sortOrder: number;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2DataApprovalLevel = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    categoryOptionGroupSet: D2CategoryOptionGroupSet;
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    level: number;
-    name: string;
-    orgUnitLevel: number;
-    orgUnitLevelName: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2DataApprovalWorkflow = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    categoryCombo: D2CategoryCombo;
-    code: Id;
-    created: string;
-    dataApprovalLevels: D2DataApprovalLevel[];
-    dataSets: D2DataSet[];
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    periodType: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2ValidationRule = {
-    access: D2Access;
-    aggregateExportAttributeOptionCombo: string;
-    aggregateExportCategoryOptionCombo: string;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
+    attachment: boolean;
     attributeValues: D2AttributeValue[];
     code: Id;
+    contentType: string;
     created: string;
-    description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
-    displayDescription: string;
-    displayFormName: string;
     displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    importance: "HIGH" | "MEDIUM" | "LOW";
-    instruction: string;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    leftSide: D2Expression;
-    legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
-    name: string;
-    notificationTemplates: D2ValidationNotificationTemplate[];
-    operator:
-        | "equal_to"
-        | "not_equal_to"
-        | "greater_than"
-        | "greater_than_or_equal_to"
-        | "less_than"
-        | "less_than_or_equal_to"
-        | "compulsory_pair"
-        | "exclusive_pair";
-    organisationUnitLevels: number[];
-    periodType: string;
-    publicAccess: string;
-    rightSide: D2Expression;
-    shortName: string;
-    skipFormValidation: boolean;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    validationRuleGroups: D2ValidationRuleGroup[];
-};
-
-export type D2ValidationRuleGroup = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    description: string;
-    displayName: string;
+    external: boolean;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
@@ -1967,492 +1336,10 @@ export type D2ValidationRuleGroup = {
     name: string;
     publicAccess: string;
     translations: D2Translation[];
+    url: string;
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
-    validationRules: D2ValidationRule[];
-};
-
-export type D2ValidationNotificationTemplate = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    messageTemplate: string;
-    name: string;
-    notifyParentOrganisationUnitOnly: boolean;
-    notifyUsersInHierarchyOnly: boolean;
-    publicAccess: string;
-    recipientUserGroups: D2UserGroup[];
-    sendStrategy: "COLLECTIVE_SUMMARY" | "SINGLE_NOTIFICATION";
-    subjectTemplate: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    validationRules: D2ValidationRule[];
-};
-
-export type D2TrackedEntityAttribute = {
-    access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    confidential: boolean;
-    created: string;
-    description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
-    displayDescription: string;
-    displayFormName: string;
-    displayInListNoProgram: boolean;
-    displayName: string;
-    displayOnVisitSchedule: boolean;
-    displayShortName: string;
-    expression: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    fieldMask: string;
-    formName: string;
-    generated: boolean;
-    href: string;
-    id: Id;
-    inherit: boolean;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
-    name: string;
-    optionSet: D2OptionSet;
-    optionSetValue: boolean;
-    orgunitScope: boolean;
-    pattern: string;
-    programScope: boolean;
-    publicAccess: string;
-    shortName: string;
-    skipSynchronization: boolean;
-    sortOrderInListNoProgram: number;
-    sortOrderInVisitSchedule: number;
-    style: D2Style;
-    translations: D2Translation[];
-    unique: boolean;
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    valueType:
-        | "TEXT"
-        | "LONG_TEXT"
-        | "LETTER"
-        | "PHONE_NUMBER"
-        | "EMAIL"
-        | "BOOLEAN"
-        | "TRUE_ONLY"
-        | "DATE"
-        | "DATETIME"
-        | "TIME"
-        | "NUMBER"
-        | "UNIT_INTERVAL"
-        | "PERCENTAGE"
-        | "INTEGER"
-        | "INTEGER_POSITIVE"
-        | "INTEGER_NEGATIVE"
-        | "INTEGER_ZERO_OR_POSITIVE"
-        | "TRACKER_ASSOCIATE"
-        | "USERNAME"
-        | "COORDINATE"
-        | "ORGANISATION_UNIT"
-        | "AGE"
-        | "URL"
-        | "FILE_RESOURCE"
-        | "IMAGE";
-};
-
-export type D2TrackedEntityType = {
-    access: D2Access;
-    allowAuditLog: boolean;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    maxTeiCountToReturn: number;
-    minAttributesRequiredToSearch: number;
-    name: string;
-    publicAccess: string;
-    shortName: string;
-    style: D2Style;
-    trackedEntityTypeAttributes: D2TrackedEntityTypeAttribute[];
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2TrackedEntityTypeAttribute = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    displayInList: boolean;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    mandatory: boolean;
-    name: string;
-    publicAccess: string;
-    searchable: boolean;
-    trackedEntityAttribute: D2TrackedEntityAttribute;
-    trackedEntityType: D2TrackedEntityType;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    valueType:
-        | "TEXT"
-        | "LONG_TEXT"
-        | "LETTER"
-        | "PHONE_NUMBER"
-        | "EMAIL"
-        | "BOOLEAN"
-        | "TRUE_ONLY"
-        | "DATE"
-        | "DATETIME"
-        | "TIME"
-        | "NUMBER"
-        | "UNIT_INTERVAL"
-        | "PERCENTAGE"
-        | "INTEGER"
-        | "INTEGER_POSITIVE"
-        | "INTEGER_NEGATIVE"
-        | "INTEGER_ZERO_OR_POSITIVE"
-        | "TRACKER_ASSOCIATE"
-        | "USERNAME"
-        | "COORDINATE"
-        | "ORGANISATION_UNIT"
-        | "AGE"
-        | "URL"
-        | "FILE_RESOURCE"
-        | "IMAGE";
-};
-
-export type D2ProgramTrackedEntityAttributeGroup = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    attributes: D2ProgramTrackedEntityAttribute[];
-    code: Id;
-    created: string;
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    shortName: string;
-    translations: D2Translation[];
-    uniqunessType: "NONE" | "STRICT" | "VALIDATION";
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2ProgramNotificationTemplate = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    deliveryChannels: never[];
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    messageTemplate: string;
-    name: string;
-    notificationRecipient:
-        | "TRACKED_ENTITY_INSTANCE"
-        | "ORGANISATION_UNIT_CONTACT"
-        | "USERS_AT_ORGANISATION_UNIT"
-        | "USER_GROUP"
-        | "PROGRAM_ATTRIBUTE"
-        | "DATA_ELEMENT";
-    notificationTrigger:
-        | "ENROLLMENT"
-        | "COMPLETION"
-        | "PROGRAM_RULE"
-        | "SCHEDULED_DAYS_DUE_DATE"
-        | "SCHEDULED_DAYS_INCIDENT_DATE"
-        | "SCHEDULED_DAYS_ENROLLMENT_DATE";
-    notifyParentOrganisationUnitOnly: boolean;
-    notifyUsersInHierarchyOnly: boolean;
-    publicAccess: string;
-    recipientDataElement: D2DataElement;
-    recipientProgramAttribute: D2TrackedEntityAttribute;
-    recipientUserGroup: D2UserGroup;
-    relativeScheduledDays: number;
-    subjectTemplate: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2ProgramStageSection = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    dataElements: D2DataElement[];
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    programIndicators: D2ProgramIndicator[];
-    programStage: D2ProgramStage;
-    publicAccess: string;
-    renderType: any;
-    shortName: string;
-    sortOrder: number;
-    style: D2Style;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2SMSCommand = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    codeValueSeparator: string;
-    completenessMethod: "ALL_DATAVALUE" | "AT_LEAST_ONE_DATAVALUE" | "DO_NOT_MARK_COMPLETE";
-    created: string;
-    currentPeriodUsedForReporting: boolean;
-    dataset: D2DataSet;
-    defaultMessage: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    moreThanOneOrgUnitMessage: string;
-    name: string;
-    noUserMessage: string;
-    parserType:
-        | "KEY_VALUE_PARSER"
-        | "J2ME_PARSER"
-        | "ALERT_PARSER"
-        | "UNREGISTERED_PARSER"
-        | "TRACKED_ENTITY_REGISTRATION_PARSER"
-        | "PROGRAM_STAGE_DATAENTRY_PARSER"
-        | "EVENT_REGISTRATION_PARSER";
-    program: D2Program;
-    programStage: D2ProgramStage;
-    publicAccess: string;
-    receivedMessage: string;
-    separator: string;
-    smsCodes: any[];
-    specialCharacters: any[];
-    successMessage: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroup: D2UserGroup;
-    userGroupAccesses: D2UserGroupAccess[];
-    wrongFormatMessage: string;
-};
-
-export type D2ProgramStage = {
-    access: D2Access;
-    allowGenerateNextVisit: boolean;
-    attributeValues: D2AttributeValue[];
-    autoGenerateEvent: boolean;
-    blockEntryForm: boolean;
-    code: Id;
-    created: string;
-    dataEntryForm: D2DataEntryForm;
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayGenerateEventBox: boolean;
-    displayName: string;
-    displayShortName: string;
-    dueDateLabel: string;
-    enableUserAssignment: boolean;
-    executionDateLabel: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
-    formName: string;
-    formType: "DEFAULT" | "CUSTOM" | "SECTION" | "SECTION_MULTIORG";
-    generatedByEnrollmentDate: boolean;
-    hideDueDate: boolean;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    minDaysFromStart: number;
-    name: string;
-    notificationTemplates: D2ProgramNotificationTemplate[];
-    openAfterEnrollment: boolean;
-    periodType: string;
-    preGenerateUID: boolean;
-    program: D2Program;
-    programStageDataElements: D2ProgramStageDataElement[];
-    programStageSections: D2ProgramStageSection[];
-    publicAccess: string;
-    remindCompleted: boolean;
-    repeatable: boolean;
-    reportDateToUse: string;
-    shortName: string;
-    sortOrder: number;
-    standardInterval: number;
-    style: D2Style;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    validationStrategy: "ON_COMPLETE" | "ON_UPDATE_AND_INSERT";
-};
-
-export type D2Program = {
-    access: D2Access;
-    accessLevel: "OPEN" | "AUDITED" | "PROTECTED" | "CLOSED";
-    attributeValues: D2AttributeValue[];
-    categoryCombo: D2CategoryCombo;
-    code: Id;
-    completeEventsExpiryDays: number;
-    created: string;
-    dataEntryForm: D2DataEntryForm;
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayFrontPageList: boolean;
-    displayIncidentDate: boolean;
-    displayName: string;
-    displayShortName: string;
-    enrollmentDateLabel: string;
-    expiryDays: number;
-    expiryPeriodType: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
-    formName: string;
-    href: string;
-    id: Id;
-    ignoreOverdueEvents: boolean;
-    incidentDateLabel: string;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    maxTeiCountToReturn: number;
-    minAttributesRequiredToSearch: number;
-    name: string;
-    notificationTemplates: D2ProgramNotificationTemplate[];
-    onlyEnrollOnce: boolean;
-    organisationUnits: D2OrganisationUnit[];
-    programIndicators: D2ProgramIndicator[];
-    programRuleVariables: D2ProgramRuleVariable[];
-    programSections: D2ProgramSection[];
-    programStages: D2ProgramStage[];
-    programTrackedEntityAttributes: D2ProgramTrackedEntityAttribute[];
-    programType: "WITH_REGISTRATION" | "WITHOUT_REGISTRATION";
-    publicAccess: string;
-    registration: boolean;
-    relatedProgram: D2Program;
-    selectEnrollmentDatesInFuture: boolean;
-    selectIncidentDatesInFuture: boolean;
-    shortName: string;
-    skipOffline: boolean;
-    style: D2Style;
-    trackedEntityType: D2TrackedEntityType;
-    translations: D2Translation[];
-    useFirstStageDuringRegistration: boolean;
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    userRoles: D2UserAuthorityGroup[];
-    version: number;
-    withoutRegistration: boolean;
 };
 
 export type D2EventChart = {
@@ -2676,39 +1563,92 @@ export type D2EventReport = {
     value: any;
 };
 
-export type D2ProgramSection = {
+export type D2Expression = {
+    description: string;
+    expression: string;
+    missingValueStrategy: "SKIP_IF_ANY_VALUE_MISSING" | "SKIP_IF_ALL_VALUES_MISSING" | "NEVER_SKIP";
+    slidingWindow: boolean;
+};
+
+export type D2ExternalFileResource = {
     access: D2Access;
     attributeValues: D2AttributeValue[];
     code: Id;
     created: string;
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
     displayName: string;
-    displayShortName: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
-    formName: string;
     href: string;
     id: Id;
     lastUpdated: string;
     lastUpdatedBy: D2User;
     name: string;
-    program: D2Program;
-    programTrackedEntityAttribute: D2TrackedEntityAttribute[];
     publicAccess: string;
-    renderType: any;
-    shortName: string;
-    sortOrder: number;
-    style: D2Style;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2ProgramIndicator = {
+export type D2ExternalMapLayer = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    attribution: string;
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    imageFormat: "PNG" | "JPG";
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    layers: string;
+    legendSet: D2LegendSet;
+    legendSetUrl: string;
+    mapLayerPosition: "BASEMAP" | "OVERLAY";
+    mapService: "WMS" | "TMS" | "XYZ";
+    name: string;
+    publicAccess: string;
+    translations: D2Translation[];
+    url: string;
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2FileResource = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    contentLength: string;
+    contentMd5: string;
+    contentType: string;
+    created: string;
+    displayName: string;
+    domain: "DATA_VALUE" | "PUSH_ANALYSIS" | "DOCUMENT" | "MESSAGE_ATTACHMENT" | "USER_AVATAR";
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    storageStatus: "NONE" | "PENDING" | "FAILED" | "STORED";
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2Icon = {};
+
+export type D2Indicator = {
     access: D2Access;
     aggregateExportAttributeOptionCombo: string;
     aggregateExportCategoryOptionCombo: string;
@@ -2726,12 +1666,14 @@ export type D2ProgramIndicator = {
         | "NONE"
         | "CUSTOM"
         | "DEFAULT";
-    analyticsPeriodBoundaries: D2AnalyticsPeriodBoundary[];
-    analyticsType: "EVENT" | "ENROLLMENT";
+    annualized: boolean;
     attributeValues: D2AttributeValue[];
     code: Id;
     created: string;
+    dataSets: D2DataSet[];
     decimals: number;
+    denominator: string;
+    denominatorDescription: string;
     description: string;
     dimensionItem: string;
     dimensionItemType:
@@ -2749,101 +1691,65 @@ export type D2ProgramIndicator = {
         | "DATA_ELEMENT_GROUP"
         | "ORGANISATION_UNIT_GROUP"
         | "CATEGORY_OPTION_GROUP";
+    displayDenominatorDescription: string;
     displayDescription: string;
     displayFormName: string;
-    displayInForm: boolean;
     displayName: string;
+    displayNumeratorDescription: string;
     displayShortName: string;
-    expression: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
-    filter: string;
     formName: string;
     href: string;
     id: Id;
+    indicatorGroups: D2IndicatorGroup[];
+    indicatorType: D2IndicatorType;
     lastUpdated: string;
     lastUpdatedBy: D2User;
     legendSet: D2LegendSet;
     legendSets: D2LegendSet[];
     name: string;
-    program: D2Program;
-    programIndicatorGroups: D2ProgramIndicatorGroup[];
+    numerator: string;
+    numeratorDescription: string;
     publicAccess: string;
     shortName: string;
     style: D2Style;
     translations: D2Translation[];
+    url: string;
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2RelationshipType = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    bidirectional: boolean;
-    code: Id;
-    created: string;
-    description: string;
-    displayFromToName: string;
-    displayName: string;
-    displayToFromName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    fromConstraint: D2RelationshipConstraint;
-    fromToName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    toConstraint: D2RelationshipConstraint;
-    toFromName: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2ProgramRuleVariable = {
+export type D2IndicatorGroup = {
     access: D2Access;
     attributeValues: D2AttributeValue[];
     code: Id;
     created: string;
-    dataElement: D2DataElement;
     displayName: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
     href: string;
     id: Id;
+    indicatorGroupSet: D2IndicatorGroupSet;
+    indicators: D2Indicator[];
     lastUpdated: string;
     lastUpdatedBy: D2User;
     name: string;
-    program: D2Program;
-    programRuleVariableSourceType:
-        | "DATAELEMENT_NEWEST_EVENT_PROGRAM_STAGE"
-        | "DATAELEMENT_NEWEST_EVENT_PROGRAM"
-        | "DATAELEMENT_CURRENT_EVENT"
-        | "DATAELEMENT_PREVIOUS_EVENT"
-        | "CALCULATED_VALUE"
-        | "TEI_ATTRIBUTE";
-    programStage: D2ProgramStage;
     publicAccess: string;
-    trackedEntityAttribute: D2TrackedEntityAttribute;
     translations: D2Translation[];
-    useCodeForOptionSet: boolean;
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2ProgramIndicatorGroup = {
+export type D2IndicatorGroupSet = {
     access: D2Access;
     attributeValues: D2AttributeValue[];
     code: Id;
+    compulsory: boolean;
     created: string;
     description: string;
     displayName: string;
@@ -2852,10 +1758,10 @@ export type D2ProgramIndicatorGroup = {
     favorites: string[];
     href: string;
     id: Id;
+    indicatorGroups: D2IndicatorGroup[];
     lastUpdated: string;
     lastUpdatedBy: D2User;
     name: string;
-    programIndicators: D2ProgramIndicator[];
     publicAccess: string;
     translations: D2Translation[];
     user: D2User;
@@ -2863,14 +1769,69 @@ export type D2ProgramIndicatorGroup = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2ProgramRuleAction = {
+export type D2IndicatorType = {
     access: D2Access;
     attributeValues: D2AttributeValue[];
     code: Id;
-    content: string;
     created: string;
-    data: string;
-    dataElement: D2DataElement;
+    displayName: string;
+    externalAccess: boolean;
+    factor: number;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    number: boolean;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2Interpretation = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    chart: D2Chart;
+    code: Id;
+    comments: D2InterpretationComment[];
+    created: string;
+    dataSet: D2DataSet;
+    displayName: string;
+    eventChart: D2EventChart;
+    eventReport: D2EventReport;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    likedBy: D2User[];
+    likes: number;
+    map: D2Map;
+    mentions: any[];
+    name: string;
+    organisationUnit: D2OrganisationUnit;
+    period: any;
+    publicAccess: string;
+    reportTable: D2ReportTable;
+    text: string;
+    translations: D2Translation[];
+    type: "REPORT_TABLE" | "CHART" | "MAP" | "EVENT_REPORT" | "EVENT_CHART" | "DATASET_REPORT";
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2InterpretationComment = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    created: string;
     displayName: string;
     externalAccess: boolean;
     favorite: boolean;
@@ -2879,66 +1840,186 @@ export type D2ProgramRuleAction = {
     id: Id;
     lastUpdated: string;
     lastUpdatedBy: D2User;
-    location: string;
+    mentions: any[];
     name: string;
-    option: D2Option;
-    optionGroup: D2OptionGroup;
-    programIndicator: D2ProgramIndicator;
-    programRule: D2ProgramRule;
-    programRuleActionType:
-        | "DISPLAYTEXT"
-        | "DISPLAYKEYVALUEPAIR"
-        | "HIDEFIELD"
-        | "HIDESECTION"
-        | "HIDEPROGRAMSTAGE"
-        | "ASSIGN"
-        | "SHOWWARNING"
-        | "WARNINGONCOMPLETE"
-        | "SHOWERROR"
-        | "ERRORONCOMPLETE"
-        | "CREATEEVENT"
-        | "SETMANDATORYFIELD"
-        | "SENDMESSAGE"
-        | "SCHEDULEMESSAGE"
-        | "HIDEOPTION"
-        | "SHOWOPTIONGROUP"
-        | "HIDEOPTIONGROUP";
-    programStage: D2ProgramStage;
-    programStageSection: D2ProgramStageSection;
     publicAccess: string;
-    templateUid: string;
-    trackedEntityAttribute: D2TrackedEntityAttribute;
+    text: string;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2ProgramRule = {
+export type D2JobConfiguration = {
     access: D2Access;
     attributeValues: D2AttributeValue[];
     code: Id;
-    condition: string;
+    configurable: boolean;
+    continuousExecution: boolean;
+    created: string;
+    cronExpression: string;
+    displayName: string;
+    enabled: boolean;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    jobParameters: string;
+    jobStatus: "RUNNING" | "COMPLETED" | "STOPPED" | "SCHEDULED" | "DISABLED" | "FAILED";
+    jobType:
+        | "DATA_STATISTICS"
+        | "DATA_INTEGRITY"
+        | "RESOURCE_TABLE"
+        | "ANALYTICS_TABLE"
+        | "DATA_SYNC"
+        | "PROGRAM_DATA_SYNC"
+        | "FILE_RESOURCE_CLEANUP"
+        | "META_DATA_SYNC"
+        | "SMS_SEND"
+        | "SEND_SCHEDULED_MESSAGE"
+        | "PROGRAM_NOTIFICATIONS"
+        | "VALIDATION_RESULTS_NOTIFICATION"
+        | "CREDENTIALS_EXPIRY_ALERT"
+        | "MONITORING"
+        | "PUSH_ANALYSIS"
+        | "PREDICTOR"
+        | "DATA_SET_NOTIFICATION"
+        | "REMOVE_EXPIRED_RESERVED_VALUES"
+        | "MOCK"
+        | "DATAVALUE_IMPORT"
+        | "ANALYTICSTABLE_UPDATE"
+        | "METADATA_IMPORT"
+        | "GML_IMPORT"
+        | "DATAVALUE_IMPORT_INTERNAL"
+        | "EVENT_IMPORT"
+        | "ENROLLMENT_IMPORT"
+        | "TEI_IMPORT"
+        | "LEADER_ELECTION"
+        | "LEADER_RENEWAL"
+        | "COMPLETE_DATA_SET_REGISTRATION_IMPORT";
+    lastExecuted: string;
+    lastExecutedStatus: "RUNNING" | "COMPLETED" | "STOPPED" | "SCHEDULED" | "DISABLED" | "FAILED";
+    lastRuntimeExecution: string;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    leaderOnlyJob: boolean;
+    name: string;
+    nextExecutionTime: string;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    userUid: string;
+};
+
+export type D2KeyJsonValue = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    key: string;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    namespace: string;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    value: string;
+};
+
+export type D2Legend = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    color: string;
+    created: string;
+    displayName: string;
+    endValue: number;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    image: string;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    startValue: number;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2LegendSet = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legends: D2Legend[];
+    name: string;
+    publicAccess: string;
+    symbolizer: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2Map = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    basemap: string;
+    code: Id;
     created: string;
     description: string;
+    displayDescription: string;
+    displayFormName: string;
     displayName: string;
+    displayShortName: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
+    formName: string;
     href: string;
     id: Id;
+    interpretations: D2Interpretation[];
     lastUpdated: string;
     lastUpdatedBy: D2User;
+    latitude: number;
+    longitude: number;
+    mapViews: D2MapView[];
     name: string;
-    priority: number;
-    program: D2Program;
-    programRuleActions: D2ProgramRuleAction[];
-    programStage: D2ProgramStage;
     publicAccess: string;
+    shortName: string;
+    subscribed: boolean;
+    subscribers: string[];
+    title: string;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
+    zoom: number;
 };
 
 export type D2MapView = {
@@ -3057,36 +2138,132 @@ export type D2MapView = {
     userOrganisationUnitGrandChildren: boolean;
 };
 
-export type D2ExternalMapLayer = {
+export type D2MessageConversation = {
     access: D2Access;
+    assignee: D2User;
     attributeValues: D2AttributeValue[];
-    attribution: string;
     code: Id;
     created: string;
     displayName: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
+    followUp: boolean;
     href: string;
     id: Id;
-    imageFormat: "PNG" | "JPG";
+    lastMessage: string;
+    lastSender: D2User;
+    lastSenderFirstname: string;
+    lastSenderSurname: string;
     lastUpdated: string;
     lastUpdatedBy: D2User;
-    layers: string;
-    legendSet: D2LegendSet;
-    legendSetUrl: string;
-    mapLayerPosition: "BASEMAP" | "OVERLAY";
-    mapService: "WMS" | "TMS" | "XYZ";
+    messageCount: number;
+    messageType: "PRIVATE" | "SYSTEM" | "VALIDATION_RESULT" | "TICKET";
+    messages: any[];
+    name: string;
+    priority: "NONE" | "LOW" | "MEDIUM" | "HIGH";
+    publicAccess: string;
+    read: boolean;
+    status: "NONE" | "OPEN" | "PENDING" | "INVALID" | "SOLVED";
+    subject: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userFirstname: string;
+    userGroupAccesses: D2UserGroupAccess[];
+    userMessages: any[];
+    userSurname: string;
+};
+
+export type D2MetadataVersion = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    hashCode: string;
+    href: string;
+    id: Id;
+    importDate: string;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
     name: string;
     publicAccess: string;
     translations: D2Translation[];
-    url: string;
+    type: "BEST_EFFORT" | "ATOMIC";
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2Chart = {
+export type D2MinMaxDataElement = {
+    dataElement: D2DataElement;
+    generated: boolean;
+    max: number;
+    min: number;
+    optionCombo: D2CategoryOptionCombo;
+    source: D2OrganisationUnit;
+};
+
+export type D2OAuth2Client = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    cid: Id;
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    grantTypes: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    redirectUris: string[];
+    secret: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2Option = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    code: string;
+    created: string;
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    optionSet: D2OptionSet;
+    publicAccess: string;
+    shortName: string;
+    sortOrder: number;
+    style: D2Style;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2OptionGroup = {
     access: D2Access;
     aggregationType:
         | "SUM"
@@ -3102,112 +2279,1030 @@ export type D2Chart = {
         | "NONE"
         | "CUSTOM"
         | "DEFAULT";
-    attributeDimensions: any[];
     attributeValues: D2AttributeValue[];
-    baseLineLabel: string;
-    baseLineValue: number;
-    category: string;
-    categoryDimensions: D2CategoryDimension[];
-    categoryOptionGroupSetDimensions: D2CategoryOptionGroupSetDimension[];
     code: Id;
-    colorSet: D2ColorSet;
-    columns: any[];
-    completedOnly: boolean;
     created: string;
-    cumulativeValues: boolean;
-    dataDimensionItems: any[];
-    dataElementDimensions: D2TrackedEntityDataElementDimension[];
-    dataElementGroupSetDimensions: D2DataElementGroupSetDimension[];
     description: string;
-    digitGroupSeparator: "COMMA" | "SPACE" | "NONE";
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
     displayDescription: string;
     displayFormName: string;
     displayName: string;
     displayShortName: string;
-    domainAxisLabel: string;
-    endDate: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
-    filterDimensions: string[];
-    filters: any[];
     formName: string;
-    hideEmptyRowItems: "NONE" | "BEFORE_FIRST" | "AFTER_LAST" | "BEFORE_FIRST_AFTER_LAST" | "ALL";
-    hideLegend: boolean;
-    hideSubtitle: boolean;
-    hideTitle: boolean;
     href: string;
     id: Id;
-    interpretations: D2Interpretation[];
-    itemOrganisationUnitGroups: D2OrganisationUnitGroup[];
     lastUpdated: string;
     lastUpdatedBy: D2User;
-    legendDisplayStrategy: "FIXED" | "BY_DATA_ITEM";
     legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
     name: string;
-    noSpaceBetweenColumns: boolean;
-    orgUnitField: string;
-    organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimension[];
-    organisationUnitLevels: number[];
-    organisationUnits: D2OrganisationUnit[];
-    parentGraphMap: D2Map;
-    percentStackedValues: boolean;
-    periods: any[];
-    programIndicatorDimensions: D2TrackedEntityProgramIndicatorDimension[];
+    optionSet: D2OptionSet;
+    options: D2Option[];
     publicAccess: string;
-    rangeAxisDecimals: number;
-    rangeAxisLabel: string;
-    rangeAxisMaxValue: number;
-    rangeAxisMinValue: number;
-    rangeAxisSteps: number;
-    regressionType: "NONE" | "LINEAR" | "POLYNOMIAL" | "LOESS";
-    relativePeriods: any;
-    rows: any[];
-    series: string;
-    seriesItems: any[];
     shortName: string;
-    showData: boolean;
-    sortOrder: number;
-    startDate: string;
-    subscribed: boolean;
-    subscribers: string[];
-    subtitle: string;
-    targetLineLabel: string;
-    targetLineValue: number;
-    timeField: string;
-    title: string;
-    topLimit: number;
     translations: D2Translation[];
-    type:
-        | "COLUMN"
-        | "STACKED_COLUMN"
-        | "BAR"
-        | "STACKED_BAR"
-        | "LINE"
-        | "AREA"
-        | "PIE"
-        | "RADAR"
-        | "GAUGE"
-        | "YEAR_OVER_YEAR_LINE"
-        | "YEAR_OVER_YEAR_COLUMN";
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
-    userOrganisationUnit: boolean;
-    userOrganisationUnitChildren: boolean;
-    userOrganisationUnitGrandChildren: boolean;
-    yearlySeries: string[];
 };
 
-export type D2Document = {
+export type D2OptionGroupSet = {
     access: D2Access;
-    attachment: boolean;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    allItems: boolean;
     attributeValues: D2AttributeValue[];
     code: Id;
-    contentType: string;
+    created: string;
+    dataDimension: boolean;
+    dataDimensionType: "DISAGGREGATION" | "ATTRIBUTE";
+    description: string;
+    dimension: string;
+    dimensionType:
+        | "DATA_X"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "DATA_COLLAPSED"
+        | "CATEGORY_OPTION_COMBO"
+        | "ATTRIBUTE_OPTION_COMBO"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION_GROUP_SET"
+        | "DATA_ELEMENT_GROUP_SET"
+        | "ORGANISATION_UNIT_GROUP_SET"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY"
+        | "OPTION_GROUP_SET"
+        | "VALIDATION_RULE"
+        | "STATIC"
+        | "ORGANISATION_UNIT_LEVEL";
+    dimensionalKeywords: D2DimensionalKeywords;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    filter: string;
+    formName: string;
+    href: string;
+    id: Id;
+    items: any[];
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendSet: D2LegendSet;
+    name: string;
+    optionGroups: D2OptionGroup[];
+    optionSet: D2OptionSet;
+    publicAccess: string;
+    shortName: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2OptionSet = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    code: Id;
     created: string;
     displayName: string;
-    external: boolean;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    options: D2Option[];
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    valueType:
+        | "TEXT"
+        | "LONG_TEXT"
+        | "LETTER"
+        | "PHONE_NUMBER"
+        | "EMAIL"
+        | "BOOLEAN"
+        | "TRUE_ONLY"
+        | "DATE"
+        | "DATETIME"
+        | "TIME"
+        | "NUMBER"
+        | "UNIT_INTERVAL"
+        | "PERCENTAGE"
+        | "INTEGER"
+        | "INTEGER_POSITIVE"
+        | "INTEGER_NEGATIVE"
+        | "INTEGER_ZERO_OR_POSITIVE"
+        | "TRACKER_ASSOCIATE"
+        | "USERNAME"
+        | "COORDINATE"
+        | "ORGANISATION_UNIT"
+        | "AGE"
+        | "URL"
+        | "FILE_RESOURCE"
+        | "IMAGE";
+    version: number;
+};
+
+export type D2OrganisationUnit = {
+    access: D2Access;
+    address: string;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    ancestors: D2OrganisationUnit[];
+    attributeValues: D2AttributeValue[];
+    children: D2OrganisationUnit[];
+    closedDate: string;
+    code: Id;
+    comment: string;
+    contactPerson: string;
+    created: string;
+    dataSets: D2DataSet[];
+    description: string;
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    email: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    geometry: D2Geometry;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    leaf: boolean;
+    legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
+    level: number;
+    memberCount: number;
+    name: string;
+    openingDate: string;
+    organisationUnitGroups: D2OrganisationUnitGroup[];
+    parent: D2OrganisationUnit;
+    path: string;
+    phoneNumber: string;
+    programs: D2Program[];
+    publicAccess: string;
+    shortName: string;
+    translations: D2Translation[];
+    type: string;
+    url: string;
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    users: D2User[];
+};
+
+export type D2OrganisationUnitGroup = {
+    access: D2Access;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    color: string;
+    created: string;
+    description: string;
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
+    formName: string;
+    geometry: D2Geometry;
+    groupSets: D2OrganisationUnitGroupSet[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
+    name: string;
+    organisationUnits: D2OrganisationUnit[];
+    publicAccess: string;
+    shortName: string;
+    symbol: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2OrganisationUnitGroupSet = {
+    access: D2Access;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    allItems: boolean;
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    compulsory: boolean;
+    created: string;
+    dataDimension: boolean;
+    dataDimensionType: "DISAGGREGATION" | "ATTRIBUTE";
+    description: string;
+    dimension: string;
+    dimensionType:
+        | "DATA_X"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "DATA_COLLAPSED"
+        | "CATEGORY_OPTION_COMBO"
+        | "ATTRIBUTE_OPTION_COMBO"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION_GROUP_SET"
+        | "DATA_ELEMENT_GROUP_SET"
+        | "ORGANISATION_UNIT_GROUP_SET"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY"
+        | "OPTION_GROUP_SET"
+        | "VALIDATION_RULE"
+        | "STATIC"
+        | "ORGANISATION_UNIT_LEVEL";
+    dimensionalKeywords: D2DimensionalKeywords;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    filter: string;
+    formName: string;
+    href: string;
+    id: Id;
+    includeSubhierarchyInAnalytics: boolean;
+    items: any[];
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendSet: D2LegendSet;
+    name: string;
+    organisationUnitGroups: D2OrganisationUnitGroup[];
+    publicAccess: string;
+    shortName: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2OrganisationUnitGroupSetDimension = {
+    organisationUnitGroupSet: D2OrganisationUnitGroupSet;
+    organisationUnitGroups: D2OrganisationUnitGroup[];
+};
+
+export type D2OrganisationUnitLevel = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    level: number;
+    name: string;
+    offlineLevels: number;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2Predictor = {
+    access: D2Access;
+    annualSampleCount: number;
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    created: string;
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    generator: D2Expression;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    organisationUnitLevels: D2OrganisationUnitLevel[];
+    output: D2DataElement;
+    outputCombo: D2CategoryOptionCombo;
+    periodType: string;
+    predictorGroups: D2PredictorGroup[];
+    publicAccess: string;
+    sampleSkipTest: D2Expression;
+    sequentialSampleCount: number;
+    sequentialSkipCount: number;
+    shortName: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2PredictorGroup = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    created: string;
+    description: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    predictors: D2Predictor[];
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2Program = {
+    access: D2Access;
+    accessLevel: "OPEN" | "AUDITED" | "PROTECTED" | "CLOSED";
+    attributeValues: D2AttributeValue[];
+    categoryCombo: D2CategoryCombo;
+    code: Id;
+    completeEventsExpiryDays: number;
+    created: string;
+    dataEntryForm: D2DataEntryForm;
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayFrontPageList: boolean;
+    displayIncidentDate: boolean;
+    displayName: string;
+    displayShortName: string;
+    enrollmentDateLabel: string;
+    expiryDays: number;
+    expiryPeriodType: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
+    formName: string;
+    href: string;
+    id: Id;
+    ignoreOverdueEvents: boolean;
+    incidentDateLabel: string;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    maxTeiCountToReturn: number;
+    minAttributesRequiredToSearch: number;
+    name: string;
+    notificationTemplates: D2ProgramNotificationTemplate[];
+    onlyEnrollOnce: boolean;
+    organisationUnits: D2OrganisationUnit[];
+    programIndicators: D2ProgramIndicator[];
+    programRuleVariables: D2ProgramRuleVariable[];
+    programSections: D2ProgramSection[];
+    programStages: D2ProgramStage[];
+    programTrackedEntityAttributes: D2ProgramTrackedEntityAttribute[];
+    programType: "WITH_REGISTRATION" | "WITHOUT_REGISTRATION";
+    publicAccess: string;
+    registration: boolean;
+    relatedProgram: D2Program;
+    selectEnrollmentDatesInFuture: boolean;
+    selectIncidentDatesInFuture: boolean;
+    shortName: string;
+    skipOffline: boolean;
+    style: D2Style;
+    trackedEntityType: D2TrackedEntityType;
+    translations: D2Translation[];
+    useFirstStageDuringRegistration: boolean;
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    userRoles: D2UserAuthorityGroup[];
+    version: number;
+    withoutRegistration: boolean;
+};
+
+export type D2ProgramDataElementDimensionItem = {
+    access: D2Access;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    created: string;
+    dataElement: D2DataElement;
+    description: string;
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
+    name: string;
+    program: D2Program;
+    publicAccess: string;
+    shortName: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    valueType:
+        | "TEXT"
+        | "LONG_TEXT"
+        | "LETTER"
+        | "PHONE_NUMBER"
+        | "EMAIL"
+        | "BOOLEAN"
+        | "TRUE_ONLY"
+        | "DATE"
+        | "DATETIME"
+        | "TIME"
+        | "NUMBER"
+        | "UNIT_INTERVAL"
+        | "PERCENTAGE"
+        | "INTEGER"
+        | "INTEGER_POSITIVE"
+        | "INTEGER_NEGATIVE"
+        | "INTEGER_ZERO_OR_POSITIVE"
+        | "TRACKER_ASSOCIATE"
+        | "USERNAME"
+        | "COORDINATE"
+        | "ORGANISATION_UNIT"
+        | "AGE"
+        | "URL"
+        | "FILE_RESOURCE"
+        | "IMAGE";
+};
+
+export type D2ProgramIndicator = {
+    access: D2Access;
+    aggregateExportAttributeOptionCombo: string;
+    aggregateExportCategoryOptionCombo: string;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    analyticsPeriodBoundaries: D2AnalyticsPeriodBoundary[];
+    analyticsType: "EVENT" | "ENROLLMENT";
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    created: string;
+    decimals: number;
+    description: string;
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
+    displayDescription: string;
+    displayFormName: string;
+    displayInForm: boolean;
+    displayName: string;
+    displayShortName: string;
+    expression: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    filter: string;
+    formName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
+    name: string;
+    program: D2Program;
+    programIndicatorGroups: D2ProgramIndicatorGroup[];
+    publicAccess: string;
+    shortName: string;
+    style: D2Style;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramIndicatorGroup = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    created: string;
+    description: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    programIndicators: D2ProgramIndicator[];
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramInstance = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    created: string;
+    createdAtClient: string;
+    deleted: boolean;
+    displayName: string;
+    endDate: string;
+    enrollmentDate: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    followup: boolean;
+    href: string;
+    id: Id;
+    incidentDate: string;
+    lastUpdated: string;
+    lastUpdatedAtClient: string;
+    lastUpdatedBy: D2User;
+    messageConversations: D2MessageConversation[];
+    name: string;
+    organisationUnit: D2OrganisationUnit;
+    program: D2Program;
+    programStageInstances: D2ProgramStageInstance[];
+    publicAccess: string;
+    relationshipItems: any[];
+    status: "ACTIVE" | "COMPLETED" | "CANCELLED";
+    storedBy: string;
+    trackedEntityComments: any[];
+    trackedEntityInstance: D2TrackedEntityInstance;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramNotificationTemplate = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    created: string;
+    deliveryChannels: never[];
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    messageTemplate: string;
+    name: string;
+    notificationRecipient:
+        | "TRACKED_ENTITY_INSTANCE"
+        | "ORGANISATION_UNIT_CONTACT"
+        | "USERS_AT_ORGANISATION_UNIT"
+        | "USER_GROUP"
+        | "PROGRAM_ATTRIBUTE"
+        | "DATA_ELEMENT";
+    notificationTrigger:
+        | "ENROLLMENT"
+        | "COMPLETION"
+        | "PROGRAM_RULE"
+        | "SCHEDULED_DAYS_DUE_DATE"
+        | "SCHEDULED_DAYS_INCIDENT_DATE"
+        | "SCHEDULED_DAYS_ENROLLMENT_DATE";
+    notifyParentOrganisationUnitOnly: boolean;
+    notifyUsersInHierarchyOnly: boolean;
+    publicAccess: string;
+    recipientDataElement: D2DataElement;
+    recipientProgramAttribute: D2TrackedEntityAttribute;
+    recipientUserGroup: D2UserGroup;
+    relativeScheduledDays: number;
+    subjectTemplate: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramRule = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    condition: string;
+    created: string;
+    description: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    priority: number;
+    program: D2Program;
+    programRuleActions: D2ProgramRuleAction[];
+    programStage: D2ProgramStage;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramRuleAction = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    content: string;
+    created: string;
+    data: string;
+    dataElement: D2DataElement;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    location: string;
+    name: string;
+    option: D2Option;
+    optionGroup: D2OptionGroup;
+    programIndicator: D2ProgramIndicator;
+    programRule: D2ProgramRule;
+    programRuleActionType:
+        | "DISPLAYTEXT"
+        | "DISPLAYKEYVALUEPAIR"
+        | "HIDEFIELD"
+        | "HIDESECTION"
+        | "HIDEPROGRAMSTAGE"
+        | "ASSIGN"
+        | "SHOWWARNING"
+        | "WARNINGONCOMPLETE"
+        | "SHOWERROR"
+        | "ERRORONCOMPLETE"
+        | "CREATEEVENT"
+        | "SETMANDATORYFIELD"
+        | "SENDMESSAGE"
+        | "SCHEDULEMESSAGE"
+        | "HIDEOPTION"
+        | "SHOWOPTIONGROUP"
+        | "HIDEOPTIONGROUP";
+    programStage: D2ProgramStage;
+    programStageSection: D2ProgramStageSection;
+    publicAccess: string;
+    templateUid: string;
+    trackedEntityAttribute: D2TrackedEntityAttribute;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramRuleVariable = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    created: string;
+    dataElement: D2DataElement;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    program: D2Program;
+    programRuleVariableSourceType:
+        | "DATAELEMENT_NEWEST_EVENT_PROGRAM_STAGE"
+        | "DATAELEMENT_NEWEST_EVENT_PROGRAM"
+        | "DATAELEMENT_CURRENT_EVENT"
+        | "DATAELEMENT_PREVIOUS_EVENT"
+        | "CALCULATED_VALUE"
+        | "TEI_ATTRIBUTE";
+    programStage: D2ProgramStage;
+    publicAccess: string;
+    trackedEntityAttribute: D2TrackedEntityAttribute;
+    translations: D2Translation[];
+    useCodeForOptionSet: boolean;
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramSection = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    created: string;
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    program: D2Program;
+    programTrackedEntityAttribute: D2TrackedEntityAttribute[];
+    publicAccess: string;
+    renderType: any;
+    shortName: string;
+    sortOrder: number;
+    style: D2Style;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramStage = {
+    access: D2Access;
+    allowGenerateNextVisit: boolean;
+    attributeValues: D2AttributeValue[];
+    autoGenerateEvent: boolean;
+    blockEntryForm: boolean;
+    code: Id;
+    created: string;
+    dataEntryForm: D2DataEntryForm;
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayGenerateEventBox: boolean;
+    displayName: string;
+    displayShortName: string;
+    dueDateLabel: string;
+    enableUserAssignment: boolean;
+    executionDateLabel: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
+    formName: string;
+    formType: "DEFAULT" | "CUSTOM" | "SECTION" | "SECTION_MULTIORG";
+    generatedByEnrollmentDate: boolean;
+    hideDueDate: boolean;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    minDaysFromStart: number;
+    name: string;
+    notificationTemplates: D2ProgramNotificationTemplate[];
+    openAfterEnrollment: boolean;
+    periodType: string;
+    preGenerateUID: boolean;
+    program: D2Program;
+    programStageDataElements: D2ProgramStageDataElement[];
+    programStageSections: D2ProgramStageSection[];
+    publicAccess: string;
+    remindCompleted: boolean;
+    repeatable: boolean;
+    reportDateToUse: string;
+    shortName: string;
+    sortOrder: number;
+    standardInterval: number;
+    style: D2Style;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    validationStrategy: "ON_COMPLETE" | "ON_UPDATE_AND_INSERT";
+};
+
+export type D2ProgramStageDataElement = {
+    access: D2Access;
+    allowFutureDate: boolean;
+    allowProvidedElsewhere: boolean;
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    compulsory: boolean;
+    created: string;
+    dataElement: D2DataElement;
+    displayInReports: boolean;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    programStage: D2ProgramStage;
+    publicAccess: string;
+    renderOptionsAsRadio: boolean;
+    renderType: any;
+    skipSynchronization: boolean;
+    sortOrder: number;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramStageInstance = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    created: string;
+    displayName: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
@@ -3218,7 +3313,331 @@ export type D2Document = {
     name: string;
     publicAccess: string;
     translations: D2Translation[];
-    url: string;
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramStageInstanceFilter = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    created: string;
+    description: string;
+    displayName: string;
+    eventQueryCriteria: any;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    program: Id;
+    programStage: Id;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramStageSection = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    created: string;
+    dataElements: D2DataElement[];
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    programIndicators: D2ProgramIndicator[];
+    programStage: D2ProgramStage;
+    publicAccess: string;
+    renderType: any;
+    shortName: string;
+    sortOrder: number;
+    style: D2Style;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramTrackedEntityAttribute = {
+    access: D2Access;
+    allowFutureDate: boolean;
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    created: string;
+    displayInList: boolean;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    mandatory: boolean;
+    name: string;
+    program: D2Program;
+    programTrackedEntityAttributeGroups: D2ProgramTrackedEntityAttributeGroup[];
+    publicAccess: string;
+    renderOptionsAsRadio: boolean;
+    renderType: any;
+    searchable: boolean;
+    sortOrder: number;
+    trackedEntityAttribute: D2TrackedEntityAttribute;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    valueType:
+        | "TEXT"
+        | "LONG_TEXT"
+        | "LETTER"
+        | "PHONE_NUMBER"
+        | "EMAIL"
+        | "BOOLEAN"
+        | "TRUE_ONLY"
+        | "DATE"
+        | "DATETIME"
+        | "TIME"
+        | "NUMBER"
+        | "UNIT_INTERVAL"
+        | "PERCENTAGE"
+        | "INTEGER"
+        | "INTEGER_POSITIVE"
+        | "INTEGER_NEGATIVE"
+        | "INTEGER_ZERO_OR_POSITIVE"
+        | "TRACKER_ASSOCIATE"
+        | "USERNAME"
+        | "COORDINATE"
+        | "ORGANISATION_UNIT"
+        | "AGE"
+        | "URL"
+        | "FILE_RESOURCE"
+        | "IMAGE";
+};
+
+export type D2ProgramTrackedEntityAttributeDimensionItem = {
+    access: D2Access;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    attribute: D2TrackedEntityAttribute;
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    created: string;
+    description: string;
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
+    name: string;
+    program: D2Program;
+    publicAccess: string;
+    shortName: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramTrackedEntityAttributeGroup = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    attributes: D2ProgramTrackedEntityAttribute[];
+    code: Id;
+    created: string;
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    shortName: string;
+    translations: D2Translation[];
+    uniqunessType: "NONE" | "STRICT" | "VALIDATION";
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2PushAnalysis = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    created: string;
+    dashboard: D2Dashboard;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    message: string;
+    name: string;
+    publicAccess: string;
+    recipientUserGroups: D2UserGroup[];
+    title: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2Relationship = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    created: string;
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    from: any;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    relationshipType: D2RelationshipType;
+    shortName: string;
+    style: D2Style;
+    to: any;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2RelationshipType = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    bidirectional: boolean;
+    code: Id;
+    created: string;
+    description: string;
+    displayFromToName: string;
+    displayName: string;
+    displayToFromName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    fromConstraint: D2RelationshipConstraint;
+    fromToName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    toConstraint: D2RelationshipConstraint;
+    toFromName: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2Report = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    cacheStrategy:
+        | "NO_CACHE"
+        | "CACHE_15_MINUTES"
+        | "CACHE_30_MINUTES"
+        | "CACHE_1_HOUR"
+        | "CACHE_6AM_TOMORROW"
+        | "CACHE_TWO_WEEKS"
+        | "RESPECT_SYSTEM_SETTING";
+    code: Id;
+    created: string;
+    designContent: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    relativePeriods: any;
+    reportParams: any;
+    reportTable: D2ReportTable;
+    translations: D2Translation[];
+    type: "JASPER_REPORT_TABLE" | "JASPER_JDBC" | "HTML";
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
@@ -3322,492 +3741,6 @@ export type D2ReportTable = {
     userOrganisationUnitGrandChildren: boolean;
 };
 
-export type D2Report = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    cacheStrategy:
-        | "NO_CACHE"
-        | "CACHE_15_MINUTES"
-        | "CACHE_30_MINUTES"
-        | "CACHE_1_HOUR"
-        | "CACHE_6AM_TOMORROW"
-        | "CACHE_TWO_WEEKS"
-        | "RESPECT_SYSTEM_SETTING";
-    code: Id;
-    created: string;
-    designContent: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    relativePeriods: any;
-    reportParams: any;
-    reportTable: D2ReportTable;
-    translations: D2Translation[];
-    type: "JASPER_REPORT_TABLE" | "JASPER_JDBC" | "HTML";
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2ValidationResult = {
-    attributeOptionCombo: D2CategoryOptionCombo;
-    created: string;
-    dayInPeriod: number;
-    id: string;
-    leftsideValue: number;
-    notificationSent: boolean;
-    organisationUnit: D2OrganisationUnit;
-    period: any;
-    rightsideValue: number;
-    validationRule: D2ValidationRule;
-};
-
-export type D2Map = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    basemap: string;
-    code: Id;
-    created: string;
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    interpretations: D2Interpretation[];
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    latitude: number;
-    longitude: number;
-    mapViews: D2MapView[];
-    name: string;
-    publicAccess: string;
-    shortName: string;
-    subscribed: boolean;
-    subscribers: string[];
-    title: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    zoom: number;
-};
-
-export type D2Predictor = {
-    access: D2Access;
-    annualSampleCount: number;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    generator: D2Expression;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    organisationUnitLevels: D2OrganisationUnitLevel[];
-    output: D2DataElement;
-    outputCombo: D2CategoryOptionCombo;
-    periodType: string;
-    predictorGroups: D2PredictorGroup[];
-    publicAccess: string;
-    sampleSkipTest: D2Expression;
-    sequentialSampleCount: number;
-    sequentialSkipCount: number;
-    shortName: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2PredictorGroup = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    description: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    predictors: D2Predictor[];
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2DashboardItem = {
-    access: D2Access;
-    appKey: string;
-    attributeValues: D2AttributeValue[];
-    chart: D2Chart;
-    code: Id;
-    contentCount: number;
-    created: string;
-    displayName: string;
-    eventChart: D2EventChart;
-    eventReport: D2EventReport;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    height: number;
-    href: string;
-    id: Id;
-    interpretationCount: number;
-    interpretationLikeCount: number;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    map: D2Map;
-    messages: boolean;
-    name: string;
-    publicAccess: string;
-    reportTable: D2ReportTable;
-    reports: D2Report[];
-    resources: D2Document[];
-    shape: "NORMAL" | "DOUBLE_WIDTH" | "FULL_WIDTH";
-    text: string;
-    translations: D2Translation[];
-    type:
-        | "CHART"
-        | "EVENT_CHART"
-        | "MAP"
-        | "REPORT_TABLE"
-        | "EVENT_REPORT"
-        | "USERS"
-        | "REPORTS"
-        | "RESOURCES"
-        | "TEXT"
-        | "MESSAGES"
-        | "APP";
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    users: D2User[];
-    width: number;
-    x: number;
-    y: number;
-};
-
-export type D2Dashboard = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    dashboardItems: D2DashboardItem[];
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    itemCount: number;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    shortName: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2PushAnalysis = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    dashboard: D2Dashboard;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    message: string;
-    name: string;
-    publicAccess: string;
-    recipientUserGroups: D2UserGroup[];
-    title: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2KeyJsonValue = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    key: string;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    namespace: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    value: string;
-};
-
-export type D2OrganisationUnitGroupSetDimension = {
-    organisationUnitGroupSet: D2OrganisationUnitGroupSet;
-    organisationUnitGroups: D2OrganisationUnitGroup[];
-};
-
-export type D2UserCredentials = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    catDimensionConstraints: D2Category[];
-    code: Id;
-    cogsDimensionConstraints: D2CategoryOptionGroupSet[];
-    created: string;
-    disabled: boolean;
-    displayName: string;
-    externalAccess: boolean;
-    externalAuth: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    invitation: boolean;
-    lastLogin: string;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    ldapId: string;
-    name: string;
-    openId: string;
-    password: string;
-    passwordLastUpdated: string;
-    publicAccess: string;
-    selfRegistered: boolean;
-    translations: D2Translation[];
-    twoFA: boolean;
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    userInfo: D2User;
-    userRoles: D2UserAuthorityGroup[];
-    username: string;
-};
-
-export type D2ProgramStageDataElement = {
-    access: D2Access;
-    allowFutureDate: boolean;
-    allowProvidedElsewhere: boolean;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    compulsory: boolean;
-    created: string;
-    dataElement: D2DataElement;
-    displayInReports: boolean;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    programStage: D2ProgramStage;
-    publicAccess: string;
-    renderOptionsAsRadio: boolean;
-    renderType: any;
-    skipSynchronization: boolean;
-    sortOrder: number;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2FileResource = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    contentLength: string;
-    contentMd5: string;
-    contentType: string;
-    created: string;
-    displayName: string;
-    domain: "DATA_VALUE" | "PUSH_ANALYSIS" | "DOCUMENT" | "MESSAGE_ATTACHMENT" | "USER_AVATAR";
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    storageStatus: "NONE" | "PENDING" | "FAILED" | "STORED";
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2ProgramInstance = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    createdAtClient: string;
-    deleted: boolean;
-    displayName: string;
-    endDate: string;
-    enrollmentDate: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    followup: boolean;
-    href: string;
-    id: Id;
-    incidentDate: string;
-    lastUpdated: string;
-    lastUpdatedAtClient: string;
-    lastUpdatedBy: D2User;
-    messageConversations: D2MessageConversation[];
-    name: string;
-    organisationUnit: D2OrganisationUnit;
-    program: D2Program;
-    programStageInstances: D2ProgramStageInstance[];
-    publicAccess: string;
-    relationshipItems: any[];
-    status: "ACTIVE" | "COMPLETED" | "CANCELLED";
-    storedBy: string;
-    trackedEntityComments: any[];
-    trackedEntityInstance: D2TrackedEntityInstance;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2UserAccess = {
-    access: string;
-    displayName: string;
-    id: string;
-    userUid: string;
-};
-
-export type D2TrackedEntityDataElementDimension = {
-    dataElement: D2DataElement;
-    filter: string;
-    legendSet: D2LegendSet;
-};
-
-export type D2Icon = {};
-
-export type D2DataElementGroupSetDimension = {
-    dataElementGroupSet: D2DataElementGroupSet;
-    dataElementGroups: D2DataElementGroup[];
-};
-
-export type D2ProgramTrackedEntityAttribute = {
-    access: D2Access;
-    allowFutureDate: boolean;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    displayInList: boolean;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    mandatory: boolean;
-    name: string;
-    program: D2Program;
-    programTrackedEntityAttributeGroups: D2ProgramTrackedEntityAttributeGroup[];
-    publicAccess: string;
-    renderOptionsAsRadio: boolean;
-    renderType: any;
-    searchable: boolean;
-    sortOrder: number;
-    trackedEntityAttribute: D2TrackedEntityAttribute;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    valueType:
-        | "TEXT"
-        | "LONG_TEXT"
-        | "LETTER"
-        | "PHONE_NUMBER"
-        | "EMAIL"
-        | "BOOLEAN"
-        | "TRUE_ONLY"
-        | "DATE"
-        | "DATETIME"
-        | "TIME"
-        | "NUMBER"
-        | "UNIT_INTERVAL"
-        | "PERCENTAGE"
-        | "INTEGER"
-        | "INTEGER_POSITIVE"
-        | "INTEGER_NEGATIVE"
-        | "INTEGER_ZERO_OR_POSITIVE"
-        | "TRACKER_ASSOCIATE"
-        | "USERNAME"
-        | "COORDINATE"
-        | "ORGANISATION_UNIT"
-        | "AGE"
-        | "URL"
-        | "FILE_RESOURCE"
-        | "IMAGE";
-};
-
 export type D2ReportingRate = {
     access: D2Access;
     aggregationType:
@@ -3874,18 +3807,95 @@ export type D2ReportingRate = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2UserGroupAccess = {
-    access: string;
-    displayName: string;
-    id: string;
-    userGroupUid: string;
-};
-
-export type D2ProgramStageInstance = {
+export type D2SMSCommand = {
     access: D2Access;
     attributeValues: D2AttributeValue[];
     code: Id;
+    codeValueSeparator: string;
+    completenessMethod: "ALL_DATAVALUE" | "AT_LEAST_ONE_DATAVALUE" | "DO_NOT_MARK_COMPLETE";
     created: string;
+    currentPeriodUsedForReporting: boolean;
+    dataset: D2DataSet;
+    defaultMessage: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    moreThanOneOrgUnitMessage: string;
+    name: string;
+    noUserMessage: string;
+    parserType:
+        | "KEY_VALUE_PARSER"
+        | "J2ME_PARSER"
+        | "ALERT_PARSER"
+        | "UNREGISTERED_PARSER"
+        | "TRACKED_ENTITY_REGISTRATION_PARSER"
+        | "PROGRAM_STAGE_DATAENTRY_PARSER"
+        | "EVENT_REGISTRATION_PARSER";
+    program: D2Program;
+    programStage: D2ProgramStage;
+    publicAccess: string;
+    receivedMessage: string;
+    separator: string;
+    smsCodes: any[];
+    specialCharacters: any[];
+    successMessage: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroup: D2UserGroup;
+    userGroupAccesses: D2UserGroupAccess[];
+    wrongFormatMessage: string;
+};
+
+export type D2Section = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    categoryCombos: D2CategoryCombo[];
+    code: Id;
+    created: string;
+    dataElements: D2DataElement[];
+    dataSet: D2DataSet;
+    description: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    greyedFields: D2DataElementOperand[];
+    href: string;
+    id: Id;
+    indicators: D2Indicator[];
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    showColumnTotals: boolean;
+    showRowTotals: boolean;
+    sortOrder: number;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2SqlView = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    cacheStrategy:
+        | "NO_CACHE"
+        | "CACHE_15_MINUTES"
+        | "CACHE_30_MINUTES"
+        | "CACHE_1_HOUR"
+        | "CACHE_6AM_TOMORROW"
+        | "CACHE_TWO_WEEKS"
+        | "RESPECT_SYSTEM_SETTING";
+    code: Id;
+    created: string;
+    description: string;
     displayName: string;
     externalAccess: boolean;
     favorite: boolean;
@@ -3896,132 +3906,120 @@ export type D2ProgramStageInstance = {
     lastUpdatedBy: D2User;
     name: string;
     publicAccess: string;
+    sqlQuery: string;
     translations: D2Translation[];
+    type: "VIEW" | "MATERIALIZED_VIEW" | "QUERY";
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2InterpretationComment = {
+export type D2TrackedEntityAttribute = {
     access: D2Access;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
     attributeValues: D2AttributeValue[];
     code: Id;
+    confidential: boolean;
     created: string;
+    description: string;
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
+    displayDescription: string;
+    displayFormName: string;
+    displayInListNoProgram: boolean;
     displayName: string;
+    displayOnVisitSchedule: boolean;
+    displayShortName: string;
+    expression: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    mentions: any[];
-    name: string;
-    publicAccess: string;
-    text: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2MinMaxDataElement = {
-    dataElement: D2DataElement;
+    fieldMask: string;
+    formName: string;
     generated: boolean;
-    max: number;
-    min: number;
-    optionCombo: D2CategoryOptionCombo;
-    source: D2OrganisationUnit;
-};
-
-export type D2MessageConversation = {
-    access: D2Access;
-    assignee: D2User;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    followUp: boolean;
     href: string;
     id: Id;
-    lastMessage: string;
-    lastSender: D2User;
-    lastSenderFirstname: string;
-    lastSenderSurname: string;
+    inherit: boolean;
     lastUpdated: string;
     lastUpdatedBy: D2User;
-    messageCount: number;
-    messageType: "PRIVATE" | "SYSTEM" | "VALIDATION_RESULT" | "TICKET";
-    messages: any[];
+    legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
     name: string;
-    priority: "NONE" | "LOW" | "MEDIUM" | "HIGH";
+    optionSet: D2OptionSet;
+    optionSetValue: boolean;
+    orgunitScope: boolean;
+    pattern: string;
+    programScope: boolean;
     publicAccess: string;
-    read: boolean;
-    status: "NONE" | "OPEN" | "PENDING" | "INVALID" | "SOLVED";
-    subject: string;
+    shortName: string;
+    skipSynchronization: boolean;
+    sortOrderInListNoProgram: number;
+    sortOrderInVisitSchedule: number;
+    style: D2Style;
     translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userFirstname: string;
-    userGroupAccesses: D2UserGroupAccess[];
-    userMessages: any[];
-    userSurname: string;
-};
-
-export type D2AnalyticsPeriodBoundary = {
-    access: D2Access;
-    analyticsPeriodBoundaryType:
-        | "BEFORE_START_OF_REPORTING_PERIOD"
-        | "BEFORE_END_OF_REPORTING_PERIOD"
-        | "AFTER_START_OF_REPORTING_PERIOD"
-        | "AFTER_END_OF_REPORTING_PERIOD";
-    attributeValues: D2AttributeValue[];
-    boundaryTarget: string;
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    offsetPeriodType: string;
-    offsetPeriods: number;
-    publicAccess: string;
-    translations: D2Translation[];
+    unique: boolean;
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
+    valueType:
+        | "TEXT"
+        | "LONG_TEXT"
+        | "LETTER"
+        | "PHONE_NUMBER"
+        | "EMAIL"
+        | "BOOLEAN"
+        | "TRUE_ONLY"
+        | "DATE"
+        | "DATETIME"
+        | "TIME"
+        | "NUMBER"
+        | "UNIT_INTERVAL"
+        | "PERCENTAGE"
+        | "INTEGER"
+        | "INTEGER_POSITIVE"
+        | "INTEGER_NEGATIVE"
+        | "INTEGER_ZERO_OR_POSITIVE"
+        | "TRACKER_ASSOCIATE"
+        | "USERNAME"
+        | "COORDINATE"
+        | "ORGANISATION_UNIT"
+        | "AGE"
+        | "URL"
+        | "FILE_RESOURCE"
+        | "IMAGE";
 };
 
-export type D2MetadataVersion = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    hashCode: string;
-    href: string;
-    id: Id;
-    importDate: string;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    type: "BEST_EFFORT" | "ATOMIC";
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
+export type D2TrackedEntityDataElementDimension = {
+    dataElement: D2DataElement;
+    filter: string;
+    legendSet: D2LegendSet;
 };
 
 export type D2TrackedEntityInstance = {
@@ -4085,171 +4083,19 @@ export type D2TrackedEntityInstanceFilter = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2ProgramStageInstanceFilter = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    description: string;
-    displayName: string;
-    eventQueryCriteria: any;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    program: Id;
-    programStage: Id;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2DataElementOperand = {
-    access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    attributeOptionCombo: D2CategoryOptionCombo;
-    attributeValues: D2AttributeValue[];
-    categoryOptionCombo: D2CategoryOptionCombo;
-    code: Id;
-    created: string;
-    dataElement: D2DataElement;
-    description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
-    name: string;
-    publicAccess: string;
-    shortName: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
 export type D2TrackedEntityProgramIndicatorDimension = {
     filter: string;
     legendSet: D2LegendSet;
     programIndicator: D2ProgramIndicator;
 };
 
-export type D2Interpretation = {
+export type D2TrackedEntityType = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
-    chart: D2Chart;
-    code: Id;
-    comments: D2InterpretationComment[];
-    created: string;
-    dataSet: D2DataSet;
-    displayName: string;
-    eventChart: D2EventChart;
-    eventReport: D2EventReport;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    likedBy: D2User[];
-    likes: number;
-    map: D2Map;
-    mentions: any[];
-    name: string;
-    organisationUnit: D2OrganisationUnit;
-    period: any;
-    publicAccess: string;
-    reportTable: D2ReportTable;
-    text: string;
-    translations: D2Translation[];
-    type: "REPORT_TABLE" | "CHART" | "MAP" | "EVENT_REPORT" | "EVENT_CHART" | "DATASET_REPORT";
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2ProgramDataElementDimensionItem = {
-    access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
+    allowAuditLog: boolean;
     attributeValues: D2AttributeValue[];
     code: Id;
     created: string;
-    dataElement: D2DataElement;
     description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
     displayDescription: string;
     displayFormName: string;
     displayName: string;
@@ -4257,17 +4103,46 @@ export type D2ProgramDataElementDimensionItem = {
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
+    featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
     formName: string;
     href: string;
     id: Id;
     lastUpdated: string;
     lastUpdatedBy: D2User;
-    legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
+    maxTeiCountToReturn: number;
+    minAttributesRequiredToSearch: number;
     name: string;
-    program: D2Program;
     publicAccess: string;
     shortName: string;
+    style: D2Style;
+    trackedEntityTypeAttributes: D2TrackedEntityTypeAttribute[];
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2TrackedEntityTypeAttribute = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    created: string;
+    displayInList: boolean;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    mandatory: boolean;
+    name: string;
+    publicAccess: string;
+    searchable: boolean;
+    trackedEntityAttribute: D2TrackedEntityAttribute;
+    trackedEntityType: D2TrackedEntityType;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
@@ -4300,72 +4175,196 @@ export type D2ProgramDataElementDimensionItem = {
         | "IMAGE";
 };
 
-export type D2DataInputPeriod = {
-    closingDate: string;
-    openingDate: string;
+export type D2User = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    avatar: D2FileResource;
+    birthday: string;
+    code: Id;
+    created: string;
+    dataViewOrganisationUnits: D2OrganisationUnit[];
+    displayName: string;
+    education: string;
+    email: string;
+    employer: string;
+    externalAccess: boolean;
+    facebookMessenger: string;
+    favorite: boolean;
+    favorites: string[];
+    firstName: string;
+    gender: string;
+    href: string;
+    id: Id;
+    interests: string;
+    introduction: string;
+    jobTitle: string;
+    languages: string;
+    lastCheckedInterpretations: string;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    nationality: string;
+    organisationUnits: D2OrganisationUnit[];
+    phoneNumber: string;
+    publicAccess: string;
+    skype: string;
+    surname: string;
+    teiSearchOrganisationUnits: D2OrganisationUnit[];
+    telegram: string;
+    translations: D2Translation[];
+    twitter: string;
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userCredentials: D2UserCredentials;
+    userGroupAccesses: D2UserGroupAccess[];
+    userGroups: D2UserGroup[];
+    welcomeMessage: string;
+    whatsApp: string;
+};
+
+export type D2UserAccess = {
+    access: string;
+    displayName: string;
+    id: string;
+    userUid: string;
+};
+
+export type D2UserAuthorityGroup = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    authorities: string[];
+    code: Id;
+    created: string;
+    description: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    users: D2User[];
+};
+
+export type D2UserCredentials = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    catDimensionConstraints: D2Category[];
+    code: Id;
+    cogsDimensionConstraints: D2CategoryOptionGroupSet[];
+    created: string;
+    disabled: boolean;
+    displayName: string;
+    externalAccess: boolean;
+    externalAuth: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    invitation: boolean;
+    lastLogin: string;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    ldapId: string;
+    name: string;
+    openId: string;
+    password: string;
+    passwordLastUpdated: string;
+    publicAccess: string;
+    selfRegistered: boolean;
+    translations: D2Translation[];
+    twoFA: boolean;
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    userInfo: D2User;
+    userRoles: D2UserAuthorityGroup[];
+    username: string;
+};
+
+export type D2UserGroup = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    managedByGroups: D2UserGroup[];
+    managedGroups: D2UserGroup[];
+    name: string;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    users: D2User[];
+};
+
+export type D2UserGroupAccess = {
+    access: string;
+    displayName: string;
+    id: string;
+    userGroupUid: string;
+};
+
+export type D2ValidationNotificationTemplate = {
+    access: D2Access;
+    attributeValues: D2AttributeValue[];
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    messageTemplate: string;
+    name: string;
+    notifyParentOrganisationUnitOnly: boolean;
+    notifyUsersInHierarchyOnly: boolean;
+    publicAccess: string;
+    recipientUserGroups: D2UserGroup[];
+    sendStrategy: "COLLECTIVE_SUMMARY" | "SINGLE_NOTIFICATION";
+    subjectTemplate: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    validationRules: D2ValidationRule[];
+};
+
+export type D2ValidationResult = {
+    attributeOptionCombo: D2CategoryOptionCombo;
+    created: string;
+    dayInPeriod: number;
+    id: string;
+    leftsideValue: number;
+    notificationSent: boolean;
+    organisationUnit: D2OrganisationUnit;
     period: any;
+    rightsideValue: number;
+    validationRule: D2ValidationRule;
 };
 
-export type D2DataSetElement = {
-    categoryCombo: D2CategoryCombo;
-    dataElement: D2DataElement;
-    dataSet: D2DataSet;
-};
-
-export type D2Color = {
+export type D2ValidationRule = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    color: string;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2CategoryOptionGroupSetDimension = {
-    categoryOptionGroupSet: D2CategoryOptionGroupSet;
-    categoryOptionGroups: D2CategoryOptionGroup[];
-};
-
-export type D2Legend = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    color: string;
-    created: string;
-    displayName: string;
-    endValue: number;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    image: string;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    startValue: number;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2ProgramTrackedEntityAttributeDimensionItem = {
-    access: D2Access;
+    aggregateExportAttributeOptionCombo: string;
+    aggregateExportCategoryOptionCombo: string;
     aggregationType:
         | "SUM"
         | "AVERAGE"
@@ -4380,7 +4379,6 @@ export type D2ProgramTrackedEntityAttributeDimensionItem = {
         | "NONE"
         | "CUSTOM"
         | "DEFAULT";
-    attribute: D2TrackedEntityAttribute;
     attributeValues: D2AttributeValue[];
     code: Id;
     created: string;
@@ -4411,79 +4409,74 @@ export type D2ProgramTrackedEntityAttributeDimensionItem = {
     formName: string;
     href: string;
     id: Id;
+    importance: "HIGH" | "MEDIUM" | "LOW";
+    instruction: string;
     lastUpdated: string;
     lastUpdatedBy: D2User;
+    leftSide: D2Expression;
     legendSet: D2LegendSet;
     legendSets: D2LegendSet[];
     name: string;
-    program: D2Program;
+    notificationTemplates: D2ValidationNotificationTemplate[];
+    operator:
+        | "equal_to"
+        | "not_equal_to"
+        | "greater_than"
+        | "greater_than_or_equal_to"
+        | "less_than"
+        | "less_than_or_equal_to"
+        | "compulsory_pair"
+        | "exclusive_pair";
+    organisationUnitLevels: number[];
+    periodType: string;
     publicAccess: string;
+    rightSide: D2Expression;
     shortName: string;
+    skipFormValidation: boolean;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
+    validationRuleGroups: D2ValidationRuleGroup[];
 };
 
-export type D2Relationship = {
+export type D2ValidationRuleGroup = {
     access: D2Access;
     attributeValues: D2AttributeValue[];
     code: Id;
     created: string;
     description: string;
-    displayDescription: string;
-    displayFormName: string;
     displayName: string;
-    displayShortName: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
-    formName: string;
-    from: any;
     href: string;
     id: Id;
     lastUpdated: string;
     lastUpdatedBy: D2User;
     name: string;
     publicAccess: string;
-    relationshipType: D2RelationshipType;
-    shortName: string;
-    style: D2Style;
-    to: any;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
+    validationRules: D2ValidationRule[];
 };
 
-export type D2CategoryDimension = {
-    category: D2Category;
-    categoryOptions: D2CategoryOption[];
-};
-
-export interface D2AttributeValueSchema {
-    name: "D2AttributeValue";
-    model: D2AttributeValue;
-    fields: { attribute: D2AttributeSchema; created: string; lastUpdated: string; value: string };
-    fieldPresets: {
-        $all: Preset<D2AttributeValue, keyof D2AttributeValue>;
-        $identifiable: Preset<D2AttributeValue, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2AttributeValue, FieldPresets["nameable"]>;
-        $persisted: Preset<D2AttributeValue, "lastUpdated" | "attribute" | "value" | "created">;
-        $owner: Preset<D2AttributeValue, "lastUpdated" | "attribute" | "value" | "created">;
-    };
-}
-
-export interface D2UserAuthorityGroupSchema {
-    name: "D2UserAuthorityGroup";
-    model: D2UserAuthorityGroup;
+export interface D2AnalyticsPeriodBoundarySchema {
+    name: "D2AnalyticsPeriodBoundary";
+    model: D2AnalyticsPeriodBoundary;
     fields: {
         access: D2Access;
+        analyticsPeriodBoundaryType:
+            | "BEFORE_START_OF_REPORTING_PERIOD"
+            | "BEFORE_END_OF_REPORTING_PERIOD"
+            | "AFTER_START_OF_REPORTING_PERIOD"
+            | "AFTER_END_OF_REPORTING_PERIOD";
         attributeValues: D2AttributeValueSchema[];
-        authorities: string[];
+        boundaryTarget: string;
         code: Id;
         created: string;
-        description: string;
         displayName: string;
         externalAccess: boolean;
         favorite: boolean;
@@ -4493,48 +4486,121 @@ export interface D2UserAuthorityGroupSchema {
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
         name: string;
+        offsetPeriodType: string;
+        offsetPeriods: number;
         publicAccess: string;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
-        users: D2UserSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2UserAuthorityGroup, keyof D2UserAuthorityGroup>;
-        $identifiable: Preset<D2UserAuthorityGroup, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2UserAuthorityGroup, FieldPresets["nameable"]>;
+        $all: Preset<D2AnalyticsPeriodBoundary, keyof D2AnalyticsPeriodBoundary>;
+        $identifiable: Preset<D2AnalyticsPeriodBoundary, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2AnalyticsPeriodBoundary, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2UserAuthorityGroup,
+            D2AnalyticsPeriodBoundary,
             | "lastUpdatedBy"
-            | "userGroupAccesses"
             | "code"
             | "created"
-            | "publicAccess"
-            | "description"
-            | "authorities"
             | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
+            | "offsetPeriodType"
             | "id"
-            | "user"
+            | "analyticsPeriodBoundaryType"
+            | "boundaryTarget"
+            | "offsetPeriods"
         >;
         $owner: Preset<
-            D2UserAuthorityGroup,
+            D2AnalyticsPeriodBoundary,
             | "lastUpdatedBy"
-            | "userGroupAccesses"
             | "code"
             | "created"
-            | "publicAccess"
-            | "description"
-            | "authorities"
             | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
+            | "offsetPeriodType"
             | "id"
-            | "user"
+            | "analyticsPeriodBoundaryType"
+            | "boundaryTarget"
+            | "offsetPeriods"
+        >;
+    };
+}
+
+export interface D2AnalyticsTableHookSchema {
+    name: "D2AnalyticsTableHook";
+    model: D2AnalyticsTableHook;
+    fields: {
+        access: D2Access;
+        analyticsTableType:
+            | "DATA_VALUE"
+            | "COMPLETENESS"
+            | "COMPLETENESS_TARGET"
+            | "ORG_UNIT_TARGET"
+            | "EVENT"
+            | "ENROLLMENT"
+            | "VALIDATION_RESULT";
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        phase: "RESOURCE_TABLE_POPULATED" | "ANALYTICS_TABLE_POPULATED";
+        publicAccess: string;
+        resourceTableType:
+            | "ORG_UNIT_STRUCTURE"
+            | "DATA_SET_ORG_UNIT_CATEGORY"
+            | "CATEGORY_OPTION_COMBO_NAME"
+            | "DATA_ELEMENT_GROUP_SET_STRUCTURE"
+            | "INDICATOR_GROUP_SET_STRUCTURE"
+            | "ORG_UNIT_GROUP_SET_STRUCTURE"
+            | "CATEGORY_STRUCTURE"
+            | "DATA_ELEMENT_STRUCTURE"
+            | "PERIOD_STRUCTURE"
+            | "DATE_PERIOD_STRUCTURE"
+            | "DATA_ELEMENT_CATEGORY_OPTION_COMBO"
+            | "DATA_APPROVAL_REMAP_LEVEL"
+            | "DATA_APPROVAL_MIN_LEVEL";
+        sql: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2AnalyticsTableHook, keyof D2AnalyticsTableHook>;
+        $identifiable: Preset<D2AnalyticsTableHook, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2AnalyticsTableHook, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2AnalyticsTableHook,
+            | "phase"
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "analyticsTableType"
+            | "sql"
+            | "lastUpdated"
+            | "name"
+            | "resourceTableType"
+            | "id"
+        >;
+        $owner: Preset<
+            D2AnalyticsTableHook,
+            | "phase"
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "analyticsTableType"
+            | "sql"
+            | "lastUpdated"
+            | "name"
+            | "resourceTableType"
+            | "id"
         >;
     };
 }
@@ -4737,759 +4803,22 @@ export interface D2AttributeSchema {
     };
 }
 
-export interface D2UserSchema {
-    name: "D2User";
-    model: D2User;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        avatar: D2FileResourceSchema;
-        birthday: string;
-        code: Id;
-        created: string;
-        dataViewOrganisationUnits: D2OrganisationUnitSchema[];
-        displayName: string;
-        education: string;
-        email: string;
-        employer: string;
-        externalAccess: boolean;
-        facebookMessenger: string;
-        favorite: boolean;
-        favorites: string[];
-        firstName: string;
-        gender: string;
-        href: string;
-        id: Id;
-        interests: string;
-        introduction: string;
-        jobTitle: string;
-        languages: string;
-        lastCheckedInterpretations: string;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        nationality: string;
-        organisationUnits: D2OrganisationUnitSchema[];
-        phoneNumber: string;
-        publicAccess: string;
-        skype: string;
-        surname: string;
-        teiSearchOrganisationUnits: D2OrganisationUnitSchema[];
-        telegram: string;
-        translations: D2Translation[];
-        twitter: string;
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userCredentials: D2UserCredentialsSchema;
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        userGroups: D2UserGroupSchema[];
-        welcomeMessage: string;
-        whatsApp: string;
-    };
+export interface D2AttributeValueSchema {
+    name: "D2AttributeValue";
+    model: D2AttributeValue;
+    fields: { attribute: D2AttributeSchema; created: string; lastUpdated: string; value: string };
     fieldPresets: {
-        $all: Preset<D2User, keyof D2User>;
-        $identifiable: Preset<D2User, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2User, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2User,
-            | "birthday"
-            | "code"
-            | "education"
-            | "gender"
-            | "jobTitle"
-            | "skype"
-            | "lastUpdated"
-            | "teiSearchOrganisationUnits"
-            | "twitter"
-            | "surname"
-            | "employer"
-            | "id"
-            | "organisationUnits"
-            | "facebookMessenger"
-            | "introduction"
-            | "email"
-            | "dataViewOrganisationUnits"
-            | "whatsApp"
-            | "languages"
-            | "created"
-            | "welcomeMessage"
-            | "userCredentials"
-            | "attributeValues"
-            | "telegram"
-            | "avatar"
-            | "lastCheckedInterpretations"
-            | "userGroups"
-            | "firstName"
-            | "phoneNumber"
-            | "nationality"
-            | "interests"
-        >;
-        $owner: Preset<
-            D2User,
-            | "birthday"
-            | "code"
-            | "education"
-            | "gender"
-            | "jobTitle"
-            | "skype"
-            | "lastUpdated"
-            | "teiSearchOrganisationUnits"
-            | "twitter"
-            | "surname"
-            | "employer"
-            | "id"
-            | "organisationUnits"
-            | "facebookMessenger"
-            | "introduction"
-            | "email"
-            | "dataViewOrganisationUnits"
-            | "whatsApp"
-            | "languages"
-            | "created"
-            | "welcomeMessage"
-            | "userCredentials"
-            | "attributeValues"
-            | "telegram"
-            | "avatar"
-            | "lastCheckedInterpretations"
-            | "firstName"
-            | "phoneNumber"
-            | "nationality"
-            | "interests"
-        >;
+        $all: Preset<D2AttributeValue, keyof D2AttributeValue>;
+        $identifiable: Preset<D2AttributeValue, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2AttributeValue, FieldPresets["nameable"]>;
+        $persisted: Preset<D2AttributeValue, "lastUpdated" | "attribute" | "value" | "created">;
+        $owner: Preset<D2AttributeValue, "lastUpdated" | "attribute" | "value" | "created">;
     };
 }
 
-export interface D2UserGroupSchema {
-    name: "D2UserGroup";
-    model: D2UserGroup;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        managedByGroups: D2UserGroupSchema[];
-        managedGroups: D2UserGroupSchema[];
-        name: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        users: D2UserSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2UserGroup, keyof D2UserGroup>;
-        $identifiable: Preset<D2UserGroup, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2UserGroup, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2UserGroup,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "managedByGroups"
-            | "attributeValues"
-            | "users"
-            | "managedGroups"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2UserGroup,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "users"
-            | "managedGroups"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
-export interface D2ExpressionSchema {
-    name: "D2Expression";
-    model: D2Expression;
-    fields: {
-        description: string;
-        expression: string;
-        missingValueStrategy:
-            | "SKIP_IF_ANY_VALUE_MISSING"
-            | "SKIP_IF_ALL_VALUES_MISSING"
-            | "NEVER_SKIP";
-        slidingWindow: boolean;
-    };
-    fieldPresets: {
-        $all: Preset<D2Expression, keyof D2Expression>;
-        $identifiable: Preset<D2Expression, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Expression, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Expression,
-            "description" | "expression" | "missingValueStrategy" | "slidingWindow"
-        >;
-        $owner: Preset<
-            D2Expression,
-            "description" | "expression" | "missingValueStrategy" | "slidingWindow"
-        >;
-    };
-}
-
-export interface D2ExternalFileResourceSchema {
-    name: "D2ExternalFileResource";
-    model: D2ExternalFileResource;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ExternalFileResource, keyof D2ExternalFileResource>;
-        $identifiable: Preset<D2ExternalFileResource, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ExternalFileResource, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ExternalFileResource,
-            "lastUpdatedBy" | "code" | "created" | "lastUpdated" | "id"
-        >;
-        $owner: Preset<
-            D2ExternalFileResource,
-            "lastUpdatedBy" | "code" | "created" | "lastUpdated" | "id"
-        >;
-    };
-}
-
-export interface D2SqlViewSchema {
-    name: "D2SqlView";
-    model: D2SqlView;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        cacheStrategy:
-            | "NO_CACHE"
-            | "CACHE_15_MINUTES"
-            | "CACHE_30_MINUTES"
-            | "CACHE_1_HOUR"
-            | "CACHE_6AM_TOMORROW"
-            | "CACHE_TWO_WEEKS"
-            | "RESPECT_SYSTEM_SETTING";
-        code: Id;
-        created: string;
-        description: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        sqlQuery: string;
-        translations: D2Translation[];
-        type: "VIEW" | "MATERIALIZED_VIEW" | "QUERY";
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2SqlView, keyof D2SqlView>;
-        $identifiable: Preset<D2SqlView, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2SqlView, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2SqlView,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "sqlQuery"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "description"
-            | "type"
-            | "externalAccess"
-            | "lastUpdated"
-            | "userAccesses"
-            | "name"
-            | "cacheStrategy"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2SqlView,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "sqlQuery"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "description"
-            | "type"
-            | "externalAccess"
-            | "lastUpdated"
-            | "userAccesses"
-            | "name"
-            | "cacheStrategy"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
-export interface D2OAuth2ClientSchema {
-    name: "D2OAuth2Client";
-    model: D2OAuth2Client;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        cid: Id;
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        grantTypes: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        redirectUris: string[];
-        secret: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2OAuth2Client, keyof D2OAuth2Client>;
-        $identifiable: Preset<D2OAuth2Client, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OAuth2Client, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2OAuth2Client,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "secret"
-            | "redirectUris"
-            | "lastUpdated"
-            | "grantTypes"
-            | "name"
-            | "id"
-            | "cid"
-        >;
-        $owner: Preset<
-            D2OAuth2Client,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "secret"
-            | "redirectUris"
-            | "lastUpdated"
-            | "grantTypes"
-            | "name"
-            | "id"
-            | "cid"
-        >;
-    };
-}
-
-export interface D2ConstantSchema {
-    name: "D2Constant";
-    model: D2Constant;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        shortName: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        value: number;
-    };
-    fieldPresets: {
-        $all: Preset<D2Constant, keyof D2Constant>;
-        $identifiable: Preset<D2Constant, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Constant, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Constant,
-            | "code"
-            | "publicAccess"
-            | "description"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "value"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "userAccesses"
-            | "name"
-            | "shortName"
-            | "user"
-        >;
-        $owner: Preset<
-            D2Constant,
-            | "code"
-            | "publicAccess"
-            | "description"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "value"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "userAccesses"
-            | "name"
-            | "shortName"
-            | "user"
-        >;
-    };
-}
-
-export interface D2JobConfigurationSchema {
-    name: "D2JobConfiguration";
-    model: D2JobConfiguration;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        configurable: boolean;
-        continuousExecution: boolean;
-        created: string;
-        cronExpression: string;
-        displayName: string;
-        enabled: boolean;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        jobParameters: string;
-        jobStatus: "RUNNING" | "COMPLETED" | "STOPPED" | "SCHEDULED" | "DISABLED" | "FAILED";
-        jobType:
-            | "DATA_STATISTICS"
-            | "DATA_INTEGRITY"
-            | "RESOURCE_TABLE"
-            | "ANALYTICS_TABLE"
-            | "DATA_SYNC"
-            | "PROGRAM_DATA_SYNC"
-            | "FILE_RESOURCE_CLEANUP"
-            | "META_DATA_SYNC"
-            | "SMS_SEND"
-            | "SEND_SCHEDULED_MESSAGE"
-            | "PROGRAM_NOTIFICATIONS"
-            | "VALIDATION_RESULTS_NOTIFICATION"
-            | "CREDENTIALS_EXPIRY_ALERT"
-            | "MONITORING"
-            | "PUSH_ANALYSIS"
-            | "PREDICTOR"
-            | "DATA_SET_NOTIFICATION"
-            | "REMOVE_EXPIRED_RESERVED_VALUES"
-            | "MOCK"
-            | "DATAVALUE_IMPORT"
-            | "ANALYTICSTABLE_UPDATE"
-            | "METADATA_IMPORT"
-            | "GML_IMPORT"
-            | "DATAVALUE_IMPORT_INTERNAL"
-            | "EVENT_IMPORT"
-            | "ENROLLMENT_IMPORT"
-            | "TEI_IMPORT"
-            | "LEADER_ELECTION"
-            | "LEADER_RENEWAL"
-            | "COMPLETE_DATA_SET_REGISTRATION_IMPORT";
-        lastExecuted: string;
-        lastExecutedStatus:
-            | "RUNNING"
-            | "COMPLETED"
-            | "STOPPED"
-            | "SCHEDULED"
-            | "DISABLED"
-            | "FAILED";
-        lastRuntimeExecution: string;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        leaderOnlyJob: boolean;
-        name: string;
-        nextExecutionTime: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        userUid: string;
-    };
-    fieldPresets: {
-        $all: Preset<D2JobConfiguration, keyof D2JobConfiguration>;
-        $identifiable: Preset<D2JobConfiguration, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2JobConfiguration, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2JobConfiguration,
-            | "jobStatus"
-            | "code"
-            | "enabled"
-            | "leaderOnlyJob"
-            | "lastUpdated"
-            | "continuousExecution"
-            | "id"
-            | "jobType"
-            | "lastUpdatedBy"
-            | "nextExecutionTime"
-            | "created"
-            | "cronExpression"
-            | "lastRuntimeExecution"
-            | "lastExecutedStatus"
-            | "name"
-            | "jobParameters"
-            | "lastExecuted"
-        >;
-        $owner: Preset<
-            D2JobConfiguration,
-            | "jobStatus"
-            | "code"
-            | "enabled"
-            | "leaderOnlyJob"
-            | "lastUpdated"
-            | "continuousExecution"
-            | "id"
-            | "jobType"
-            | "lastUpdatedBy"
-            | "nextExecutionTime"
-            | "created"
-            | "cronExpression"
-            | "lastRuntimeExecution"
-            | "lastExecutedStatus"
-            | "name"
-            | "jobParameters"
-            | "lastExecuted"
-        >;
-    };
-}
-
-export interface D2OptionSchema {
-    name: "D2Option";
-    model: D2Option;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: string;
-        created: string;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        optionSet: D2OptionSetSchema;
-        publicAccess: string;
-        shortName: string;
-        sortOrder: number;
-        style: D2Style;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Option, keyof D2Option>;
-        $identifiable: Preset<D2Option, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Option, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Option,
-            | "code"
-            | "description"
-            | "lastUpdated"
-            | "optionSet"
-            | "translations"
-            | "formName"
-            | "id"
-            | "created"
-            | "attributeValues"
-            | "sortOrder"
-            | "name"
-            | "style"
-        >;
-        $owner: Preset<
-            D2Option,
-            | "code"
-            | "description"
-            | "lastUpdated"
-            | "optionSet"
-            | "translations"
-            | "formName"
-            | "id"
-            | "created"
-            | "attributeValues"
-            | "sortOrder"
-            | "name"
-            | "style"
-        >;
-    };
-}
-
-export interface D2OptionSetSchema {
-    name: "D2OptionSet";
-    model: D2OptionSet;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        options: D2OptionSchema[];
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        valueType:
-            | "TEXT"
-            | "LONG_TEXT"
-            | "LETTER"
-            | "PHONE_NUMBER"
-            | "EMAIL"
-            | "BOOLEAN"
-            | "TRUE_ONLY"
-            | "DATE"
-            | "DATETIME"
-            | "TIME"
-            | "NUMBER"
-            | "UNIT_INTERVAL"
-            | "PERCENTAGE"
-            | "INTEGER"
-            | "INTEGER_POSITIVE"
-            | "INTEGER_NEGATIVE"
-            | "INTEGER_ZERO_OR_POSITIVE"
-            | "TRACKER_ASSOCIATE"
-            | "USERNAME"
-            | "COORDINATE"
-            | "ORGANISATION_UNIT"
-            | "AGE"
-            | "URL"
-            | "FILE_RESOURCE"
-            | "IMAGE";
-        version: number;
-    };
-    fieldPresets: {
-        $all: Preset<D2OptionSet, keyof D2OptionSet>;
-        $identifiable: Preset<D2OptionSet, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OptionSet, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2OptionSet,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "version"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "valueType"
-            | "name"
-            | "options"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2OptionSet,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "version"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "valueType"
-            | "name"
-            | "options"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
-export interface D2OptionGroupSetSchema {
-    name: "D2OptionGroupSet";
-    model: D2OptionGroupSet;
+export interface D2CategorySchema {
+    name: "D2Category";
+    model: D2Category;
     fields: {
         access: D2Access;
         aggregationType:
@@ -5508,6 +4837,8 @@ export interface D2OptionGroupSetSchema {
             | "DEFAULT";
         allItems: boolean;
         attributeValues: D2AttributeValueSchema[];
+        categoryCombos: D2CategoryComboSchema[];
+        categoryOptions: D2CategoryOptionSchema[];
         code: Id;
         created: string;
         dataDimension: boolean;
@@ -5550,8 +4881,6 @@ export interface D2OptionGroupSetSchema {
         lastUpdatedBy: D2UserSchema;
         legendSet: D2LegendSetSchema;
         name: string;
-        optionGroups: D2OptionGroupSchema[];
-        optionSet: D2OptionSetSchema;
         publicAccess: string;
         shortName: string;
         translations: D2Translation[];
@@ -5560,40 +4889,41 @@ export interface D2OptionGroupSetSchema {
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2OptionGroupSet, keyof D2OptionGroupSet>;
-        $identifiable: Preset<D2OptionGroupSet, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OptionGroupSet, FieldPresets["nameable"]>;
+        $all: Preset<D2Category, keyof D2Category>;
+        $identifiable: Preset<D2Category, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Category, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2OptionGroupSet,
+            D2Category,
+            | "dataDimensionType"
             | "code"
             | "publicAccess"
-            | "description"
-            | "optionGroups"
             | "lastUpdated"
-            | "optionSet"
             | "translations"
+            | "categoryCombos"
             | "id"
+            | "categoryOptions"
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "created"
+            | "attributeValues"
             | "userAccesses"
             | "name"
             | "dataDimension"
             | "user"
         >;
         $owner: Preset<
-            D2OptionGroupSet,
+            D2Category,
+            | "dataDimensionType"
             | "code"
             | "publicAccess"
-            | "description"
-            | "optionGroups"
             | "lastUpdated"
-            | "optionSet"
             | "translations"
             | "id"
+            | "categoryOptions"
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "created"
+            | "attributeValues"
             | "userAccesses"
             | "name"
             | "dataDimension"
@@ -5602,663 +4932,86 @@ export interface D2OptionGroupSetSchema {
     };
 }
 
-export interface D2OptionGroupSchema {
-    name: "D2OptionGroup";
-    model: D2OptionGroup;
-    fields: {
-        access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        description: string;
-        dimensionItem: string;
-        dimensionItemType:
-            | "DATA_ELEMENT"
-            | "DATA_ELEMENT_OPERAND"
-            | "INDICATOR"
-            | "REPORTING_RATE"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION"
-            | "OPTION_GROUP"
-            | "DATA_ELEMENT_GROUP"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY_OPTION_GROUP";
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        legendSet: D2LegendSetSchema;
-        legendSets: D2LegendSetSchema[];
-        name: string;
-        optionSet: D2OptionSetSchema;
-        options: D2OptionSchema[];
-        publicAccess: string;
-        shortName: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2OptionGroup, keyof D2OptionGroup>;
-        $identifiable: Preset<D2OptionGroup, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OptionGroup, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2OptionGroup,
-            | "code"
-            | "publicAccess"
-            | "lastUpdated"
-            | "optionSet"
-            | "translations"
-            | "options"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "userAccesses"
-            | "name"
-            | "shortName"
-            | "user"
-        >;
-        $owner: Preset<
-            D2OptionGroup,
-            | "code"
-            | "publicAccess"
-            | "lastUpdated"
-            | "optionSet"
-            | "translations"
-            | "options"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "userAccesses"
-            | "name"
-            | "shortName"
-            | "user"
-        >;
-    };
-}
-
-export interface D2ColorSetSchema {
-    name: "D2ColorSet";
-    model: D2ColorSet;
+export interface D2CategoryComboSchema {
+    name: "D2CategoryCombo";
+    model: D2CategoryCombo;
     fields: {
         access: D2Access;
         attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        colors: D2ColorSchema[];
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ColorSet, keyof D2ColorSet>;
-        $identifiable: Preset<D2ColorSet, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ColorSet, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ColorSet,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "colors"
-            | "lastUpdated"
-            | "translations"
-            | "name"
-            | "id"
-        >;
-        $owner: Preset<
-            D2ColorSet,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "colors"
-            | "lastUpdated"
-            | "translations"
-            | "name"
-            | "id"
-        >;
-    };
-}
-
-export interface D2LegendSetSchema {
-    name: "D2LegendSet";
-    model: D2LegendSet;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        categories: D2CategorySchema[];
+        categoryOptionCombos: D2CategoryOptionComboSchema[];
         code: Id;
         created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        legends: D2LegendSchema[];
-        name: string;
-        publicAccess: string;
-        symbolizer: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2LegendSet, keyof D2LegendSet>;
-        $identifiable: Preset<D2LegendSet, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2LegendSet, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2LegendSet,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "symbolizer"
-            | "lastUpdated"
-            | "legends"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2LegendSet,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "symbolizer"
-            | "lastUpdated"
-            | "legends"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
-export interface D2OrganisationUnitSchema {
-    name: "D2OrganisationUnit";
-    model: D2OrganisationUnit;
-    fields: {
-        access: D2Access;
-        address: string;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
-        ancestors: D2OrganisationUnitSchema[];
-        attributeValues: D2AttributeValueSchema[];
-        children: D2OrganisationUnitSchema[];
-        closedDate: string;
-        code: Id;
-        comment: string;
-        contactPerson: string;
-        created: string;
-        dataSets: D2DataSetSchema[];
-        description: string;
-        dimensionItem: string;
-        dimensionItemType:
-            | "DATA_ELEMENT"
-            | "DATA_ELEMENT_OPERAND"
-            | "INDICATOR"
-            | "REPORTING_RATE"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION"
-            | "OPTION_GROUP"
-            | "DATA_ELEMENT_GROUP"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY_OPTION_GROUP";
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        email: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        geometry: D2Geometry;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        leaf: boolean;
-        legendSet: D2LegendSetSchema;
-        legendSets: D2LegendSetSchema[];
-        level: number;
-        memberCount: number;
-        name: string;
-        openingDate: string;
-        organisationUnitGroups: D2OrganisationUnitGroupSchema[];
-        parent: D2OrganisationUnitSchema;
-        path: string;
-        phoneNumber: string;
-        programs: D2ProgramSchema[];
-        publicAccess: string;
-        shortName: string;
-        translations: D2Translation[];
-        type: string;
-        url: string;
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        users: D2UserSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2OrganisationUnit, keyof D2OrganisationUnit>;
-        $identifiable: Preset<D2OrganisationUnit, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OrganisationUnit, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2OrganisationUnit,
-            | "parent"
-            | "path"
-            | "lastUpdated"
-            | "children"
-            | "translations"
-            | "id"
-            | "organisationUnitGroups"
-            | "lastUpdatedBy"
-            | "created"
-            | "attributeValues"
-            | "users"
-            | "phoneNumber"
-            | "name"
-            | "dataSets"
-            | "programs"
-            | "shortName"
-            | "code"
-            | "description"
-            | "contactPerson"
-            | "openingDate"
-            | "email"
-            | "address"
-            | "url"
-            | "closedDate"
-            | "geometry"
-            | "comment"
-            | "user"
-        >;
-        $owner: Preset<
-            D2OrganisationUnit,
-            | "parent"
-            | "path"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "created"
-            | "attributeValues"
-            | "phoneNumber"
-            | "name"
-            | "shortName"
-            | "code"
-            | "description"
-            | "contactPerson"
-            | "openingDate"
-            | "email"
-            | "address"
-            | "url"
-            | "closedDate"
-            | "geometry"
-            | "comment"
-            | "user"
-        >;
-    };
-}
-
-export interface D2OrganisationUnitLevelSchema {
-    name: "D2OrganisationUnitLevel";
-    model: D2OrganisationUnitLevel;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        level: number;
-        name: string;
-        offlineLevels: number;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2OrganisationUnitLevel, keyof D2OrganisationUnitLevel>;
-        $identifiable: Preset<D2OrganisationUnitLevel, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OrganisationUnitLevel, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2OrganisationUnitLevel,
-            | "lastUpdatedBy"
-            | "offlineLevels"
-            | "code"
-            | "level"
-            | "created"
-            | "lastUpdated"
-            | "translations"
-            | "name"
-            | "id"
-        >;
-        $owner: Preset<
-            D2OrganisationUnitLevel,
-            | "lastUpdatedBy"
-            | "offlineLevels"
-            | "code"
-            | "level"
-            | "created"
-            | "lastUpdated"
-            | "translations"
-            | "name"
-            | "id"
-        >;
-    };
-}
-
-export interface D2OrganisationUnitGroupSchema {
-    name: "D2OrganisationUnitGroup";
-    model: D2OrganisationUnitGroup;
-    fields: {
-        access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        color: string;
-        created: string;
-        description: string;
-        dimensionItem: string;
-        dimensionItemType:
-            | "DATA_ELEMENT"
-            | "DATA_ELEMENT_OPERAND"
-            | "INDICATOR"
-            | "REPORTING_RATE"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION"
-            | "OPTION_GROUP"
-            | "DATA_ELEMENT_GROUP"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY_OPTION_GROUP";
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
-        formName: string;
-        geometry: D2Geometry;
-        groupSets: D2OrganisationUnitGroupSetSchema[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        legendSet: D2LegendSetSchema;
-        legendSets: D2LegendSetSchema[];
-        name: string;
-        organisationUnits: D2OrganisationUnitSchema[];
-        publicAccess: string;
-        shortName: string;
-        symbol: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2OrganisationUnitGroup, keyof D2OrganisationUnitGroup>;
-        $identifiable: Preset<D2OrganisationUnitGroup, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OrganisationUnitGroup, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2OrganisationUnitGroup,
-            | "symbol"
-            | "code"
-            | "color"
-            | "publicAccess"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "organisationUnits"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "groupSets"
-            | "userAccesses"
-            | "name"
-            | "geometry"
-            | "shortName"
-            | "user"
-        >;
-        $owner: Preset<
-            D2OrganisationUnitGroup,
-            | "symbol"
-            | "code"
-            | "color"
-            | "publicAccess"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "organisationUnits"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "userAccesses"
-            | "name"
-            | "geometry"
-            | "shortName"
-            | "user"
-        >;
-    };
-}
-
-export interface D2OrganisationUnitGroupSetSchema {
-    name: "D2OrganisationUnitGroupSet";
-    model: D2OrganisationUnitGroupSet;
-    fields: {
-        access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
-        allItems: boolean;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        compulsory: boolean;
-        created: string;
-        dataDimension: boolean;
         dataDimensionType: "DISAGGREGATION" | "ATTRIBUTE";
-        description: string;
-        dimension: string;
-        dimensionType:
-            | "DATA_X"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "DATA_COLLAPSED"
-            | "CATEGORY_OPTION_COMBO"
-            | "ATTRIBUTE_OPTION_COMBO"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION_GROUP_SET"
-            | "DATA_ELEMENT_GROUP_SET"
-            | "ORGANISATION_UNIT_GROUP_SET"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY"
-            | "OPTION_GROUP_SET"
-            | "VALIDATION_RULE"
-            | "STATIC"
-            | "ORGANISATION_UNIT_LEVEL";
-        dimensionalKeywords: D2DimensionalKeywords;
-        displayDescription: string;
-        displayFormName: string;
         displayName: string;
-        displayShortName: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
-        filter: string;
-        formName: string;
         href: string;
         id: Id;
-        includeSubhierarchyInAnalytics: boolean;
-        items: any[];
+        isDefault: boolean;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
-        legendSet: D2LegendSetSchema;
         name: string;
-        organisationUnitGroups: D2OrganisationUnitGroupSchema[];
         publicAccess: string;
-        shortName: string;
+        skipTotal: boolean;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2OrganisationUnitGroupSet, keyof D2OrganisationUnitGroupSet>;
-        $identifiable: Preset<D2OrganisationUnitGroupSet, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OrganisationUnitGroupSet, FieldPresets["nameable"]>;
+        $all: Preset<D2CategoryCombo, keyof D2CategoryCombo>;
+        $identifiable: Preset<D2CategoryCombo, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2CategoryCombo, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2OrganisationUnitGroupSet,
+            D2CategoryCombo,
+            | "dataDimensionType"
             | "code"
             | "publicAccess"
-            | "description"
             | "lastUpdated"
             | "translations"
             | "id"
-            | "organisationUnitGroups"
+            | "categories"
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "created"
-            | "attributeValues"
-            | "compulsory"
-            | "includeSubhierarchyInAnalytics"
+            | "categoryOptionCombos"
             | "userAccesses"
             | "name"
-            | "dataDimension"
+            | "skipTotal"
             | "user"
         >;
         $owner: Preset<
-            D2OrganisationUnitGroupSet,
+            D2CategoryCombo,
+            | "dataDimensionType"
             | "code"
             | "publicAccess"
-            | "description"
             | "lastUpdated"
             | "translations"
             | "id"
-            | "organisationUnitGroups"
+            | "categories"
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "created"
-            | "attributeValues"
-            | "compulsory"
-            | "includeSubhierarchyInAnalytics"
             | "userAccesses"
             | "name"
-            | "dataDimension"
+            | "skipTotal"
             | "user"
         >;
+    };
+}
+
+export interface D2CategoryDimensionSchema {
+    name: "D2CategoryDimension";
+    model: D2CategoryDimension;
+    fields: { category: D2CategorySchema; categoryOptions: D2CategoryOptionSchema[] };
+    fieldPresets: {
+        $all: Preset<D2CategoryDimension, keyof D2CategoryDimension>;
+        $identifiable: Preset<D2CategoryDimension, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2CategoryDimension, FieldPresets["nameable"]>;
+        $persisted: Preset<D2CategoryDimension, "categoryOptions" | "category">;
+        $owner: Preset<D2CategoryDimension, "categoryOptions" | "category">;
     };
 }
 
@@ -6377,6 +5130,105 @@ export interface D2CategoryOptionSchema {
             | "shortName"
             | "user"
             | "startDate"
+        >;
+    };
+}
+
+export interface D2CategoryOptionComboSchema {
+    name: "D2CategoryOptionCombo";
+    model: D2CategoryOptionCombo;
+    fields: {
+        access: D2Access;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        attributeValues: D2AttributeValueSchema[];
+        categoryCombo: D2CategoryComboSchema;
+        categoryOptions: D2CategoryOptionSchema[];
+        code: Id;
+        created: string;
+        description: string;
+        dimensionItem: string;
+        dimensionItemType:
+            | "DATA_ELEMENT"
+            | "DATA_ELEMENT_OPERAND"
+            | "INDICATOR"
+            | "REPORTING_RATE"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION"
+            | "OPTION_GROUP"
+            | "DATA_ELEMENT_GROUP"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY_OPTION_GROUP";
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        ignoreApproval: boolean;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendSet: D2LegendSetSchema;
+        legendSets: D2LegendSetSchema[];
+        name: string;
+        publicAccess: string;
+        shortName: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2CategoryOptionCombo, keyof D2CategoryOptionCombo>;
+        $identifiable: Preset<D2CategoryOptionCombo, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2CategoryOptionCombo, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2CategoryOptionCombo,
+            | "code"
+            | "lastUpdated"
+            | "ignoreApproval"
+            | "categoryCombo"
+            | "translations"
+            | "id"
+            | "categoryOptions"
+            | "lastUpdatedBy"
+            | "created"
+            | "attributeValues"
+            | "name"
+        >;
+        $owner: Preset<
+            D2CategoryOptionCombo,
+            | "code"
+            | "lastUpdated"
+            | "ignoreApproval"
+            | "categoryCombo"
+            | "translations"
+            | "id"
+            | "categoryOptions"
+            | "lastUpdatedBy"
+            | "created"
+            | "attributeValues"
+            | "name"
         >;
     };
 }
@@ -6605,9 +5457,31 @@ export interface D2CategoryOptionGroupSetSchema {
     };
 }
 
-export interface D2CategorySchema {
-    name: "D2Category";
-    model: D2Category;
+export interface D2CategoryOptionGroupSetDimensionSchema {
+    name: "D2CategoryOptionGroupSetDimension";
+    model: D2CategoryOptionGroupSetDimension;
+    fields: {
+        categoryOptionGroupSet: D2CategoryOptionGroupSetSchema;
+        categoryOptionGroups: D2CategoryOptionGroupSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2CategoryOptionGroupSetDimension, keyof D2CategoryOptionGroupSetDimension>;
+        $identifiable: Preset<D2CategoryOptionGroupSetDimension, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2CategoryOptionGroupSetDimension, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2CategoryOptionGroupSetDimension,
+            "categoryOptionGroups" | "categoryOptionGroupSet"
+        >;
+        $owner: Preset<
+            D2CategoryOptionGroupSetDimension,
+            "categoryOptionGroups" | "categoryOptionGroupSet"
+        >;
+    };
+}
+
+export interface D2ChartSchema {
+    name: "D2Chart";
+    model: D2Chart;
     fields: {
         access: D2Access;
         aggregationType:
@@ -6624,36 +5498,362 @@ export interface D2CategorySchema {
             | "NONE"
             | "CUSTOM"
             | "DEFAULT";
-        allItems: boolean;
+        attributeDimensions: any[];
         attributeValues: D2AttributeValueSchema[];
-        categoryCombos: D2CategoryComboSchema[];
-        categoryOptions: D2CategoryOptionSchema[];
+        baseLineLabel: string;
+        baseLineValue: number;
+        category: string;
+        categoryDimensions: D2CategoryDimensionSchema[];
+        categoryOptionGroupSetDimensions: D2CategoryOptionGroupSetDimensionSchema[];
+        code: Id;
+        colorSet: D2ColorSetSchema;
+        columns: any[];
+        completedOnly: boolean;
+        created: string;
+        cumulativeValues: boolean;
+        dataDimensionItems: any[];
+        dataElementDimensions: D2TrackedEntityDataElementDimensionSchema[];
+        dataElementGroupSetDimensions: D2DataElementGroupSetDimensionSchema[];
+        description: string;
+        digitGroupSeparator: "COMMA" | "SPACE" | "NONE";
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        domainAxisLabel: string;
+        endDate: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        filterDimensions: string[];
+        filters: any[];
+        formName: string;
+        hideEmptyRowItems:
+            | "NONE"
+            | "BEFORE_FIRST"
+            | "AFTER_LAST"
+            | "BEFORE_FIRST_AFTER_LAST"
+            | "ALL";
+        hideLegend: boolean;
+        hideSubtitle: boolean;
+        hideTitle: boolean;
+        href: string;
+        id: Id;
+        interpretations: D2InterpretationSchema[];
+        itemOrganisationUnitGroups: D2OrganisationUnitGroupSchema[];
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendDisplayStrategy: "FIXED" | "BY_DATA_ITEM";
+        legendSet: D2LegendSetSchema;
+        name: string;
+        noSpaceBetweenColumns: boolean;
+        orgUnitField: string;
+        organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimensionSchema[];
+        organisationUnitLevels: number[];
+        organisationUnits: D2OrganisationUnitSchema[];
+        parentGraphMap: D2MapSchema;
+        percentStackedValues: boolean;
+        periods: any[];
+        programIndicatorDimensions: D2TrackedEntityProgramIndicatorDimensionSchema[];
+        publicAccess: string;
+        rangeAxisDecimals: number;
+        rangeAxisLabel: string;
+        rangeAxisMaxValue: number;
+        rangeAxisMinValue: number;
+        rangeAxisSteps: number;
+        regressionType: "NONE" | "LINEAR" | "POLYNOMIAL" | "LOESS";
+        relativePeriods: any;
+        rows: any[];
+        series: string;
+        seriesItems: any[];
+        shortName: string;
+        showData: boolean;
+        sortOrder: number;
+        startDate: string;
+        subscribed: boolean;
+        subscribers: string[];
+        subtitle: string;
+        targetLineLabel: string;
+        targetLineValue: number;
+        timeField: string;
+        title: string;
+        topLimit: number;
+        translations: D2Translation[];
+        type:
+            | "COLUMN"
+            | "STACKED_COLUMN"
+            | "BAR"
+            | "STACKED_BAR"
+            | "LINE"
+            | "AREA"
+            | "PIE"
+            | "RADAR"
+            | "GAUGE"
+            | "YEAR_OVER_YEAR_LINE"
+            | "YEAR_OVER_YEAR_COLUMN";
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        userOrganisationUnit: boolean;
+        userOrganisationUnitChildren: boolean;
+        userOrganisationUnitGrandChildren: boolean;
+        yearlySeries: string[];
+    };
+    fieldPresets: {
+        $all: Preset<D2Chart, keyof D2Chart>;
+        $identifiable: Preset<D2Chart, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Chart, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Chart,
+            | "dataElementGroupSetDimensions"
+            | "showData"
+            | "endDate"
+            | "baseLineValue"
+            | "publicAccess"
+            | "userOrganisationUnitChildren"
+            | "type"
+            | "lastUpdated"
+            | "translations"
+            | "yearlySeries"
+            | "userOrganisationUnit"
+            | "filterDimensions"
+            | "id"
+            | "interpretations"
+            | "itemOrganisationUnitGroups"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "domainAxisLabel"
+            | "created"
+            | "subscribers"
+            | "rangeAxisLabel"
+            | "regressionType"
+            | "completedOnly"
+            | "cumulativeValues"
+            | "subtitle"
+            | "sortOrder"
+            | "userAccesses"
+            | "name"
+            | "rangeAxisDecimals"
+            | "startDate"
+            | "hideEmptyRowItems"
+            | "favorites"
+            | "dataDimensionItems"
+            | "aggregationType"
+            | "code"
+            | "categoryOptionGroupSetDimensions"
+            | "userOrganisationUnitGrandChildren"
+            | "hideSubtitle"
+            | "description"
+            | "organisationUnitGroupSetDimensions"
+            | "title"
+            | "hideLegend"
+            | "organisationUnitLevels"
+            | "externalAccess"
+            | "rangeAxisMinValue"
+            | "percentStackedValues"
+            | "seriesItems"
+            | "legendDisplayStrategy"
+            | "noSpaceBetweenColumns"
+            | "relativePeriods"
+            | "rangeAxisSteps"
+            | "targetLineLabel"
+            | "periods"
+            | "organisationUnits"
+            | "categoryDimensions"
+            | "targetLineValue"
+            | "baseLineLabel"
+            | "hideTitle"
+            | "series"
+            | "legendSet"
+            | "rangeAxisMaxValue"
+            | "colorSet"
+            | "category"
+            | "user"
+        >;
+        $owner: Preset<
+            D2Chart,
+            | "dataElementGroupSetDimensions"
+            | "showData"
+            | "endDate"
+            | "baseLineValue"
+            | "publicAccess"
+            | "userOrganisationUnitChildren"
+            | "type"
+            | "lastUpdated"
+            | "translations"
+            | "yearlySeries"
+            | "userOrganisationUnit"
+            | "filterDimensions"
+            | "id"
+            | "itemOrganisationUnitGroups"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "domainAxisLabel"
+            | "created"
+            | "subscribers"
+            | "rangeAxisLabel"
+            | "regressionType"
+            | "completedOnly"
+            | "cumulativeValues"
+            | "subtitle"
+            | "sortOrder"
+            | "userAccesses"
+            | "name"
+            | "rangeAxisDecimals"
+            | "startDate"
+            | "hideEmptyRowItems"
+            | "favorites"
+            | "dataDimensionItems"
+            | "aggregationType"
+            | "code"
+            | "categoryOptionGroupSetDimensions"
+            | "userOrganisationUnitGrandChildren"
+            | "hideSubtitle"
+            | "description"
+            | "organisationUnitGroupSetDimensions"
+            | "title"
+            | "hideLegend"
+            | "organisationUnitLevels"
+            | "externalAccess"
+            | "rangeAxisMinValue"
+            | "percentStackedValues"
+            | "seriesItems"
+            | "legendDisplayStrategy"
+            | "noSpaceBetweenColumns"
+            | "relativePeriods"
+            | "rangeAxisSteps"
+            | "targetLineLabel"
+            | "periods"
+            | "organisationUnits"
+            | "categoryDimensions"
+            | "targetLineValue"
+            | "baseLineLabel"
+            | "hideTitle"
+            | "series"
+            | "legendSet"
+            | "rangeAxisMaxValue"
+            | "colorSet"
+            | "category"
+            | "user"
+        >;
+    };
+}
+
+export interface D2ColorSchema {
+    name: "D2Color";
+    model: D2Color;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        color: string;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2Color, keyof D2Color>;
+        $identifiable: Preset<D2Color, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Color, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Color,
+            | "lastUpdatedBy"
+            | "code"
+            | "color"
+            | "created"
+            | "lastUpdated"
+            | "translations"
+            | "name"
+            | "id"
+        >;
+        $owner: Preset<
+            D2Color,
+            | "lastUpdatedBy"
+            | "code"
+            | "color"
+            | "created"
+            | "lastUpdated"
+            | "translations"
+            | "name"
+            | "id"
+        >;
+    };
+}
+
+export interface D2ColorSetSchema {
+    name: "D2ColorSet";
+    model: D2ColorSet;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        colors: D2ColorSchema[];
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ColorSet, keyof D2ColorSet>;
+        $identifiable: Preset<D2ColorSet, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ColorSet, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ColorSet,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "colors"
+            | "lastUpdated"
+            | "translations"
+            | "name"
+            | "id"
+        >;
+        $owner: Preset<
+            D2ColorSet,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "colors"
+            | "lastUpdated"
+            | "translations"
+            | "name"
+            | "id"
+        >;
+    };
+}
+
+export interface D2ConstantSchema {
+    name: "D2Constant";
+    model: D2Constant;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
         code: Id;
         created: string;
-        dataDimension: boolean;
-        dataDimensionType: "DISAGGREGATION" | "ATTRIBUTE";
         description: string;
-        dimension: string;
-        dimensionType:
-            | "DATA_X"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "DATA_COLLAPSED"
-            | "CATEGORY_OPTION_COMBO"
-            | "ATTRIBUTE_OPTION_COMBO"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION_GROUP_SET"
-            | "DATA_ELEMENT_GROUP_SET"
-            | "ORGANISATION_UNIT_GROUP_SET"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY"
-            | "OPTION_GROUP_SET"
-            | "VALIDATION_RULE"
-            | "STATIC"
-            | "ORGANISATION_UNIT_LEVEL";
-        dimensionalKeywords: D2DimensionalKeywords;
         displayDescription: string;
         displayFormName: string;
         displayName: string;
@@ -6661,14 +5861,86 @@ export interface D2CategorySchema {
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
-        filter: string;
         formName: string;
         href: string;
         id: Id;
-        items: any[];
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
-        legendSet: D2LegendSetSchema;
+        name: string;
+        publicAccess: string;
+        shortName: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        value: number;
+    };
+    fieldPresets: {
+        $all: Preset<D2Constant, keyof D2Constant>;
+        $identifiable: Preset<D2Constant, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Constant, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Constant,
+            | "code"
+            | "publicAccess"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "value"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "userAccesses"
+            | "name"
+            | "shortName"
+            | "user"
+        >;
+        $owner: Preset<
+            D2Constant,
+            | "code"
+            | "publicAccess"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "value"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "userAccesses"
+            | "name"
+            | "shortName"
+            | "user"
+        >;
+    };
+}
+
+export interface D2DashboardSchema {
+    name: "D2Dashboard";
+    model: D2Dashboard;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        created: string;
+        dashboardItems: D2DashboardItemSchema[];
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        itemCount: number;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
         name: string;
         publicAccess: string;
         shortName: string;
@@ -6678,214 +5950,292 @@ export interface D2CategorySchema {
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2Category, keyof D2Category>;
-        $identifiable: Preset<D2Category, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Category, FieldPresets["nameable"]>;
+        $all: Preset<D2Dashboard, keyof D2Dashboard>;
+        $identifiable: Preset<D2Dashboard, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Dashboard, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2Category,
-            | "dataDimensionType"
+            D2Dashboard,
+            | "favorites"
             | "code"
             | "publicAccess"
+            | "description"
+            | "externalAccess"
             | "lastUpdated"
             | "translations"
-            | "categoryCombos"
             | "id"
-            | "categoryOptions"
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "created"
-            | "attributeValues"
+            | "dashboardItems"
             | "userAccesses"
             | "name"
-            | "dataDimension"
             | "user"
         >;
         $owner: Preset<
-            D2Category,
-            | "dataDimensionType"
+            D2Dashboard,
+            | "favorites"
             | "code"
             | "publicAccess"
+            | "description"
+            | "externalAccess"
             | "lastUpdated"
             | "translations"
             | "id"
-            | "categoryOptions"
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "created"
-            | "attributeValues"
+            | "dashboardItems"
             | "userAccesses"
             | "name"
-            | "dataDimension"
             | "user"
         >;
     };
 }
 
-export interface D2CategoryComboSchema {
-    name: "D2CategoryCombo";
-    model: D2CategoryCombo;
+export interface D2DashboardItemSchema {
+    name: "D2DashboardItem";
+    model: D2DashboardItem;
+    fields: {
+        access: D2Access;
+        appKey: string;
+        attributeValues: D2AttributeValueSchema[];
+        chart: D2ChartSchema;
+        code: Id;
+        contentCount: number;
+        created: string;
+        displayName: string;
+        eventChart: D2EventChartSchema;
+        eventReport: D2EventReportSchema;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        height: number;
+        href: string;
+        id: Id;
+        interpretationCount: number;
+        interpretationLikeCount: number;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        map: D2MapSchema;
+        messages: boolean;
+        name: string;
+        publicAccess: string;
+        reportTable: D2ReportTableSchema;
+        reports: D2ReportSchema[];
+        resources: D2DocumentSchema[];
+        shape: "NORMAL" | "DOUBLE_WIDTH" | "FULL_WIDTH";
+        text: string;
+        translations: D2Translation[];
+        type:
+            | "CHART"
+            | "EVENT_CHART"
+            | "MAP"
+            | "REPORT_TABLE"
+            | "EVENT_REPORT"
+            | "USERS"
+            | "REPORTS"
+            | "RESOURCES"
+            | "TEXT"
+            | "MESSAGES"
+            | "APP";
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        users: D2UserSchema[];
+        width: number;
+        x: number;
+        y: number;
+    };
+    fieldPresets: {
+        $all: Preset<D2DashboardItem, keyof D2DashboardItem>;
+        $identifiable: Preset<D2DashboardItem, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2DashboardItem, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2DashboardItem,
+            | "reports"
+            | "code"
+            | "reportTable"
+            | "lastUpdated"
+            | "translations"
+            | "appKey"
+            | "id"
+            | "text"
+            | "map"
+            | "height"
+            | "lastUpdatedBy"
+            | "shape"
+            | "created"
+            | "resources"
+            | "users"
+            | "eventReport"
+            | "eventChart"
+            | "width"
+            | "x"
+            | "messages"
+            | "y"
+            | "chart"
+        >;
+        $owner: Preset<
+            D2DashboardItem,
+            | "reports"
+            | "code"
+            | "reportTable"
+            | "lastUpdated"
+            | "translations"
+            | "appKey"
+            | "id"
+            | "text"
+            | "map"
+            | "height"
+            | "lastUpdatedBy"
+            | "shape"
+            | "created"
+            | "resources"
+            | "users"
+            | "eventReport"
+            | "eventChart"
+            | "width"
+            | "x"
+            | "messages"
+            | "y"
+            | "chart"
+        >;
+    };
+}
+
+export interface D2DataApprovalLevelSchema {
+    name: "D2DataApprovalLevel";
+    model: D2DataApprovalLevel;
     fields: {
         access: D2Access;
         attributeValues: D2AttributeValueSchema[];
-        categories: D2CategorySchema[];
-        categoryOptionCombos: D2CategoryOptionComboSchema[];
+        categoryOptionGroupSet: D2CategoryOptionGroupSetSchema;
         code: Id;
         created: string;
-        dataDimensionType: "DISAGGREGATION" | "ATTRIBUTE";
         displayName: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
         href: string;
         id: Id;
-        isDefault: boolean;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
+        level: number;
         name: string;
+        orgUnitLevel: number;
+        orgUnitLevelName: string;
         publicAccess: string;
-        skipTotal: boolean;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2CategoryCombo, keyof D2CategoryCombo>;
-        $identifiable: Preset<D2CategoryCombo, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2CategoryCombo, FieldPresets["nameable"]>;
+        $all: Preset<D2DataApprovalLevel, keyof D2DataApprovalLevel>;
+        $identifiable: Preset<D2DataApprovalLevel, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2DataApprovalLevel, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2CategoryCombo,
-            | "dataDimensionType"
+            D2DataApprovalLevel,
+            | "lastUpdatedBy"
+            | "categoryOptionGroupSet"
+            | "userGroupAccesses"
             | "code"
+            | "level"
+            | "created"
             | "publicAccess"
             | "lastUpdated"
             | "translations"
-            | "id"
-            | "categories"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "categoryOptionCombos"
             | "userAccesses"
             | "name"
-            | "skipTotal"
+            | "orgUnitLevel"
+            | "id"
             | "user"
         >;
         $owner: Preset<
-            D2CategoryCombo,
-            | "dataDimensionType"
+            D2DataApprovalLevel,
+            | "lastUpdatedBy"
+            | "categoryOptionGroupSet"
+            | "userGroupAccesses"
             | "code"
+            | "level"
+            | "created"
             | "publicAccess"
             | "lastUpdated"
             | "translations"
-            | "id"
-            | "categories"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
             | "userAccesses"
             | "name"
-            | "skipTotal"
+            | "orgUnitLevel"
+            | "id"
             | "user"
         >;
     };
 }
 
-export interface D2CategoryOptionComboSchema {
-    name: "D2CategoryOptionCombo";
-    model: D2CategoryOptionCombo;
+export interface D2DataApprovalWorkflowSchema {
+    name: "D2DataApprovalWorkflow";
+    model: D2DataApprovalWorkflow;
     fields: {
         access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
         attributeValues: D2AttributeValueSchema[];
         categoryCombo: D2CategoryComboSchema;
-        categoryOptions: D2CategoryOptionSchema[];
         code: Id;
         created: string;
-        description: string;
-        dimensionItem: string;
-        dimensionItemType:
-            | "DATA_ELEMENT"
-            | "DATA_ELEMENT_OPERAND"
-            | "INDICATOR"
-            | "REPORTING_RATE"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION"
-            | "OPTION_GROUP"
-            | "DATA_ELEMENT_GROUP"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY_OPTION_GROUP";
-        displayDescription: string;
-        displayFormName: string;
+        dataApprovalLevels: D2DataApprovalLevelSchema[];
+        dataSets: D2DataSetSchema[];
         displayName: string;
-        displayShortName: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
-        formName: string;
         href: string;
         id: Id;
-        ignoreApproval: boolean;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
-        legendSet: D2LegendSetSchema;
-        legendSets: D2LegendSetSchema[];
         name: string;
+        periodType: string;
         publicAccess: string;
-        shortName: string;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2CategoryOptionCombo, keyof D2CategoryOptionCombo>;
-        $identifiable: Preset<D2CategoryOptionCombo, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2CategoryOptionCombo, FieldPresets["nameable"]>;
+        $all: Preset<D2DataApprovalWorkflow, keyof D2DataApprovalWorkflow>;
+        $identifiable: Preset<D2DataApprovalWorkflow, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2DataApprovalWorkflow, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2CategoryOptionCombo,
+            D2DataApprovalWorkflow,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
             | "code"
+            | "created"
+            | "publicAccess"
+            | "dataApprovalLevels"
             | "lastUpdated"
-            | "ignoreApproval"
+            | "periodType"
             | "categoryCombo"
             | "translations"
-            | "id"
-            | "categoryOptions"
-            | "lastUpdatedBy"
-            | "created"
-            | "attributeValues"
+            | "userAccesses"
             | "name"
+            | "dataSets"
+            | "id"
+            | "user"
         >;
         $owner: Preset<
-            D2CategoryOptionCombo,
+            D2DataApprovalWorkflow,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
             | "code"
+            | "created"
+            | "publicAccess"
+            | "dataApprovalLevels"
             | "lastUpdated"
-            | "ignoreApproval"
+            | "periodType"
             | "categoryCombo"
             | "translations"
-            | "id"
-            | "categoryOptions"
-            | "lastUpdatedBy"
-            | "created"
-            | "attributeValues"
+            | "userAccesses"
             | "name"
+            | "id"
+            | "user"
         >;
     };
 }
@@ -7280,149 +6630,30 @@ export interface D2DataElementGroupSetSchema {
     };
 }
 
-export interface D2IndicatorTypeSchema {
-    name: "D2IndicatorType";
-    model: D2IndicatorType;
+export interface D2DataElementGroupSetDimensionSchema {
+    name: "D2DataElementGroupSetDimension";
+    model: D2DataElementGroupSetDimension;
     fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        factor: number;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        number: boolean;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
+        dataElementGroupSet: D2DataElementGroupSetSchema;
+        dataElementGroups: D2DataElementGroupSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2IndicatorType, keyof D2IndicatorType>;
-        $identifiable: Preset<D2IndicatorType, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2IndicatorType, FieldPresets["nameable"]>;
+        $all: Preset<D2DataElementGroupSetDimension, keyof D2DataElementGroupSetDimension>;
+        $identifiable: Preset<D2DataElementGroupSetDimension, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2DataElementGroupSetDimension, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2IndicatorType,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "lastUpdated"
-            | "number"
-            | "translations"
-            | "name"
-            | "id"
-            | "factor"
+            D2DataElementGroupSetDimension,
+            "dataElementGroups" | "dataElementGroupSet"
         >;
-        $owner: Preset<
-            D2IndicatorType,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "lastUpdated"
-            | "number"
-            | "translations"
-            | "name"
-            | "id"
-            | "factor"
-        >;
+        $owner: Preset<D2DataElementGroupSetDimension, "dataElementGroups" | "dataElementGroupSet">;
     };
 }
 
-export interface D2AnalyticsTableHookSchema {
-    name: "D2AnalyticsTableHook";
-    model: D2AnalyticsTableHook;
+export interface D2DataElementOperandSchema {
+    name: "D2DataElementOperand";
+    model: D2DataElementOperand;
     fields: {
         access: D2Access;
-        analyticsTableType:
-            | "DATA_VALUE"
-            | "COMPLETENESS"
-            | "COMPLETENESS_TARGET"
-            | "ORG_UNIT_TARGET"
-            | "EVENT"
-            | "ENROLLMENT"
-            | "VALIDATION_RESULT";
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        phase: "RESOURCE_TABLE_POPULATED" | "ANALYTICS_TABLE_POPULATED";
-        publicAccess: string;
-        resourceTableType:
-            | "ORG_UNIT_STRUCTURE"
-            | "DATA_SET_ORG_UNIT_CATEGORY"
-            | "CATEGORY_OPTION_COMBO_NAME"
-            | "DATA_ELEMENT_GROUP_SET_STRUCTURE"
-            | "INDICATOR_GROUP_SET_STRUCTURE"
-            | "ORG_UNIT_GROUP_SET_STRUCTURE"
-            | "CATEGORY_STRUCTURE"
-            | "DATA_ELEMENT_STRUCTURE"
-            | "PERIOD_STRUCTURE"
-            | "DATE_PERIOD_STRUCTURE"
-            | "DATA_ELEMENT_CATEGORY_OPTION_COMBO"
-            | "DATA_APPROVAL_REMAP_LEVEL"
-            | "DATA_APPROVAL_MIN_LEVEL";
-        sql: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2AnalyticsTableHook, keyof D2AnalyticsTableHook>;
-        $identifiable: Preset<D2AnalyticsTableHook, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2AnalyticsTableHook, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2AnalyticsTableHook,
-            | "phase"
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "analyticsTableType"
-            | "sql"
-            | "lastUpdated"
-            | "name"
-            | "resourceTableType"
-            | "id"
-        >;
-        $owner: Preset<
-            D2AnalyticsTableHook,
-            | "phase"
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "analyticsTableType"
-            | "sql"
-            | "lastUpdated"
-            | "name"
-            | "resourceTableType"
-            | "id"
-        >;
-    };
-}
-
-export interface D2IndicatorSchema {
-    name: "D2Indicator";
-    model: D2Indicator;
-    fields: {
-        access: D2Access;
-        aggregateExportAttributeOptionCombo: string;
-        aggregateExportCategoryOptionCombo: string;
         aggregationType:
             | "SUM"
             | "AVERAGE"
@@ -7437,14 +6668,12 @@ export interface D2IndicatorSchema {
             | "NONE"
             | "CUSTOM"
             | "DEFAULT";
-        annualized: boolean;
+        attributeOptionCombo: D2CategoryOptionComboSchema;
         attributeValues: D2AttributeValueSchema[];
+        categoryOptionCombo: D2CategoryOptionComboSchema;
         code: Id;
         created: string;
-        dataSets: D2DataSetSchema[];
-        decimals: number;
-        denominator: string;
-        denominatorDescription: string;
+        dataElement: D2DataElementSchema;
         description: string;
         dimensionItem: string;
         dimensionItemType:
@@ -7462,11 +6691,9 @@ export interface D2IndicatorSchema {
             | "DATA_ELEMENT_GROUP"
             | "ORGANISATION_UNIT_GROUP"
             | "CATEGORY_OPTION_GROUP";
-        displayDenominatorDescription: string;
         displayDescription: string;
         displayFormName: string;
         displayName: string;
-        displayNumeratorDescription: string;
         displayShortName: string;
         externalAccess: boolean;
         favorite: boolean;
@@ -7474,223 +6701,24 @@ export interface D2IndicatorSchema {
         formName: string;
         href: string;
         id: Id;
-        indicatorGroups: D2IndicatorGroupSchema[];
-        indicatorType: D2IndicatorTypeSchema;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
         legendSet: D2LegendSetSchema;
         legendSets: D2LegendSetSchema[];
         name: string;
-        numerator: string;
-        numeratorDescription: string;
         publicAccess: string;
         shortName: string;
-        style: D2Style;
-        translations: D2Translation[];
-        url: string;
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Indicator, keyof D2Indicator>;
-        $identifiable: Preset<D2Indicator, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Indicator, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Indicator,
-            | "code"
-            | "publicAccess"
-            | "aggregateExportCategoryOptionCombo"
-            | "description"
-            | "lastUpdated"
-            | "denominatorDescription"
-            | "indicatorType"
-            | "translations"
-            | "formName"
-            | "id"
-            | "numeratorDescription"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "indicatorGroups"
-            | "url"
-            | "numerator"
-            | "denominator"
-            | "annualized"
-            | "userAccesses"
-            | "decimals"
-            | "name"
-            | "dataSets"
-            | "legendSets"
-            | "style"
-            | "shortName"
-            | "user"
-            | "aggregateExportAttributeOptionCombo"
-        >;
-        $owner: Preset<
-            D2Indicator,
-            | "code"
-            | "publicAccess"
-            | "aggregateExportCategoryOptionCombo"
-            | "description"
-            | "lastUpdated"
-            | "denominatorDescription"
-            | "indicatorType"
-            | "translations"
-            | "formName"
-            | "id"
-            | "numeratorDescription"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "url"
-            | "numerator"
-            | "denominator"
-            | "annualized"
-            | "userAccesses"
-            | "decimals"
-            | "name"
-            | "legendSets"
-            | "style"
-            | "shortName"
-            | "user"
-            | "aggregateExportAttributeOptionCombo"
-        >;
-    };
-}
-
-export interface D2IndicatorGroupSchema {
-    name: "D2IndicatorGroup";
-    model: D2IndicatorGroup;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        indicatorGroupSet: D2IndicatorGroupSetSchema;
-        indicators: D2IndicatorSchema[];
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2IndicatorGroup, keyof D2IndicatorGroup>;
-        $identifiable: Preset<D2IndicatorGroup, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2IndicatorGroup, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2IndicatorGroup,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "indicators"
-            | "indicatorGroupSet"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2IndicatorGroup,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "indicators"
-            | "indicatorGroupSet"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
-export interface D2IndicatorGroupSetSchema {
-    name: "D2IndicatorGroupSet";
-    model: D2IndicatorGroupSet;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        compulsory: boolean;
-        created: string;
-        description: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        indicatorGroups: D2IndicatorGroupSchema[];
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2IndicatorGroupSet, keyof D2IndicatorGroupSet>;
-        $identifiable: Preset<D2IndicatorGroupSet, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2IndicatorGroupSet, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2IndicatorGroupSet,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "description"
-            | "indicatorGroups"
-            | "lastUpdated"
-            | "compulsory"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2IndicatorGroupSet,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "description"
-            | "indicatorGroups"
-            | "lastUpdated"
-            | "compulsory"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
+        $all: Preset<D2DataElementOperand, keyof D2DataElementOperand>;
+        $identifiable: Preset<D2DataElementOperand, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2DataElementOperand, FieldPresets["nameable"]>;
+        $persisted: Preset<D2DataElementOperand, "categoryOptionCombo" | "dataElement">;
+        $owner: Preset<D2DataElementOperand, "categoryOptionCombo" | "dataElement">;
     };
 }
 
@@ -7750,6 +6778,19 @@ export interface D2DataEntryFormSchema {
             | "style"
             | "id"
         >;
+    };
+}
+
+export interface D2DataInputPeriodSchema {
+    name: "D2DataInputPeriod";
+    model: D2DataInputPeriod;
+    fields: { closingDate: string; openingDate: string; period: any };
+    fieldPresets: {
+        $all: Preset<D2DataInputPeriod, keyof D2DataInputPeriod>;
+        $identifiable: Preset<D2DataInputPeriod, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2DataInputPeriod, FieldPresets["nameable"]>;
+        $persisted: Preset<D2DataInputPeriod, "period" | "closingDate" | "openingDate">;
+        $owner: Preset<D2DataInputPeriod, "period" | "closingDate" | "openingDate">;
     };
 }
 
@@ -7939,6 +6980,23 @@ export interface D2DataSetSchema {
     };
 }
 
+export interface D2DataSetElementSchema {
+    name: "D2DataSetElement";
+    model: D2DataSetElement;
+    fields: {
+        categoryCombo: D2CategoryComboSchema;
+        dataElement: D2DataElementSchema;
+        dataSet: D2DataSetSchema;
+    };
+    fieldPresets: {
+        $all: Preset<D2DataSetElement, keyof D2DataSetElement>;
+        $identifiable: Preset<D2DataSetElement, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2DataSetElement, FieldPresets["nameable"]>;
+        $persisted: Preset<D2DataSetElement, "dataElement" | "categoryCombo" | "dataSet">;
+        $owner: Preset<D2DataSetElement, "dataElement" | "categoryCombo" | "dataSet">;
+    };
+}
+
 export interface D2DataSetNotificationTemplateSchema {
     name: "D2DataSetNotificationTemplate";
     model: D2DataSetNotificationTemplate;
@@ -8020,368 +7078,18 @@ export interface D2DataSetNotificationTemplateSchema {
     };
 }
 
-export interface D2SectionSchema {
-    name: "D2Section";
-    model: D2Section;
+export interface D2DocumentSchema {
+    name: "D2Document";
+    model: D2Document;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        categoryCombos: D2CategoryComboSchema[];
-        code: Id;
-        created: string;
-        dataElements: D2DataElementSchema[];
-        dataSet: D2DataSetSchema;
-        description: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        greyedFields: D2DataElementOperandSchema[];
-        href: string;
-        id: Id;
-        indicators: D2IndicatorSchema[];
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        showColumnTotals: boolean;
-        showRowTotals: boolean;
-        sortOrder: number;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Section, keyof D2Section>;
-        $identifiable: Preset<D2Section, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Section, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Section,
-            | "code"
-            | "greyedFields"
-            | "description"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "dataSet"
-            | "dataElements"
-            | "showColumnTotals"
-            | "lastUpdatedBy"
-            | "created"
-            | "attributeValues"
-            | "indicators"
-            | "sortOrder"
-            | "name"
-            | "showRowTotals"
-        >;
-        $owner: Preset<
-            D2Section,
-            | "code"
-            | "greyedFields"
-            | "description"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "dataSet"
-            | "dataElements"
-            | "showColumnTotals"
-            | "lastUpdatedBy"
-            | "created"
-            | "attributeValues"
-            | "indicators"
-            | "sortOrder"
-            | "name"
-            | "showRowTotals"
-        >;
-    };
-}
-
-export interface D2DataApprovalLevelSchema {
-    name: "D2DataApprovalLevel";
-    model: D2DataApprovalLevel;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        categoryOptionGroupSet: D2CategoryOptionGroupSetSchema;
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        level: number;
-        name: string;
-        orgUnitLevel: number;
-        orgUnitLevelName: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2DataApprovalLevel, keyof D2DataApprovalLevel>;
-        $identifiable: Preset<D2DataApprovalLevel, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2DataApprovalLevel, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2DataApprovalLevel,
-            | "lastUpdatedBy"
-            | "categoryOptionGroupSet"
-            | "userGroupAccesses"
-            | "code"
-            | "level"
-            | "created"
-            | "publicAccess"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "orgUnitLevel"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2DataApprovalLevel,
-            | "lastUpdatedBy"
-            | "categoryOptionGroupSet"
-            | "userGroupAccesses"
-            | "code"
-            | "level"
-            | "created"
-            | "publicAccess"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "orgUnitLevel"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
-export interface D2DataApprovalWorkflowSchema {
-    name: "D2DataApprovalWorkflow";
-    model: D2DataApprovalWorkflow;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        categoryCombo: D2CategoryComboSchema;
-        code: Id;
-        created: string;
-        dataApprovalLevels: D2DataApprovalLevelSchema[];
-        dataSets: D2DataSetSchema[];
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        periodType: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2DataApprovalWorkflow, keyof D2DataApprovalWorkflow>;
-        $identifiable: Preset<D2DataApprovalWorkflow, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2DataApprovalWorkflow, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2DataApprovalWorkflow,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "dataApprovalLevels"
-            | "lastUpdated"
-            | "periodType"
-            | "categoryCombo"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "dataSets"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2DataApprovalWorkflow,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "dataApprovalLevels"
-            | "lastUpdated"
-            | "periodType"
-            | "categoryCombo"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
-export interface D2ValidationRuleSchema {
-    name: "D2ValidationRule";
-    model: D2ValidationRule;
-    fields: {
-        access: D2Access;
-        aggregateExportAttributeOptionCombo: string;
-        aggregateExportCategoryOptionCombo: string;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
+        attachment: boolean;
         attributeValues: D2AttributeValueSchema[];
         code: Id;
+        contentType: string;
         created: string;
-        description: string;
-        dimensionItem: string;
-        dimensionItemType:
-            | "DATA_ELEMENT"
-            | "DATA_ELEMENT_OPERAND"
-            | "INDICATOR"
-            | "REPORTING_RATE"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION"
-            | "OPTION_GROUP"
-            | "DATA_ELEMENT_GROUP"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY_OPTION_GROUP";
-        displayDescription: string;
-        displayFormName: string;
         displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        importance: "HIGH" | "MEDIUM" | "LOW";
-        instruction: string;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        leftSide: D2ExpressionSchema;
-        legendSet: D2LegendSetSchema;
-        legendSets: D2LegendSetSchema[];
-        name: string;
-        notificationTemplates: D2ValidationNotificationTemplateSchema[];
-        operator:
-            | "equal_to"
-            | "not_equal_to"
-            | "greater_than"
-            | "greater_than_or_equal_to"
-            | "less_than"
-            | "less_than_or_equal_to"
-            | "compulsory_pair"
-            | "exclusive_pair";
-        organisationUnitLevels: number[];
-        periodType: string;
-        publicAccess: string;
-        rightSide: D2ExpressionSchema;
-        shortName: string;
-        skipFormValidation: boolean;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        validationRuleGroups: D2ValidationRuleGroupSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ValidationRule, keyof D2ValidationRule>;
-        $identifiable: Preset<D2ValidationRule, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ValidationRule, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ValidationRule,
-            | "validationRuleGroups"
-            | "code"
-            | "importance"
-            | "publicAccess"
-            | "description"
-            | "operator"
-            | "organisationUnitLevels"
-            | "lastUpdated"
-            | "leftSide"
-            | "notificationTemplates"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "rightSide"
-            | "periodType"
-            | "instruction"
-            | "userAccesses"
-            | "name"
-            | "skipFormValidation"
-            | "user"
-        >;
-        $owner: Preset<
-            D2ValidationRule,
-            | "code"
-            | "importance"
-            | "publicAccess"
-            | "description"
-            | "operator"
-            | "organisationUnitLevels"
-            | "lastUpdated"
-            | "leftSide"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "rightSide"
-            | "periodType"
-            | "instruction"
-            | "userAccesses"
-            | "name"
-            | "skipFormValidation"
-            | "user"
-        >;
-    };
-}
-
-export interface D2ValidationRuleGroupSchema {
-    name: "D2ValidationRuleGroup";
-    model: D2ValidationRuleGroup;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        description: string;
-        displayName: string;
+        external: boolean;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
@@ -8392,1133 +7100,54 @@ export interface D2ValidationRuleGroupSchema {
         name: string;
         publicAccess: string;
         translations: D2Translation[];
+        url: string;
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
-        validationRules: D2ValidationRuleSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2ValidationRuleGroup, keyof D2ValidationRuleGroup>;
-        $identifiable: Preset<D2ValidationRuleGroup, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ValidationRuleGroup, FieldPresets["nameable"]>;
+        $all: Preset<D2Document, keyof D2Document>;
+        $identifiable: Preset<D2Document, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Document, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2ValidationRuleGroup,
+            D2Document,
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "code"
-            | "validationRules"
             | "created"
             | "publicAccess"
             | "attributeValues"
-            | "description"
+            | "url"
+            | "externalAccess"
             | "lastUpdated"
+            | "external"
+            | "attachment"
             | "translations"
             | "userAccesses"
             | "name"
             | "id"
             | "user"
+            | "contentType"
         >;
         $owner: Preset<
-            D2ValidationRuleGroup,
+            D2Document,
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "code"
-            | "validationRules"
             | "created"
             | "publicAccess"
             | "attributeValues"
-            | "description"
+            | "url"
+            | "externalAccess"
             | "lastUpdated"
+            | "external"
+            | "attachment"
             | "translations"
             | "userAccesses"
             | "name"
             | "id"
             | "user"
-        >;
-    };
-}
-
-export interface D2ValidationNotificationTemplateSchema {
-    name: "D2ValidationNotificationTemplate";
-    model: D2ValidationNotificationTemplate;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        messageTemplate: string;
-        name: string;
-        notifyParentOrganisationUnitOnly: boolean;
-        notifyUsersInHierarchyOnly: boolean;
-        publicAccess: string;
-        recipientUserGroups: D2UserGroupSchema[];
-        sendStrategy: "COLLECTIVE_SUMMARY" | "SINGLE_NOTIFICATION";
-        subjectTemplate: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        validationRules: D2ValidationRuleSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ValidationNotificationTemplate, keyof D2ValidationNotificationTemplate>;
-        $identifiable: Preset<D2ValidationNotificationTemplate, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ValidationNotificationTemplate, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ValidationNotificationTemplate,
-            | "code"
-            | "recipientUserGroups"
-            | "lastUpdated"
-            | "subjectTemplate"
-            | "id"
-            | "sendStrategy"
-            | "lastUpdatedBy"
-            | "validationRules"
-            | "created"
-            | "notifyUsersInHierarchyOnly"
-            | "name"
-            | "messageTemplate"
-        >;
-        $owner: Preset<
-            D2ValidationNotificationTemplate,
-            | "code"
-            | "recipientUserGroups"
-            | "lastUpdated"
-            | "subjectTemplate"
-            | "id"
-            | "sendStrategy"
-            | "lastUpdatedBy"
-            | "validationRules"
-            | "created"
-            | "notifyUsersInHierarchyOnly"
-            | "name"
-            | "messageTemplate"
-        >;
-    };
-}
-
-export interface D2TrackedEntityAttributeSchema {
-    name: "D2TrackedEntityAttribute";
-    model: D2TrackedEntityAttribute;
-    fields: {
-        access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        confidential: boolean;
-        created: string;
-        description: string;
-        dimensionItem: string;
-        dimensionItemType:
-            | "DATA_ELEMENT"
-            | "DATA_ELEMENT_OPERAND"
-            | "INDICATOR"
-            | "REPORTING_RATE"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION"
-            | "OPTION_GROUP"
-            | "DATA_ELEMENT_GROUP"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY_OPTION_GROUP";
-        displayDescription: string;
-        displayFormName: string;
-        displayInListNoProgram: boolean;
-        displayName: string;
-        displayOnVisitSchedule: boolean;
-        displayShortName: string;
-        expression: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        fieldMask: string;
-        formName: string;
-        generated: boolean;
-        href: string;
-        id: Id;
-        inherit: boolean;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        legendSet: D2LegendSetSchema;
-        legendSets: D2LegendSetSchema[];
-        name: string;
-        optionSet: D2OptionSetSchema;
-        optionSetValue: boolean;
-        orgunitScope: boolean;
-        pattern: string;
-        programScope: boolean;
-        publicAccess: string;
-        shortName: string;
-        skipSynchronization: boolean;
-        sortOrderInListNoProgram: number;
-        sortOrderInVisitSchedule: number;
-        style: D2Style;
-        translations: D2Translation[];
-        unique: boolean;
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        valueType:
-            | "TEXT"
-            | "LONG_TEXT"
-            | "LETTER"
-            | "PHONE_NUMBER"
-            | "EMAIL"
-            | "BOOLEAN"
-            | "TRUE_ONLY"
-            | "DATE"
-            | "DATETIME"
-            | "TIME"
-            | "NUMBER"
-            | "UNIT_INTERVAL"
-            | "PERCENTAGE"
-            | "INTEGER"
-            | "INTEGER_POSITIVE"
-            | "INTEGER_NEGATIVE"
-            | "INTEGER_ZERO_OR_POSITIVE"
-            | "TRACKER_ASSOCIATE"
-            | "USERNAME"
-            | "COORDINATE"
-            | "ORGANISATION_UNIT"
-            | "AGE"
-            | "URL"
-            | "FILE_RESOURCE"
-            | "IMAGE";
-    };
-    fieldPresets: {
-        $all: Preset<D2TrackedEntityAttribute, keyof D2TrackedEntityAttribute>;
-        $identifiable: Preset<D2TrackedEntityAttribute, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2TrackedEntityAttribute, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2TrackedEntityAttribute,
-            | "programScope"
-            | "publicAccess"
-            | "lastUpdated"
-            | "generated"
-            | "translations"
-            | "valueType"
-            | "id"
-            | "confidential"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "unique"
-            | "userAccesses"
-            | "name"
-            | "legendSets"
-            | "style"
-            | "shortName"
-            | "aggregationType"
-            | "code"
-            | "displayInListNoProgram"
-            | "pattern"
-            | "description"
-            | "skipSynchronization"
-            | "sortOrderInListNoProgram"
-            | "optionSet"
-            | "displayOnVisitSchedule"
-            | "formName"
-            | "sortOrderInVisitSchedule"
-            | "orgunitScope"
-            | "fieldMask"
-            | "expression"
-            | "inherit"
-            | "user"
-        >;
-        $owner: Preset<
-            D2TrackedEntityAttribute,
-            | "programScope"
-            | "publicAccess"
-            | "lastUpdated"
-            | "generated"
-            | "translations"
-            | "valueType"
-            | "id"
-            | "confidential"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "unique"
-            | "userAccesses"
-            | "name"
-            | "legendSets"
-            | "style"
-            | "shortName"
-            | "aggregationType"
-            | "code"
-            | "displayInListNoProgram"
-            | "pattern"
-            | "description"
-            | "skipSynchronization"
-            | "sortOrderInListNoProgram"
-            | "optionSet"
-            | "displayOnVisitSchedule"
-            | "formName"
-            | "sortOrderInVisitSchedule"
-            | "orgunitScope"
-            | "fieldMask"
-            | "expression"
-            | "inherit"
-            | "user"
-        >;
-    };
-}
-
-export interface D2TrackedEntityTypeSchema {
-    name: "D2TrackedEntityType";
-    model: D2TrackedEntityType;
-    fields: {
-        access: D2Access;
-        allowAuditLog: boolean;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        maxTeiCountToReturn: number;
-        minAttributesRequiredToSearch: number;
-        name: string;
-        publicAccess: string;
-        shortName: string;
-        style: D2Style;
-        trackedEntityTypeAttributes: D2TrackedEntityTypeAttributeSchema[];
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2TrackedEntityType, keyof D2TrackedEntityType>;
-        $identifiable: Preset<D2TrackedEntityType, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2TrackedEntityType, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2TrackedEntityType,
-            | "code"
-            | "publicAccess"
-            | "trackedEntityTypeAttributes"
-            | "description"
-            | "lastUpdated"
-            | "allowAuditLog"
-            | "translations"
-            | "formName"
-            | "featureType"
-            | "minAttributesRequiredToSearch"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "maxTeiCountToReturn"
-            | "userAccesses"
-            | "name"
-            | "style"
-            | "user"
-        >;
-        $owner: Preset<
-            D2TrackedEntityType,
-            | "code"
-            | "publicAccess"
-            | "trackedEntityTypeAttributes"
-            | "description"
-            | "lastUpdated"
-            | "allowAuditLog"
-            | "translations"
-            | "formName"
-            | "featureType"
-            | "minAttributesRequiredToSearch"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "maxTeiCountToReturn"
-            | "userAccesses"
-            | "name"
-            | "style"
-            | "user"
-        >;
-    };
-}
-
-export interface D2TrackedEntityTypeAttributeSchema {
-    name: "D2TrackedEntityTypeAttribute";
-    model: D2TrackedEntityTypeAttribute;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        displayInList: boolean;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        mandatory: boolean;
-        name: string;
-        publicAccess: string;
-        searchable: boolean;
-        trackedEntityAttribute: D2TrackedEntityAttributeSchema;
-        trackedEntityType: D2TrackedEntityTypeSchema;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        valueType:
-            | "TEXT"
-            | "LONG_TEXT"
-            | "LETTER"
-            | "PHONE_NUMBER"
-            | "EMAIL"
-            | "BOOLEAN"
-            | "TRUE_ONLY"
-            | "DATE"
-            | "DATETIME"
-            | "TIME"
-            | "NUMBER"
-            | "UNIT_INTERVAL"
-            | "PERCENTAGE"
-            | "INTEGER"
-            | "INTEGER_POSITIVE"
-            | "INTEGER_NEGATIVE"
-            | "INTEGER_ZERO_OR_POSITIVE"
-            | "TRACKER_ASSOCIATE"
-            | "USERNAME"
-            | "COORDINATE"
-            | "ORGANISATION_UNIT"
-            | "AGE"
-            | "URL"
-            | "FILE_RESOURCE"
-            | "IMAGE";
-    };
-    fieldPresets: {
-        $all: Preset<D2TrackedEntityTypeAttribute, keyof D2TrackedEntityTypeAttribute>;
-        $identifiable: Preset<D2TrackedEntityTypeAttribute, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2TrackedEntityTypeAttribute, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2TrackedEntityTypeAttribute,
-            | "code"
-            | "mandatory"
-            | "trackedEntityAttribute"
-            | "lastUpdated"
-            | "id"
-            | "lastUpdatedBy"
-            | "created"
-            | "searchable"
-            | "displayInList"
-            | "trackedEntityType"
-        >;
-        $owner: Preset<
-            D2TrackedEntityTypeAttribute,
-            | "code"
-            | "mandatory"
-            | "trackedEntityAttribute"
-            | "lastUpdated"
-            | "id"
-            | "lastUpdatedBy"
-            | "created"
-            | "searchable"
-            | "displayInList"
-            | "trackedEntityType"
-        >;
-    };
-}
-
-export interface D2ProgramTrackedEntityAttributeGroupSchema {
-    name: "D2ProgramTrackedEntityAttributeGroup";
-    model: D2ProgramTrackedEntityAttributeGroup;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        attributes: D2ProgramTrackedEntityAttributeSchema[];
-        code: Id;
-        created: string;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        shortName: string;
-        translations: D2Translation[];
-        uniqunessType: "NONE" | "STRICT" | "VALIDATION";
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<
-            D2ProgramTrackedEntityAttributeGroup,
-            keyof D2ProgramTrackedEntityAttributeGroup
-        >;
-        $identifiable: Preset<D2ProgramTrackedEntityAttributeGroup, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramTrackedEntityAttributeGroup, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramTrackedEntityAttributeGroup,
-            | "code"
-            | "uniqunessType"
-            | "description"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "created"
-            | "name"
-            | "attributes"
-            | "shortName"
-        >;
-        $owner: Preset<
-            D2ProgramTrackedEntityAttributeGroup,
-            | "code"
-            | "uniqunessType"
-            | "description"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "created"
-            | "name"
-            | "shortName"
-        >;
-    };
-}
-
-export interface D2ProgramNotificationTemplateSchema {
-    name: "D2ProgramNotificationTemplate";
-    model: D2ProgramNotificationTemplate;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        deliveryChannels: never[];
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        messageTemplate: string;
-        name: string;
-        notificationRecipient:
-            | "TRACKED_ENTITY_INSTANCE"
-            | "ORGANISATION_UNIT_CONTACT"
-            | "USERS_AT_ORGANISATION_UNIT"
-            | "USER_GROUP"
-            | "PROGRAM_ATTRIBUTE"
-            | "DATA_ELEMENT";
-        notificationTrigger:
-            | "ENROLLMENT"
-            | "COMPLETION"
-            | "PROGRAM_RULE"
-            | "SCHEDULED_DAYS_DUE_DATE"
-            | "SCHEDULED_DAYS_INCIDENT_DATE"
-            | "SCHEDULED_DAYS_ENROLLMENT_DATE";
-        notifyParentOrganisationUnitOnly: boolean;
-        notifyUsersInHierarchyOnly: boolean;
-        publicAccess: string;
-        recipientDataElement: D2DataElementSchema;
-        recipientProgramAttribute: D2TrackedEntityAttributeSchema;
-        recipientUserGroup: D2UserGroupSchema;
-        relativeScheduledDays: number;
-        subjectTemplate: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramNotificationTemplate, keyof D2ProgramNotificationTemplate>;
-        $identifiable: Preset<D2ProgramNotificationTemplate, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramNotificationTemplate, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramNotificationTemplate,
-            | "code"
-            | "notificationTrigger"
-            | "lastUpdated"
-            | "relativeScheduledDays"
-            | "id"
-            | "subjectTemplate"
-            | "lastUpdatedBy"
-            | "deliveryChannels"
-            | "recipientDataElement"
-            | "created"
-            | "notifyUsersInHierarchyOnly"
-            | "notificationRecipient"
-            | "recipientProgramAttribute"
-            | "notifyParentOrganisationUnitOnly"
-            | "name"
-            | "recipientUserGroup"
-            | "messageTemplate"
-        >;
-        $owner: Preset<
-            D2ProgramNotificationTemplate,
-            | "code"
-            | "notificationTrigger"
-            | "lastUpdated"
-            | "relativeScheduledDays"
-            | "id"
-            | "subjectTemplate"
-            | "lastUpdatedBy"
-            | "deliveryChannels"
-            | "recipientDataElement"
-            | "created"
-            | "notifyUsersInHierarchyOnly"
-            | "notificationRecipient"
-            | "recipientProgramAttribute"
-            | "notifyParentOrganisationUnitOnly"
-            | "name"
-            | "recipientUserGroup"
-            | "messageTemplate"
-        >;
-    };
-}
-
-export interface D2ProgramStageSectionSchema {
-    name: "D2ProgramStageSection";
-    model: D2ProgramStageSection;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        dataElements: D2DataElementSchema[];
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        programIndicators: D2ProgramIndicatorSchema[];
-        programStage: D2ProgramStageSchema;
-        publicAccess: string;
-        renderType: any;
-        shortName: string;
-        sortOrder: number;
-        style: D2Style;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramStageSection, keyof D2ProgramStageSection>;
-        $identifiable: Preset<D2ProgramStageSection, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramStageSection, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramStageSection,
-            | "code"
-            | "description"
-            | "programIndicators"
-            | "lastUpdated"
-            | "translations"
-            | "formName"
-            | "id"
-            | "renderType"
-            | "dataElements"
-            | "lastUpdatedBy"
-            | "programStage"
-            | "created"
-            | "sortOrder"
-            | "name"
-            | "style"
-        >;
-        $owner: Preset<
-            D2ProgramStageSection,
-            | "code"
-            | "description"
-            | "programIndicators"
-            | "lastUpdated"
-            | "translations"
-            | "formName"
-            | "id"
-            | "renderType"
-            | "dataElements"
-            | "lastUpdatedBy"
-            | "programStage"
-            | "created"
-            | "sortOrder"
-            | "name"
-            | "style"
-        >;
-    };
-}
-
-export interface D2SMSCommandSchema {
-    name: "D2SMSCommand";
-    model: D2SMSCommand;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        codeValueSeparator: string;
-        completenessMethod: "ALL_DATAVALUE" | "AT_LEAST_ONE_DATAVALUE" | "DO_NOT_MARK_COMPLETE";
-        created: string;
-        currentPeriodUsedForReporting: boolean;
-        dataset: D2DataSetSchema;
-        defaultMessage: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        moreThanOneOrgUnitMessage: string;
-        name: string;
-        noUserMessage: string;
-        parserType:
-            | "KEY_VALUE_PARSER"
-            | "J2ME_PARSER"
-            | "ALERT_PARSER"
-            | "UNREGISTERED_PARSER"
-            | "TRACKED_ENTITY_REGISTRATION_PARSER"
-            | "PROGRAM_STAGE_DATAENTRY_PARSER"
-            | "EVENT_REGISTRATION_PARSER";
-        program: D2ProgramSchema;
-        programStage: D2ProgramStageSchema;
-        publicAccess: string;
-        receivedMessage: string;
-        separator: string;
-        smsCodes: any[];
-        specialCharacters: any[];
-        successMessage: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroup: D2UserGroupSchema;
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        wrongFormatMessage: string;
-    };
-    fieldPresets: {
-        $all: Preset<D2SMSCommand, keyof D2SMSCommand>;
-        $identifiable: Preset<D2SMSCommand, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2SMSCommand, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2SMSCommand,
-            | "moreThanOneOrgUnitMessage"
-            | "smsCodes"
-            | "specialCharacters"
-            | "currentPeriodUsedForReporting"
-            | "program"
-            | "noUserMessage"
-            | "lastUpdated"
-            | "receivedMessage"
-            | "defaultMessage"
-            | "id"
-            | "userGroup"
-            | "programStage"
-            | "completenessMethod"
-            | "created"
-            | "wrongFormatMessage"
-            | "separator"
-            | "successMessage"
-            | "codeValueSeparator"
-            | "parserType"
-            | "name"
-            | "dataset"
-        >;
-        $owner: Preset<
-            D2SMSCommand,
-            | "moreThanOneOrgUnitMessage"
-            | "smsCodes"
-            | "specialCharacters"
-            | "currentPeriodUsedForReporting"
-            | "program"
-            | "noUserMessage"
-            | "lastUpdated"
-            | "receivedMessage"
-            | "defaultMessage"
-            | "id"
-            | "userGroup"
-            | "programStage"
-            | "completenessMethod"
-            | "created"
-            | "wrongFormatMessage"
-            | "separator"
-            | "successMessage"
-            | "codeValueSeparator"
-            | "parserType"
-            | "name"
-            | "dataset"
-        >;
-    };
-}
-
-export interface D2ProgramStageSchema {
-    name: "D2ProgramStage";
-    model: D2ProgramStage;
-    fields: {
-        access: D2Access;
-        allowGenerateNextVisit: boolean;
-        attributeValues: D2AttributeValueSchema[];
-        autoGenerateEvent: boolean;
-        blockEntryForm: boolean;
-        code: Id;
-        created: string;
-        dataEntryForm: D2DataEntryFormSchema;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayGenerateEventBox: boolean;
-        displayName: string;
-        displayShortName: string;
-        dueDateLabel: string;
-        enableUserAssignment: boolean;
-        executionDateLabel: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
-        formName: string;
-        formType: "DEFAULT" | "CUSTOM" | "SECTION" | "SECTION_MULTIORG";
-        generatedByEnrollmentDate: boolean;
-        hideDueDate: boolean;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        minDaysFromStart: number;
-        name: string;
-        notificationTemplates: D2ProgramNotificationTemplateSchema[];
-        openAfterEnrollment: boolean;
-        periodType: string;
-        preGenerateUID: boolean;
-        program: D2ProgramSchema;
-        programStageDataElements: D2ProgramStageDataElementSchema[];
-        programStageSections: D2ProgramStageSectionSchema[];
-        publicAccess: string;
-        remindCompleted: boolean;
-        repeatable: boolean;
-        reportDateToUse: string;
-        shortName: string;
-        sortOrder: number;
-        standardInterval: number;
-        style: D2Style;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        validationStrategy: "ON_COMPLETE" | "ON_UPDATE_AND_INSERT";
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramStage, keyof D2ProgramStage>;
-        $identifiable: Preset<D2ProgramStage, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramStage, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramStage,
-            | "dataEntryForm"
-            | "allowGenerateNextVisit"
-            | "publicAccess"
-            | "reportDateToUse"
-            | "program"
-            | "lastUpdated"
-            | "programStageDataElements"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "generatedByEnrollmentDate"
-            | "created"
-            | "attributeValues"
-            | "sortOrder"
-            | "userAccesses"
-            | "name"
-            | "hideDueDate"
-            | "enableUserAssignment"
-            | "style"
-            | "minDaysFromStart"
-            | "standardInterval"
-            | "dueDateLabel"
-            | "executionDateLabel"
-            | "code"
-            | "preGenerateUID"
-            | "description"
-            | "notificationTemplates"
-            | "openAfterEnrollment"
-            | "repeatable"
-            | "formName"
-            | "featureType"
-            | "remindCompleted"
-            | "displayGenerateEventBox"
-            | "validationStrategy"
-            | "autoGenerateEvent"
-            | "periodType"
-            | "blockEntryForm"
-            | "user"
-            | "programStageSections"
-        >;
-        $owner: Preset<
-            D2ProgramStage,
-            | "dataEntryForm"
-            | "allowGenerateNextVisit"
-            | "publicAccess"
-            | "reportDateToUse"
-            | "program"
-            | "lastUpdated"
-            | "programStageDataElements"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "generatedByEnrollmentDate"
-            | "created"
-            | "attributeValues"
-            | "sortOrder"
-            | "userAccesses"
-            | "name"
-            | "hideDueDate"
-            | "enableUserAssignment"
-            | "style"
-            | "minDaysFromStart"
-            | "standardInterval"
-            | "dueDateLabel"
-            | "executionDateLabel"
-            | "code"
-            | "preGenerateUID"
-            | "description"
-            | "notificationTemplates"
-            | "openAfterEnrollment"
-            | "repeatable"
-            | "formName"
-            | "featureType"
-            | "remindCompleted"
-            | "displayGenerateEventBox"
-            | "validationStrategy"
-            | "autoGenerateEvent"
-            | "periodType"
-            | "blockEntryForm"
-            | "user"
-            | "programStageSections"
-        >;
-    };
-}
-
-export interface D2ProgramSchema {
-    name: "D2Program";
-    model: D2Program;
-    fields: {
-        access: D2Access;
-        accessLevel: "OPEN" | "AUDITED" | "PROTECTED" | "CLOSED";
-        attributeValues: D2AttributeValueSchema[];
-        categoryCombo: D2CategoryComboSchema;
-        code: Id;
-        completeEventsExpiryDays: number;
-        created: string;
-        dataEntryForm: D2DataEntryFormSchema;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayFrontPageList: boolean;
-        displayIncidentDate: boolean;
-        displayName: string;
-        displayShortName: string;
-        enrollmentDateLabel: string;
-        expiryDays: number;
-        expiryPeriodType: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
-        formName: string;
-        href: string;
-        id: Id;
-        ignoreOverdueEvents: boolean;
-        incidentDateLabel: string;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        maxTeiCountToReturn: number;
-        minAttributesRequiredToSearch: number;
-        name: string;
-        notificationTemplates: D2ProgramNotificationTemplateSchema[];
-        onlyEnrollOnce: boolean;
-        organisationUnits: D2OrganisationUnitSchema[];
-        programIndicators: D2ProgramIndicatorSchema[];
-        programRuleVariables: D2ProgramRuleVariableSchema[];
-        programSections: D2ProgramSectionSchema[];
-        programStages: D2ProgramStageSchema[];
-        programTrackedEntityAttributes: D2ProgramTrackedEntityAttributeSchema[];
-        programType: "WITH_REGISTRATION" | "WITHOUT_REGISTRATION";
-        publicAccess: string;
-        registration: boolean;
-        relatedProgram: D2ProgramSchema;
-        selectEnrollmentDatesInFuture: boolean;
-        selectIncidentDatesInFuture: boolean;
-        shortName: string;
-        skipOffline: boolean;
-        style: D2Style;
-        trackedEntityType: D2TrackedEntityTypeSchema;
-        translations: D2Translation[];
-        useFirstStageDuringRegistration: boolean;
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        userRoles: D2UserAuthorityGroupSchema[];
-        version: number;
-        withoutRegistration: boolean;
-    };
-    fieldPresets: {
-        $all: Preset<D2Program, keyof D2Program>;
-        $identifiable: Preset<D2Program, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Program, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Program,
-            | "dataEntryForm"
-            | "publicAccess"
-            | "ignoreOverdueEvents"
-            | "skipOffline"
-            | "programIndicators"
-            | "lastUpdated"
-            | "categoryCombo"
-            | "translations"
-            | "id"
-            | "enrollmentDateLabel"
-            | "lastUpdatedBy"
-            | "onlyEnrollOnce"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "version"
-            | "maxTeiCountToReturn"
-            | "selectIncidentDatesInFuture"
-            | "incidentDateLabel"
-            | "userRoles"
-            | "expiryPeriodType"
-            | "userAccesses"
-            | "name"
-            | "selectEnrollmentDatesInFuture"
-            | "style"
-            | "shortName"
-            | "useFirstStageDuringRegistration"
-            | "code"
-            | "programRuleVariables"
-            | "programTrackedEntityAttributes"
-            | "completeEventsExpiryDays"
-            | "description"
-            | "relatedProgram"
-            | "notificationTemplates"
-            | "formName"
-            | "featureType"
-            | "minAttributesRequiredToSearch"
-            | "displayFrontPageList"
-            | "organisationUnits"
-            | "programType"
-            | "accessLevel"
-            | "programSections"
-            | "programStages"
-            | "trackedEntityType"
-            | "displayIncidentDate"
-            | "expiryDays"
-            | "user"
-        >;
-        $owner: Preset<
-            D2Program,
-            | "dataEntryForm"
-            | "publicAccess"
-            | "ignoreOverdueEvents"
-            | "skipOffline"
-            | "lastUpdated"
-            | "categoryCombo"
-            | "translations"
-            | "id"
-            | "enrollmentDateLabel"
-            | "lastUpdatedBy"
-            | "onlyEnrollOnce"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "version"
-            | "maxTeiCountToReturn"
-            | "selectIncidentDatesInFuture"
-            | "incidentDateLabel"
-            | "expiryPeriodType"
-            | "userAccesses"
-            | "name"
-            | "selectEnrollmentDatesInFuture"
-            | "style"
-            | "shortName"
-            | "useFirstStageDuringRegistration"
-            | "code"
-            | "programTrackedEntityAttributes"
-            | "completeEventsExpiryDays"
-            | "description"
-            | "relatedProgram"
-            | "notificationTemplates"
-            | "formName"
-            | "featureType"
-            | "minAttributesRequiredToSearch"
-            | "displayFrontPageList"
-            | "organisationUnits"
-            | "programType"
-            | "accessLevel"
-            | "programSections"
-            | "programStages"
-            | "trackedEntityType"
-            | "displayIncidentDate"
-            | "expiryDays"
-            | "user"
+            | "contentType"
         >;
     };
 }
@@ -10049,84 +7678,230 @@ export interface D2EventReportSchema {
     };
 }
 
-export interface D2ProgramSectionSchema {
-    name: "D2ProgramSection";
-    model: D2ProgramSection;
+export interface D2ExpressionSchema {
+    name: "D2Expression";
+    model: D2Expression;
+    fields: {
+        description: string;
+        expression: string;
+        missingValueStrategy:
+            | "SKIP_IF_ANY_VALUE_MISSING"
+            | "SKIP_IF_ALL_VALUES_MISSING"
+            | "NEVER_SKIP";
+        slidingWindow: boolean;
+    };
+    fieldPresets: {
+        $all: Preset<D2Expression, keyof D2Expression>;
+        $identifiable: Preset<D2Expression, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Expression, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Expression,
+            "description" | "expression" | "missingValueStrategy" | "slidingWindow"
+        >;
+        $owner: Preset<
+            D2Expression,
+            "description" | "expression" | "missingValueStrategy" | "slidingWindow"
+        >;
+    };
+}
+
+export interface D2ExternalFileResourceSchema {
+    name: "D2ExternalFileResource";
+    model: D2ExternalFileResource;
     fields: {
         access: D2Access;
         attributeValues: D2AttributeValueSchema[];
         code: Id;
         created: string;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
         displayName: string;
-        displayShortName: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
-        formName: string;
         href: string;
         id: Id;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
         name: string;
-        program: D2ProgramSchema;
-        programTrackedEntityAttribute: D2TrackedEntityAttributeSchema[];
         publicAccess: string;
-        renderType: any;
-        shortName: string;
-        sortOrder: number;
-        style: D2Style;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2ProgramSection, keyof D2ProgramSection>;
-        $identifiable: Preset<D2ProgramSection, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramSection, FieldPresets["nameable"]>;
+        $all: Preset<D2ExternalFileResource, keyof D2ExternalFileResource>;
+        $identifiable: Preset<D2ExternalFileResource, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ExternalFileResource, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2ProgramSection,
-            | "code"
-            | "description"
-            | "program"
-            | "programTrackedEntityAttribute"
-            | "lastUpdated"
-            | "translations"
-            | "formName"
-            | "id"
-            | "renderType"
-            | "lastUpdatedBy"
-            | "created"
-            | "sortOrder"
-            | "name"
-            | "style"
+            D2ExternalFileResource,
+            "lastUpdatedBy" | "code" | "created" | "lastUpdated" | "id"
         >;
         $owner: Preset<
-            D2ProgramSection,
-            | "code"
-            | "description"
-            | "program"
-            | "programTrackedEntityAttribute"
-            | "lastUpdated"
-            | "translations"
-            | "formName"
-            | "id"
-            | "renderType"
-            | "lastUpdatedBy"
-            | "created"
-            | "sortOrder"
-            | "name"
-            | "style"
+            D2ExternalFileResource,
+            "lastUpdatedBy" | "code" | "created" | "lastUpdated" | "id"
         >;
     };
 }
 
-export interface D2ProgramIndicatorSchema {
-    name: "D2ProgramIndicator";
-    model: D2ProgramIndicator;
+export interface D2ExternalMapLayerSchema {
+    name: "D2ExternalMapLayer";
+    model: D2ExternalMapLayer;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        attribution: string;
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        imageFormat: "PNG" | "JPG";
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        layers: string;
+        legendSet: D2LegendSetSchema;
+        legendSetUrl: string;
+        mapLayerPosition: "BASEMAP" | "OVERLAY";
+        mapService: "WMS" | "TMS" | "XYZ";
+        name: string;
+        publicAccess: string;
+        translations: D2Translation[];
+        url: string;
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ExternalMapLayer, keyof D2ExternalMapLayer>;
+        $identifiable: Preset<D2ExternalMapLayer, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ExternalMapLayer, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ExternalMapLayer,
+            | "imageFormat"
+            | "code"
+            | "publicAccess"
+            | "legendSetUrl"
+            | "mapService"
+            | "lastUpdated"
+            | "layers"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "mapLayerPosition"
+            | "url"
+            | "userAccesses"
+            | "name"
+            | "legendSet"
+            | "attribution"
+            | "user"
+        >;
+        $owner: Preset<
+            D2ExternalMapLayer,
+            | "imageFormat"
+            | "code"
+            | "publicAccess"
+            | "legendSetUrl"
+            | "mapService"
+            | "lastUpdated"
+            | "layers"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "mapLayerPosition"
+            | "url"
+            | "userAccesses"
+            | "name"
+            | "legendSet"
+            | "attribution"
+            | "user"
+        >;
+    };
+}
+
+export interface D2FileResourceSchema {
+    name: "D2FileResource";
+    model: D2FileResource;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        contentLength: string;
+        contentMd5: string;
+        contentType: string;
+        created: string;
+        displayName: string;
+        domain: "DATA_VALUE" | "PUSH_ANALYSIS" | "DOCUMENT" | "MESSAGE_ATTACHMENT" | "USER_AVATAR";
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        storageStatus: "NONE" | "PENDING" | "FAILED" | "STORED";
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2FileResource, keyof D2FileResource>;
+        $identifiable: Preset<D2FileResource, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2FileResource, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2FileResource,
+            | "contentMd5"
+            | "code"
+            | "lastUpdated"
+            | "id"
+            | "contentType"
+            | "lastUpdatedBy"
+            | "created"
+            | "domain"
+            | "name"
+            | "contentLength"
+            | "user"
+        >;
+        $owner: Preset<
+            D2FileResource,
+            | "contentMd5"
+            | "code"
+            | "lastUpdated"
+            | "id"
+            | "contentType"
+            | "lastUpdatedBy"
+            | "created"
+            | "domain"
+            | "name"
+            | "contentLength"
+            | "user"
+        >;
+    };
+}
+
+export interface D2IconSchema {
+    name: "D2Icon";
+    model: D2Icon;
+    fields: {};
+    fieldPresets: {
+        $all: Preset<D2Icon, keyof D2Icon>;
+        $identifiable: Preset<D2Icon, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Icon, FieldPresets["nameable"]>;
+        $persisted: Preset<D2Icon, never>;
+        $owner: Preset<D2Icon, never>;
+    };
+}
+
+export interface D2IndicatorSchema {
+    name: "D2Indicator";
+    model: D2Indicator;
     fields: {
         access: D2Access;
         aggregateExportAttributeOptionCombo: string;
@@ -10145,12 +7920,14 @@ export interface D2ProgramIndicatorSchema {
             | "NONE"
             | "CUSTOM"
             | "DEFAULT";
-        analyticsPeriodBoundaries: D2AnalyticsPeriodBoundarySchema[];
-        analyticsType: "EVENT" | "ENROLLMENT";
+        annualized: boolean;
         attributeValues: D2AttributeValueSchema[];
         code: Id;
         created: string;
+        dataSets: D2DataSetSchema[];
         decimals: number;
+        denominator: string;
+        denominatorDescription: string;
         description: string;
         dimensionItem: string;
         dimensionItemType:
@@ -10168,63 +7945,66 @@ export interface D2ProgramIndicatorSchema {
             | "DATA_ELEMENT_GROUP"
             | "ORGANISATION_UNIT_GROUP"
             | "CATEGORY_OPTION_GROUP";
+        displayDenominatorDescription: string;
         displayDescription: string;
         displayFormName: string;
-        displayInForm: boolean;
         displayName: string;
+        displayNumeratorDescription: string;
         displayShortName: string;
-        expression: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
-        filter: string;
         formName: string;
         href: string;
         id: Id;
+        indicatorGroups: D2IndicatorGroupSchema[];
+        indicatorType: D2IndicatorTypeSchema;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
         legendSet: D2LegendSetSchema;
         legendSets: D2LegendSetSchema[];
         name: string;
-        program: D2ProgramSchema;
-        programIndicatorGroups: D2ProgramIndicatorGroupSchema[];
+        numerator: string;
+        numeratorDescription: string;
         publicAccess: string;
         shortName: string;
         style: D2Style;
         translations: D2Translation[];
+        url: string;
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2ProgramIndicator, keyof D2ProgramIndicator>;
-        $identifiable: Preset<D2ProgramIndicator, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramIndicator, FieldPresets["nameable"]>;
+        $all: Preset<D2Indicator, keyof D2Indicator>;
+        $identifiable: Preset<D2Indicator, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Indicator, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2ProgramIndicator,
-            | "aggregationType"
+            D2Indicator,
             | "code"
-            | "displayInForm"
             | "publicAccess"
             | "aggregateExportCategoryOptionCombo"
             | "description"
-            | "program"
             | "lastUpdated"
+            | "denominatorDescription"
+            | "indicatorType"
             | "translations"
             | "formName"
             | "id"
-            | "programIndicatorGroups"
-            | "analyticsPeriodBoundaries"
+            | "numeratorDescription"
             | "lastUpdatedBy"
             | "userGroupAccesses"
-            | "expression"
             | "created"
             | "attributeValues"
-            | "filter"
+            | "indicatorGroups"
+            | "url"
+            | "numerator"
+            | "denominator"
+            | "annualized"
             | "userAccesses"
             | "decimals"
             | "name"
-            | "analyticsType"
+            | "dataSets"
             | "legendSets"
             | "style"
             | "shortName"
@@ -10232,29 +8012,29 @@ export interface D2ProgramIndicatorSchema {
             | "aggregateExportAttributeOptionCombo"
         >;
         $owner: Preset<
-            D2ProgramIndicator,
-            | "aggregationType"
+            D2Indicator,
             | "code"
-            | "displayInForm"
             | "publicAccess"
             | "aggregateExportCategoryOptionCombo"
             | "description"
-            | "program"
             | "lastUpdated"
+            | "denominatorDescription"
+            | "indicatorType"
             | "translations"
             | "formName"
             | "id"
-            | "analyticsPeriodBoundaries"
+            | "numeratorDescription"
             | "lastUpdatedBy"
             | "userGroupAccesses"
-            | "expression"
             | "created"
             | "attributeValues"
-            | "filter"
+            | "url"
+            | "numerator"
+            | "denominator"
+            | "annualized"
             | "userAccesses"
             | "decimals"
             | "name"
-            | "analyticsType"
             | "legendSets"
             | "style"
             | "shortName"
@@ -10264,175 +8044,25 @@ export interface D2ProgramIndicatorSchema {
     };
 }
 
-export interface D2RelationshipTypeSchema {
-    name: "D2RelationshipType";
-    model: D2RelationshipType;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        bidirectional: boolean;
-        code: Id;
-        created: string;
-        description: string;
-        displayFromToName: string;
-        displayName: string;
-        displayToFromName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        fromConstraint: D2RelationshipConstraint;
-        fromToName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        toConstraint: D2RelationshipConstraint;
-        toFromName: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2RelationshipType, keyof D2RelationshipType>;
-        $identifiable: Preset<D2RelationshipType, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2RelationshipType, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2RelationshipType,
-            | "bidirectional"
-            | "code"
-            | "publicAccess"
-            | "description"
-            | "fromToName"
-            | "lastUpdated"
-            | "translations"
-            | "toConstraint"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "toFromName"
-            | "fromConstraint"
-            | "userAccesses"
-            | "name"
-            | "user"
-        >;
-        $owner: Preset<
-            D2RelationshipType,
-            | "bidirectional"
-            | "code"
-            | "publicAccess"
-            | "description"
-            | "fromToName"
-            | "lastUpdated"
-            | "translations"
-            | "toConstraint"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "toFromName"
-            | "fromConstraint"
-            | "userAccesses"
-            | "name"
-            | "user"
-        >;
-    };
-}
-
-export interface D2ProgramRuleVariableSchema {
-    name: "D2ProgramRuleVariable";
-    model: D2ProgramRuleVariable;
+export interface D2IndicatorGroupSchema {
+    name: "D2IndicatorGroup";
+    model: D2IndicatorGroup;
     fields: {
         access: D2Access;
         attributeValues: D2AttributeValueSchema[];
         code: Id;
         created: string;
-        dataElement: D2DataElementSchema;
         displayName: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
         href: string;
         id: Id;
+        indicatorGroupSet: D2IndicatorGroupSetSchema;
+        indicators: D2IndicatorSchema[];
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
         name: string;
-        program: D2ProgramSchema;
-        programRuleVariableSourceType:
-            | "DATAELEMENT_NEWEST_EVENT_PROGRAM_STAGE"
-            | "DATAELEMENT_NEWEST_EVENT_PROGRAM"
-            | "DATAELEMENT_CURRENT_EVENT"
-            | "DATAELEMENT_PREVIOUS_EVENT"
-            | "CALCULATED_VALUE"
-            | "TEI_ATTRIBUTE";
-        programStage: D2ProgramStageSchema;
-        publicAccess: string;
-        trackedEntityAttribute: D2TrackedEntityAttributeSchema;
-        translations: D2Translation[];
-        useCodeForOptionSet: boolean;
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramRuleVariable, keyof D2ProgramRuleVariable>;
-        $identifiable: Preset<D2ProgramRuleVariable, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramRuleVariable, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramRuleVariable,
-            | "code"
-            | "programRuleVariableSourceType"
-            | "program"
-            | "trackedEntityAttribute"
-            | "lastUpdated"
-            | "id"
-            | "lastUpdatedBy"
-            | "programStage"
-            | "created"
-            | "useCodeForOptionSet"
-            | "dataElement"
-            | "name"
-        >;
-        $owner: Preset<
-            D2ProgramRuleVariable,
-            | "code"
-            | "programRuleVariableSourceType"
-            | "program"
-            | "trackedEntityAttribute"
-            | "lastUpdated"
-            | "id"
-            | "lastUpdatedBy"
-            | "programStage"
-            | "created"
-            | "useCodeForOptionSet"
-            | "dataElement"
-            | "name"
-        >;
-    };
-}
-
-export interface D2ProgramIndicatorGroupSchema {
-    name: "D2ProgramIndicatorGroup";
-    model: D2ProgramIndicatorGroup;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        description: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        programIndicators: D2ProgramIndicatorSchema[];
         publicAccess: string;
         translations: D2Translation[];
         user: D2UserSchema;
@@ -10440,19 +8070,19 @@ export interface D2ProgramIndicatorGroupSchema {
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2ProgramIndicatorGroup, keyof D2ProgramIndicatorGroup>;
-        $identifiable: Preset<D2ProgramIndicatorGroup, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramIndicatorGroup, FieldPresets["nameable"]>;
+        $all: Preset<D2IndicatorGroup, keyof D2IndicatorGroup>;
+        $identifiable: Preset<D2IndicatorGroup, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2IndicatorGroup, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2ProgramIndicatorGroup,
+            D2IndicatorGroup,
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "code"
             | "created"
             | "publicAccess"
             | "attributeValues"
-            | "description"
-            | "programIndicators"
+            | "indicators"
+            | "indicatorGroupSet"
             | "lastUpdated"
             | "translations"
             | "userAccesses"
@@ -10461,15 +8091,15 @@ export interface D2ProgramIndicatorGroupSchema {
             | "user"
         >;
         $owner: Preset<
-            D2ProgramIndicatorGroup,
+            D2IndicatorGroup,
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "code"
             | "created"
             | "publicAccess"
             | "attributeValues"
-            | "description"
-            | "programIndicators"
+            | "indicators"
+            | "indicatorGroupSet"
             | "lastUpdated"
             | "translations"
             | "userAccesses"
@@ -10480,116 +8110,14 @@ export interface D2ProgramIndicatorGroupSchema {
     };
 }
 
-export interface D2ProgramRuleActionSchema {
-    name: "D2ProgramRuleAction";
-    model: D2ProgramRuleAction;
+export interface D2IndicatorGroupSetSchema {
+    name: "D2IndicatorGroupSet";
+    model: D2IndicatorGroupSet;
     fields: {
         access: D2Access;
         attributeValues: D2AttributeValueSchema[];
         code: Id;
-        content: string;
-        created: string;
-        data: string;
-        dataElement: D2DataElementSchema;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        location: string;
-        name: string;
-        option: D2OptionSchema;
-        optionGroup: D2OptionGroupSchema;
-        programIndicator: D2ProgramIndicatorSchema;
-        programRule: D2ProgramRuleSchema;
-        programRuleActionType:
-            | "DISPLAYTEXT"
-            | "DISPLAYKEYVALUEPAIR"
-            | "HIDEFIELD"
-            | "HIDESECTION"
-            | "HIDEPROGRAMSTAGE"
-            | "ASSIGN"
-            | "SHOWWARNING"
-            | "WARNINGONCOMPLETE"
-            | "SHOWERROR"
-            | "ERRORONCOMPLETE"
-            | "CREATEEVENT"
-            | "SETMANDATORYFIELD"
-            | "SENDMESSAGE"
-            | "SCHEDULEMESSAGE"
-            | "HIDEOPTION"
-            | "SHOWOPTIONGROUP"
-            | "HIDEOPTIONGROUP";
-        programStage: D2ProgramStageSchema;
-        programStageSection: D2ProgramStageSectionSchema;
-        publicAccess: string;
-        templateUid: string;
-        trackedEntityAttribute: D2TrackedEntityAttributeSchema;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramRuleAction, keyof D2ProgramRuleAction>;
-        $identifiable: Preset<D2ProgramRuleAction, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramRuleAction, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramRuleAction,
-            | "code"
-            | "data"
-            | "optionGroup"
-            | "templateUid"
-            | "content"
-            | "trackedEntityAttribute"
-            | "lastUpdated"
-            | "programIndicator"
-            | "id"
-            | "programRule"
-            | "programStageSection"
-            | "programRuleActionType"
-            | "lastUpdatedBy"
-            | "programStage"
-            | "created"
-            | "dataElement"
-            | "location"
-            | "option"
-        >;
-        $owner: Preset<
-            D2ProgramRuleAction,
-            | "code"
-            | "data"
-            | "optionGroup"
-            | "templateUid"
-            | "content"
-            | "trackedEntityAttribute"
-            | "lastUpdated"
-            | "programIndicator"
-            | "id"
-            | "programRule"
-            | "programStageSection"
-            | "programRuleActionType"
-            | "lastUpdatedBy"
-            | "programStage"
-            | "created"
-            | "dataElement"
-            | "location"
-            | "option"
-        >;
-    };
-}
-
-export interface D2ProgramRuleSchema {
-    name: "D2ProgramRule";
-    model: D2ProgramRule;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        condition: string;
+        compulsory: boolean;
         created: string;
         description: string;
         displayName: string;
@@ -10598,13 +8126,10 @@ export interface D2ProgramRuleSchema {
         favorites: string[];
         href: string;
         id: Id;
+        indicatorGroups: D2IndicatorGroupSchema[];
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
         name: string;
-        priority: number;
-        program: D2ProgramSchema;
-        programRuleActions: D2ProgramRuleActionSchema[];
-        programStage: D2ProgramStageSchema;
         publicAccess: string;
         translations: D2Translation[];
         user: D2UserSchema;
@@ -10612,40 +8137,630 @@ export interface D2ProgramRuleSchema {
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2ProgramRule, keyof D2ProgramRule>;
-        $identifiable: Preset<D2ProgramRule, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramRule, FieldPresets["nameable"]>;
+        $all: Preset<D2IndicatorGroupSet, keyof D2IndicatorGroupSet>;
+        $identifiable: Preset<D2IndicatorGroupSet, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2IndicatorGroupSet, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2ProgramRule,
-            | "code"
-            | "description"
-            | "program"
-            | "lastUpdated"
-            | "translations"
-            | "id"
+            D2IndicatorGroupSet,
             | "lastUpdatedBy"
-            | "programStage"
+            | "userGroupAccesses"
+            | "code"
             | "created"
-            | "priority"
-            | "condition"
-            | "programRuleActions"
+            | "publicAccess"
+            | "description"
+            | "indicatorGroups"
+            | "lastUpdated"
+            | "compulsory"
+            | "translations"
+            | "userAccesses"
             | "name"
+            | "id"
+            | "user"
         >;
         $owner: Preset<
-            D2ProgramRule,
+            D2IndicatorGroupSet,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
             | "code"
+            | "created"
+            | "publicAccess"
             | "description"
-            | "program"
+            | "indicatorGroups"
+            | "lastUpdated"
+            | "compulsory"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+        >;
+    };
+}
+
+export interface D2IndicatorTypeSchema {
+    name: "D2IndicatorType";
+    model: D2IndicatorType;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        factor: number;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        number: boolean;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2IndicatorType, keyof D2IndicatorType>;
+        $identifiable: Preset<D2IndicatorType, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2IndicatorType, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2IndicatorType,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "lastUpdated"
+            | "number"
+            | "translations"
+            | "name"
+            | "id"
+            | "factor"
+        >;
+        $owner: Preset<
+            D2IndicatorType,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "lastUpdated"
+            | "number"
+            | "translations"
+            | "name"
+            | "id"
+            | "factor"
+        >;
+    };
+}
+
+export interface D2InterpretationSchema {
+    name: "D2Interpretation";
+    model: D2Interpretation;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        chart: D2ChartSchema;
+        code: Id;
+        comments: D2InterpretationCommentSchema[];
+        created: string;
+        dataSet: D2DataSetSchema;
+        displayName: string;
+        eventChart: D2EventChartSchema;
+        eventReport: D2EventReportSchema;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        likedBy: D2UserSchema[];
+        likes: number;
+        map: D2MapSchema;
+        mentions: any[];
+        name: string;
+        organisationUnit: D2OrganisationUnitSchema;
+        period: any;
+        publicAccess: string;
+        reportTable: D2ReportTableSchema;
+        text: string;
+        translations: D2Translation[];
+        type: "REPORT_TABLE" | "CHART" | "MAP" | "EVENT_REPORT" | "EVENT_CHART" | "DATASET_REPORT";
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2Interpretation, keyof D2Interpretation>;
+        $identifiable: Preset<D2Interpretation, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Interpretation, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Interpretation,
+            | "likedBy"
+            | "organisationUnit"
+            | "publicAccess"
+            | "reportTable"
+            | "lastUpdated"
+            | "id"
+            | "text"
+            | "map"
+            | "dataSet"
+            | "likes"
+            | "period"
+            | "userGroupAccesses"
+            | "comments"
+            | "created"
+            | "eventReport"
+            | "userAccesses"
+            | "mentions"
+            | "eventChart"
+            | "user"
+            | "chart"
+        >;
+        $owner: Preset<
+            D2Interpretation,
+            | "likedBy"
+            | "organisationUnit"
+            | "publicAccess"
+            | "reportTable"
+            | "lastUpdated"
+            | "id"
+            | "text"
+            | "map"
+            | "dataSet"
+            | "likes"
+            | "period"
+            | "userGroupAccesses"
+            | "comments"
+            | "created"
+            | "eventReport"
+            | "userAccesses"
+            | "mentions"
+            | "eventChart"
+            | "user"
+            | "chart"
+        >;
+    };
+}
+
+export interface D2InterpretationCommentSchema {
+    name: "D2InterpretationComment";
+    model: D2InterpretationComment;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        mentions: any[];
+        name: string;
+        publicAccess: string;
+        text: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2InterpretationComment, keyof D2InterpretationComment>;
+        $identifiable: Preset<D2InterpretationComment, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2InterpretationComment, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2InterpretationComment,
+            "created" | "lastUpdated" | "mentions" | "text" | "id" | "user"
+        >;
+        $owner: Preset<
+            D2InterpretationComment,
+            "created" | "lastUpdated" | "mentions" | "text" | "id" | "user"
+        >;
+    };
+}
+
+export interface D2JobConfigurationSchema {
+    name: "D2JobConfiguration";
+    model: D2JobConfiguration;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        configurable: boolean;
+        continuousExecution: boolean;
+        created: string;
+        cronExpression: string;
+        displayName: string;
+        enabled: boolean;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        jobParameters: string;
+        jobStatus: "RUNNING" | "COMPLETED" | "STOPPED" | "SCHEDULED" | "DISABLED" | "FAILED";
+        jobType:
+            | "DATA_STATISTICS"
+            | "DATA_INTEGRITY"
+            | "RESOURCE_TABLE"
+            | "ANALYTICS_TABLE"
+            | "DATA_SYNC"
+            | "PROGRAM_DATA_SYNC"
+            | "FILE_RESOURCE_CLEANUP"
+            | "META_DATA_SYNC"
+            | "SMS_SEND"
+            | "SEND_SCHEDULED_MESSAGE"
+            | "PROGRAM_NOTIFICATIONS"
+            | "VALIDATION_RESULTS_NOTIFICATION"
+            | "CREDENTIALS_EXPIRY_ALERT"
+            | "MONITORING"
+            | "PUSH_ANALYSIS"
+            | "PREDICTOR"
+            | "DATA_SET_NOTIFICATION"
+            | "REMOVE_EXPIRED_RESERVED_VALUES"
+            | "MOCK"
+            | "DATAVALUE_IMPORT"
+            | "ANALYTICSTABLE_UPDATE"
+            | "METADATA_IMPORT"
+            | "GML_IMPORT"
+            | "DATAVALUE_IMPORT_INTERNAL"
+            | "EVENT_IMPORT"
+            | "ENROLLMENT_IMPORT"
+            | "TEI_IMPORT"
+            | "LEADER_ELECTION"
+            | "LEADER_RENEWAL"
+            | "COMPLETE_DATA_SET_REGISTRATION_IMPORT";
+        lastExecuted: string;
+        lastExecutedStatus:
+            | "RUNNING"
+            | "COMPLETED"
+            | "STOPPED"
+            | "SCHEDULED"
+            | "DISABLED"
+            | "FAILED";
+        lastRuntimeExecution: string;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        leaderOnlyJob: boolean;
+        name: string;
+        nextExecutionTime: string;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        userUid: string;
+    };
+    fieldPresets: {
+        $all: Preset<D2JobConfiguration, keyof D2JobConfiguration>;
+        $identifiable: Preset<D2JobConfiguration, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2JobConfiguration, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2JobConfiguration,
+            | "jobStatus"
+            | "code"
+            | "enabled"
+            | "leaderOnlyJob"
+            | "lastUpdated"
+            | "continuousExecution"
+            | "id"
+            | "jobType"
+            | "lastUpdatedBy"
+            | "nextExecutionTime"
+            | "created"
+            | "cronExpression"
+            | "lastRuntimeExecution"
+            | "lastExecutedStatus"
+            | "name"
+            | "jobParameters"
+            | "lastExecuted"
+        >;
+        $owner: Preset<
+            D2JobConfiguration,
+            | "jobStatus"
+            | "code"
+            | "enabled"
+            | "leaderOnlyJob"
+            | "lastUpdated"
+            | "continuousExecution"
+            | "id"
+            | "jobType"
+            | "lastUpdatedBy"
+            | "nextExecutionTime"
+            | "created"
+            | "cronExpression"
+            | "lastRuntimeExecution"
+            | "lastExecutedStatus"
+            | "name"
+            | "jobParameters"
+            | "lastExecuted"
+        >;
+    };
+}
+
+export interface D2KeyJsonValueSchema {
+    name: "D2KeyJsonValue";
+    model: D2KeyJsonValue;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        key: string;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        namespace: string;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        value: string;
+    };
+    fieldPresets: {
+        $all: Preset<D2KeyJsonValue, keyof D2KeyJsonValue>;
+        $identifiable: Preset<D2KeyJsonValue, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2KeyJsonValue, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2KeyJsonValue,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "lastUpdated"
+            | "userAccesses"
+            | "namespace"
+            | "id"
+            | "user"
+            | "key"
+        >;
+        $owner: Preset<
+            D2KeyJsonValue,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "lastUpdated"
+            | "userAccesses"
+            | "namespace"
+            | "id"
+            | "user"
+            | "key"
+        >;
+    };
+}
+
+export interface D2LegendSchema {
+    name: "D2Legend";
+    model: D2Legend;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        color: string;
+        created: string;
+        displayName: string;
+        endValue: number;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        image: string;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        startValue: number;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2Legend, keyof D2Legend>;
+        $identifiable: Preset<D2Legend, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Legend, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Legend,
+            | "lastUpdatedBy"
+            | "image"
+            | "code"
+            | "endValue"
+            | "color"
+            | "created"
             | "lastUpdated"
             | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "programStage"
-            | "created"
-            | "priority"
-            | "condition"
-            | "programRuleActions"
             | "name"
+            | "startValue"
+            | "id"
+        >;
+        $owner: Preset<
+            D2Legend,
+            | "lastUpdatedBy"
+            | "image"
+            | "code"
+            | "endValue"
+            | "color"
+            | "created"
+            | "lastUpdated"
+            | "translations"
+            | "name"
+            | "startValue"
+            | "id"
+        >;
+    };
+}
+
+export interface D2LegendSetSchema {
+    name: "D2LegendSet";
+    model: D2LegendSet;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legends: D2LegendSchema[];
+        name: string;
+        publicAccess: string;
+        symbolizer: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2LegendSet, keyof D2LegendSet>;
+        $identifiable: Preset<D2LegendSet, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2LegendSet, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2LegendSet,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "attributeValues"
+            | "symbolizer"
+            | "lastUpdated"
+            | "legends"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+        >;
+        $owner: Preset<
+            D2LegendSet,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "attributeValues"
+            | "symbolizer"
+            | "lastUpdated"
+            | "legends"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+        >;
+    };
+}
+
+export interface D2MapSchema {
+    name: "D2Map";
+    model: D2Map;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        basemap: string;
+        code: Id;
+        created: string;
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        interpretations: D2InterpretationSchema[];
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        latitude: number;
+        longitude: number;
+        mapViews: D2MapViewSchema[];
+        name: string;
+        publicAccess: string;
+        shortName: string;
+        subscribed: boolean;
+        subscribers: string[];
+        title: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        zoom: number;
+    };
+    fieldPresets: {
+        $all: Preset<D2Map, keyof D2Map>;
+        $identifiable: Preset<D2Map, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Map, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Map,
+            | "favorites"
+            | "code"
+            | "publicAccess"
+            | "basemap"
+            | "latitude"
+            | "description"
+            | "title"
+            | "externalAccess"
+            | "lastUpdated"
+            | "translations"
+            | "mapViews"
+            | "id"
+            | "interpretations"
+            | "longitude"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "subscribers"
+            | "created"
+            | "zoom"
+            | "userAccesses"
+            | "name"
+            | "user"
+        >;
+        $owner: Preset<
+            D2Map,
+            | "favorites"
+            | "code"
+            | "publicAccess"
+            | "basemap"
+            | "latitude"
+            | "description"
+            | "title"
+            | "externalAccess"
+            | "lastUpdated"
+            | "translations"
+            | "mapViews"
+            | "id"
+            | "longitude"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "subscribers"
+            | "created"
+            | "zoom"
+            | "userAccesses"
+            | "name"
+            | "user"
         >;
     };
 }
@@ -10893,89 +9008,301 @@ export interface D2MapViewSchema {
     };
 }
 
-export interface D2ExternalMapLayerSchema {
-    name: "D2ExternalMapLayer";
-    model: D2ExternalMapLayer;
+export interface D2MessageConversationSchema {
+    name: "D2MessageConversation";
+    model: D2MessageConversation;
     fields: {
         access: D2Access;
+        assignee: D2UserSchema;
         attributeValues: D2AttributeValueSchema[];
-        attribution: string;
         code: Id;
         created: string;
         displayName: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
+        followUp: boolean;
         href: string;
         id: Id;
-        imageFormat: "PNG" | "JPG";
+        lastMessage: string;
+        lastSender: D2UserSchema;
+        lastSenderFirstname: string;
+        lastSenderSurname: string;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
-        layers: string;
-        legendSet: D2LegendSetSchema;
-        legendSetUrl: string;
-        mapLayerPosition: "BASEMAP" | "OVERLAY";
-        mapService: "WMS" | "TMS" | "XYZ";
+        messageCount: number;
+        messageType: "PRIVATE" | "SYSTEM" | "VALIDATION_RESULT" | "TICKET";
+        messages: any[];
+        name: string;
+        priority: "NONE" | "LOW" | "MEDIUM" | "HIGH";
+        publicAccess: string;
+        read: boolean;
+        status: "NONE" | "OPEN" | "PENDING" | "INVALID" | "SOLVED";
+        subject: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userFirstname: string;
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        userMessages: any[];
+        userSurname: string;
+    };
+    fieldPresets: {
+        $all: Preset<D2MessageConversation, keyof D2MessageConversation>;
+        $identifiable: Preset<D2MessageConversation, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2MessageConversation, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2MessageConversation,
+            | "messageCount"
+            | "subject"
+            | "lastUpdated"
+            | "messageType"
+            | "userMessages"
+            | "id"
+            | "lastSender"
+            | "created"
+            | "lastMessage"
+            | "priority"
+            | "messages"
+            | "assignee"
+            | "user"
+            | "status"
+        >;
+        $owner: Preset<
+            D2MessageConversation,
+            | "messageCount"
+            | "subject"
+            | "lastUpdated"
+            | "messageType"
+            | "userMessages"
+            | "id"
+            | "lastSender"
+            | "created"
+            | "lastMessage"
+            | "priority"
+            | "messages"
+            | "assignee"
+            | "user"
+            | "status"
+        >;
+    };
+}
+
+export interface D2MetadataVersionSchema {
+    name: "D2MetadataVersion";
+    model: D2MetadataVersion;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        hashCode: string;
+        href: string;
+        id: Id;
+        importDate: string;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
         name: string;
         publicAccess: string;
         translations: D2Translation[];
-        url: string;
+        type: "BEST_EFFORT" | "ATOMIC";
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2ExternalMapLayer, keyof D2ExternalMapLayer>;
-        $identifiable: Preset<D2ExternalMapLayer, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ExternalMapLayer, FieldPresets["nameable"]>;
+        $all: Preset<D2MetadataVersion, keyof D2MetadataVersion>;
+        $identifiable: Preset<D2MetadataVersion, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2MetadataVersion, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2ExternalMapLayer,
-            | "imageFormat"
-            | "code"
-            | "publicAccess"
-            | "legendSetUrl"
-            | "mapService"
-            | "lastUpdated"
-            | "layers"
-            | "id"
+            D2MetadataVersion,
             | "lastUpdatedBy"
-            | "userGroupAccesses"
+            | "code"
             | "created"
-            | "mapLayerPosition"
-            | "url"
-            | "userAccesses"
+            | "type"
+            | "lastUpdated"
+            | "importDate"
+            | "hashCode"
             | "name"
-            | "legendSet"
-            | "attribution"
-            | "user"
+            | "id"
         >;
         $owner: Preset<
-            D2ExternalMapLayer,
-            | "imageFormat"
-            | "code"
-            | "publicAccess"
-            | "legendSetUrl"
-            | "mapService"
-            | "lastUpdated"
-            | "layers"
-            | "id"
+            D2MetadataVersion,
             | "lastUpdatedBy"
-            | "userGroupAccesses"
+            | "code"
             | "created"
-            | "mapLayerPosition"
-            | "url"
-            | "userAccesses"
+            | "type"
+            | "lastUpdated"
+            | "importDate"
+            | "hashCode"
             | "name"
-            | "legendSet"
-            | "attribution"
-            | "user"
+            | "id"
         >;
     };
 }
 
-export interface D2ChartSchema {
-    name: "D2Chart";
-    model: D2Chart;
+export interface D2MinMaxDataElementSchema {
+    name: "D2MinMaxDataElement";
+    model: D2MinMaxDataElement;
+    fields: {
+        dataElement: D2DataElementSchema;
+        generated: boolean;
+        max: number;
+        min: number;
+        optionCombo: D2CategoryOptionComboSchema;
+        source: D2OrganisationUnitSchema;
+    };
+    fieldPresets: {
+        $all: Preset<D2MinMaxDataElement, keyof D2MinMaxDataElement>;
+        $identifiable: Preset<D2MinMaxDataElement, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2MinMaxDataElement, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2MinMaxDataElement,
+            "min" | "generated" | "max" | "dataElement" | "source" | "optionCombo"
+        >;
+        $owner: Preset<
+            D2MinMaxDataElement,
+            "min" | "generated" | "max" | "dataElement" | "source" | "optionCombo"
+        >;
+    };
+}
+
+export interface D2OAuth2ClientSchema {
+    name: "D2OAuth2Client";
+    model: D2OAuth2Client;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        cid: Id;
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        grantTypes: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        redirectUris: string[];
+        secret: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2OAuth2Client, keyof D2OAuth2Client>;
+        $identifiable: Preset<D2OAuth2Client, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OAuth2Client, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2OAuth2Client,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "secret"
+            | "redirectUris"
+            | "lastUpdated"
+            | "grantTypes"
+            | "name"
+            | "id"
+            | "cid"
+        >;
+        $owner: Preset<
+            D2OAuth2Client,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "secret"
+            | "redirectUris"
+            | "lastUpdated"
+            | "grantTypes"
+            | "name"
+            | "id"
+            | "cid"
+        >;
+    };
+}
+
+export interface D2OptionSchema {
+    name: "D2Option";
+    model: D2Option;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        code: string;
+        created: string;
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        optionSet: D2OptionSetSchema;
+        publicAccess: string;
+        shortName: string;
+        sortOrder: number;
+        style: D2Style;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2Option, keyof D2Option>;
+        $identifiable: Preset<D2Option, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Option, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Option,
+            | "code"
+            | "description"
+            | "lastUpdated"
+            | "optionSet"
+            | "translations"
+            | "formName"
+            | "id"
+            | "created"
+            | "attributeValues"
+            | "sortOrder"
+            | "name"
+            | "style"
+        >;
+        $owner: Preset<
+            D2Option,
+            | "code"
+            | "description"
+            | "lastUpdated"
+            | "optionSet"
+            | "translations"
+            | "formName"
+            | "id"
+            | "created"
+            | "attributeValues"
+            | "sortOrder"
+            | "name"
+            | "style"
+        >;
+    };
+}
+
+export interface D2OptionGroupSchema {
+    name: "D2OptionGroup";
+    model: D2OptionGroup;
     fields: {
         access: D2Access;
         aggregationType:
@@ -10992,259 +9319,2115 @@ export interface D2ChartSchema {
             | "NONE"
             | "CUSTOM"
             | "DEFAULT";
-        attributeDimensions: any[];
         attributeValues: D2AttributeValueSchema[];
-        baseLineLabel: string;
-        baseLineValue: number;
-        category: string;
-        categoryDimensions: D2CategoryDimensionSchema[];
-        categoryOptionGroupSetDimensions: D2CategoryOptionGroupSetDimensionSchema[];
         code: Id;
-        colorSet: D2ColorSetSchema;
-        columns: any[];
-        completedOnly: boolean;
         created: string;
-        cumulativeValues: boolean;
-        dataDimensionItems: any[];
-        dataElementDimensions: D2TrackedEntityDataElementDimensionSchema[];
-        dataElementGroupSetDimensions: D2DataElementGroupSetDimensionSchema[];
         description: string;
-        digitGroupSeparator: "COMMA" | "SPACE" | "NONE";
+        dimensionItem: string;
+        dimensionItemType:
+            | "DATA_ELEMENT"
+            | "DATA_ELEMENT_OPERAND"
+            | "INDICATOR"
+            | "REPORTING_RATE"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION"
+            | "OPTION_GROUP"
+            | "DATA_ELEMENT_GROUP"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY_OPTION_GROUP";
         displayDescription: string;
         displayFormName: string;
         displayName: string;
         displayShortName: string;
-        domainAxisLabel: string;
-        endDate: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
-        filterDimensions: string[];
-        filters: any[];
         formName: string;
-        hideEmptyRowItems:
-            | "NONE"
-            | "BEFORE_FIRST"
-            | "AFTER_LAST"
-            | "BEFORE_FIRST_AFTER_LAST"
-            | "ALL";
-        hideLegend: boolean;
-        hideSubtitle: boolean;
-        hideTitle: boolean;
         href: string;
         id: Id;
-        interpretations: D2InterpretationSchema[];
-        itemOrganisationUnitGroups: D2OrganisationUnitGroupSchema[];
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
-        legendDisplayStrategy: "FIXED" | "BY_DATA_ITEM";
         legendSet: D2LegendSetSchema;
+        legendSets: D2LegendSetSchema[];
         name: string;
-        noSpaceBetweenColumns: boolean;
-        orgUnitField: string;
-        organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimensionSchema[];
-        organisationUnitLevels: number[];
-        organisationUnits: D2OrganisationUnitSchema[];
-        parentGraphMap: D2MapSchema;
-        percentStackedValues: boolean;
-        periods: any[];
-        programIndicatorDimensions: D2TrackedEntityProgramIndicatorDimensionSchema[];
+        optionSet: D2OptionSetSchema;
+        options: D2OptionSchema[];
         publicAccess: string;
-        rangeAxisDecimals: number;
-        rangeAxisLabel: string;
-        rangeAxisMaxValue: number;
-        rangeAxisMinValue: number;
-        rangeAxisSteps: number;
-        regressionType: "NONE" | "LINEAR" | "POLYNOMIAL" | "LOESS";
-        relativePeriods: any;
-        rows: any[];
-        series: string;
-        seriesItems: any[];
         shortName: string;
-        showData: boolean;
-        sortOrder: number;
-        startDate: string;
-        subscribed: boolean;
-        subscribers: string[];
-        subtitle: string;
-        targetLineLabel: string;
-        targetLineValue: number;
-        timeField: string;
-        title: string;
-        topLimit: number;
         translations: D2Translation[];
-        type:
-            | "COLUMN"
-            | "STACKED_COLUMN"
-            | "BAR"
-            | "STACKED_BAR"
-            | "LINE"
-            | "AREA"
-            | "PIE"
-            | "RADAR"
-            | "GAUGE"
-            | "YEAR_OVER_YEAR_LINE"
-            | "YEAR_OVER_YEAR_COLUMN";
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
-        userOrganisationUnit: boolean;
-        userOrganisationUnitChildren: boolean;
-        userOrganisationUnitGrandChildren: boolean;
-        yearlySeries: string[];
     };
     fieldPresets: {
-        $all: Preset<D2Chart, keyof D2Chart>;
-        $identifiable: Preset<D2Chart, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Chart, FieldPresets["nameable"]>;
+        $all: Preset<D2OptionGroup, keyof D2OptionGroup>;
+        $identifiable: Preset<D2OptionGroup, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OptionGroup, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2Chart,
-            | "dataElementGroupSetDimensions"
-            | "showData"
-            | "endDate"
-            | "baseLineValue"
+            D2OptionGroup,
+            | "code"
             | "publicAccess"
-            | "userOrganisationUnitChildren"
-            | "type"
             | "lastUpdated"
+            | "optionSet"
             | "translations"
-            | "yearlySeries"
-            | "userOrganisationUnit"
-            | "filterDimensions"
+            | "options"
             | "id"
-            | "interpretations"
-            | "itemOrganisationUnitGroups"
             | "lastUpdatedBy"
             | "userGroupAccesses"
-            | "domainAxisLabel"
             | "created"
-            | "subscribers"
-            | "rangeAxisLabel"
-            | "regressionType"
-            | "completedOnly"
-            | "cumulativeValues"
-            | "subtitle"
-            | "sortOrder"
+            | "attributeValues"
             | "userAccesses"
             | "name"
-            | "rangeAxisDecimals"
-            | "startDate"
-            | "hideEmptyRowItems"
-            | "favorites"
-            | "dataDimensionItems"
-            | "aggregationType"
-            | "code"
-            | "categoryOptionGroupSetDimensions"
-            | "userOrganisationUnitGrandChildren"
-            | "hideSubtitle"
-            | "description"
-            | "organisationUnitGroupSetDimensions"
-            | "title"
-            | "hideLegend"
-            | "organisationUnitLevels"
-            | "externalAccess"
-            | "rangeAxisMinValue"
-            | "percentStackedValues"
-            | "seriesItems"
-            | "legendDisplayStrategy"
-            | "noSpaceBetweenColumns"
-            | "relativePeriods"
-            | "rangeAxisSteps"
-            | "targetLineLabel"
-            | "periods"
-            | "organisationUnits"
-            | "categoryDimensions"
-            | "targetLineValue"
-            | "baseLineLabel"
-            | "hideTitle"
-            | "series"
-            | "legendSet"
-            | "rangeAxisMaxValue"
-            | "colorSet"
-            | "category"
+            | "shortName"
             | "user"
         >;
         $owner: Preset<
-            D2Chart,
-            | "dataElementGroupSetDimensions"
-            | "showData"
-            | "endDate"
-            | "baseLineValue"
+            D2OptionGroup,
+            | "code"
             | "publicAccess"
-            | "userOrganisationUnitChildren"
-            | "type"
             | "lastUpdated"
+            | "optionSet"
             | "translations"
-            | "yearlySeries"
-            | "userOrganisationUnit"
-            | "filterDimensions"
+            | "options"
             | "id"
-            | "itemOrganisationUnitGroups"
             | "lastUpdatedBy"
             | "userGroupAccesses"
-            | "domainAxisLabel"
             | "created"
-            | "subscribers"
-            | "rangeAxisLabel"
-            | "regressionType"
-            | "completedOnly"
-            | "cumulativeValues"
-            | "subtitle"
-            | "sortOrder"
+            | "attributeValues"
             | "userAccesses"
             | "name"
-            | "rangeAxisDecimals"
-            | "startDate"
-            | "hideEmptyRowItems"
-            | "favorites"
-            | "dataDimensionItems"
-            | "aggregationType"
-            | "code"
-            | "categoryOptionGroupSetDimensions"
-            | "userOrganisationUnitGrandChildren"
-            | "hideSubtitle"
-            | "description"
-            | "organisationUnitGroupSetDimensions"
-            | "title"
-            | "hideLegend"
-            | "organisationUnitLevels"
-            | "externalAccess"
-            | "rangeAxisMinValue"
-            | "percentStackedValues"
-            | "seriesItems"
-            | "legendDisplayStrategy"
-            | "noSpaceBetweenColumns"
-            | "relativePeriods"
-            | "rangeAxisSteps"
-            | "targetLineLabel"
-            | "periods"
-            | "organisationUnits"
-            | "categoryDimensions"
-            | "targetLineValue"
-            | "baseLineLabel"
-            | "hideTitle"
-            | "series"
-            | "legendSet"
-            | "rangeAxisMaxValue"
-            | "colorSet"
-            | "category"
+            | "shortName"
             | "user"
         >;
     };
 }
 
-export interface D2DocumentSchema {
-    name: "D2Document";
-    model: D2Document;
+export interface D2OptionGroupSetSchema {
+    name: "D2OptionGroupSet";
+    model: D2OptionGroupSet;
     fields: {
         access: D2Access;
-        attachment: boolean;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        allItems: boolean;
         attributeValues: D2AttributeValueSchema[];
         code: Id;
-        contentType: string;
+        created: string;
+        dataDimension: boolean;
+        dataDimensionType: "DISAGGREGATION" | "ATTRIBUTE";
+        description: string;
+        dimension: string;
+        dimensionType:
+            | "DATA_X"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "DATA_COLLAPSED"
+            | "CATEGORY_OPTION_COMBO"
+            | "ATTRIBUTE_OPTION_COMBO"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION_GROUP_SET"
+            | "DATA_ELEMENT_GROUP_SET"
+            | "ORGANISATION_UNIT_GROUP_SET"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY"
+            | "OPTION_GROUP_SET"
+            | "VALIDATION_RULE"
+            | "STATIC"
+            | "ORGANISATION_UNIT_LEVEL";
+        dimensionalKeywords: D2DimensionalKeywords;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        filter: string;
+        formName: string;
+        href: string;
+        id: Id;
+        items: any[];
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendSet: D2LegendSetSchema;
+        name: string;
+        optionGroups: D2OptionGroupSchema[];
+        optionSet: D2OptionSetSchema;
+        publicAccess: string;
+        shortName: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2OptionGroupSet, keyof D2OptionGroupSet>;
+        $identifiable: Preset<D2OptionGroupSet, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OptionGroupSet, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2OptionGroupSet,
+            | "code"
+            | "publicAccess"
+            | "description"
+            | "optionGroups"
+            | "lastUpdated"
+            | "optionSet"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "userAccesses"
+            | "name"
+            | "dataDimension"
+            | "user"
+        >;
+        $owner: Preset<
+            D2OptionGroupSet,
+            | "code"
+            | "publicAccess"
+            | "description"
+            | "optionGroups"
+            | "lastUpdated"
+            | "optionSet"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "userAccesses"
+            | "name"
+            | "dataDimension"
+            | "user"
+        >;
+    };
+}
+
+export interface D2OptionSetSchema {
+    name: "D2OptionSet";
+    model: D2OptionSet;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
         created: string;
         displayName: string;
-        external: boolean;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        options: D2OptionSchema[];
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        valueType:
+            | "TEXT"
+            | "LONG_TEXT"
+            | "LETTER"
+            | "PHONE_NUMBER"
+            | "EMAIL"
+            | "BOOLEAN"
+            | "TRUE_ONLY"
+            | "DATE"
+            | "DATETIME"
+            | "TIME"
+            | "NUMBER"
+            | "UNIT_INTERVAL"
+            | "PERCENTAGE"
+            | "INTEGER"
+            | "INTEGER_POSITIVE"
+            | "INTEGER_NEGATIVE"
+            | "INTEGER_ZERO_OR_POSITIVE"
+            | "TRACKER_ASSOCIATE"
+            | "USERNAME"
+            | "COORDINATE"
+            | "ORGANISATION_UNIT"
+            | "AGE"
+            | "URL"
+            | "FILE_RESOURCE"
+            | "IMAGE";
+        version: number;
+    };
+    fieldPresets: {
+        $all: Preset<D2OptionSet, keyof D2OptionSet>;
+        $identifiable: Preset<D2OptionSet, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OptionSet, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2OptionSet,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "attributeValues"
+            | "version"
+            | "lastUpdated"
+            | "translations"
+            | "userAccesses"
+            | "valueType"
+            | "name"
+            | "options"
+            | "id"
+            | "user"
+        >;
+        $owner: Preset<
+            D2OptionSet,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "attributeValues"
+            | "version"
+            | "lastUpdated"
+            | "translations"
+            | "userAccesses"
+            | "valueType"
+            | "name"
+            | "options"
+            | "id"
+            | "user"
+        >;
+    };
+}
+
+export interface D2OrganisationUnitSchema {
+    name: "D2OrganisationUnit";
+    model: D2OrganisationUnit;
+    fields: {
+        access: D2Access;
+        address: string;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        ancestors: D2OrganisationUnitSchema[];
+        attributeValues: D2AttributeValueSchema[];
+        children: D2OrganisationUnitSchema[];
+        closedDate: string;
+        code: Id;
+        comment: string;
+        contactPerson: string;
+        created: string;
+        dataSets: D2DataSetSchema[];
+        description: string;
+        dimensionItem: string;
+        dimensionItemType:
+            | "DATA_ELEMENT"
+            | "DATA_ELEMENT_OPERAND"
+            | "INDICATOR"
+            | "REPORTING_RATE"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION"
+            | "OPTION_GROUP"
+            | "DATA_ELEMENT_GROUP"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY_OPTION_GROUP";
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        email: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        geometry: D2Geometry;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        leaf: boolean;
+        legendSet: D2LegendSetSchema;
+        legendSets: D2LegendSetSchema[];
+        level: number;
+        memberCount: number;
+        name: string;
+        openingDate: string;
+        organisationUnitGroups: D2OrganisationUnitGroupSchema[];
+        parent: D2OrganisationUnitSchema;
+        path: string;
+        phoneNumber: string;
+        programs: D2ProgramSchema[];
+        publicAccess: string;
+        shortName: string;
+        translations: D2Translation[];
+        type: string;
+        url: string;
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        users: D2UserSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2OrganisationUnit, keyof D2OrganisationUnit>;
+        $identifiable: Preset<D2OrganisationUnit, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OrganisationUnit, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2OrganisationUnit,
+            | "parent"
+            | "path"
+            | "lastUpdated"
+            | "children"
+            | "translations"
+            | "id"
+            | "organisationUnitGroups"
+            | "lastUpdatedBy"
+            | "created"
+            | "attributeValues"
+            | "users"
+            | "phoneNumber"
+            | "name"
+            | "dataSets"
+            | "programs"
+            | "shortName"
+            | "code"
+            | "description"
+            | "contactPerson"
+            | "openingDate"
+            | "email"
+            | "address"
+            | "url"
+            | "closedDate"
+            | "geometry"
+            | "comment"
+            | "user"
+        >;
+        $owner: Preset<
+            D2OrganisationUnit,
+            | "parent"
+            | "path"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "created"
+            | "attributeValues"
+            | "phoneNumber"
+            | "name"
+            | "shortName"
+            | "code"
+            | "description"
+            | "contactPerson"
+            | "openingDate"
+            | "email"
+            | "address"
+            | "url"
+            | "closedDate"
+            | "geometry"
+            | "comment"
+            | "user"
+        >;
+    };
+}
+
+export interface D2OrganisationUnitGroupSchema {
+    name: "D2OrganisationUnitGroup";
+    model: D2OrganisationUnitGroup;
+    fields: {
+        access: D2Access;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        color: string;
+        created: string;
+        description: string;
+        dimensionItem: string;
+        dimensionItemType:
+            | "DATA_ELEMENT"
+            | "DATA_ELEMENT_OPERAND"
+            | "INDICATOR"
+            | "REPORTING_RATE"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION"
+            | "OPTION_GROUP"
+            | "DATA_ELEMENT_GROUP"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY_OPTION_GROUP";
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
+        formName: string;
+        geometry: D2Geometry;
+        groupSets: D2OrganisationUnitGroupSetSchema[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendSet: D2LegendSetSchema;
+        legendSets: D2LegendSetSchema[];
+        name: string;
+        organisationUnits: D2OrganisationUnitSchema[];
+        publicAccess: string;
+        shortName: string;
+        symbol: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2OrganisationUnitGroup, keyof D2OrganisationUnitGroup>;
+        $identifiable: Preset<D2OrganisationUnitGroup, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OrganisationUnitGroup, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2OrganisationUnitGroup,
+            | "symbol"
+            | "code"
+            | "color"
+            | "publicAccess"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "organisationUnits"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "groupSets"
+            | "userAccesses"
+            | "name"
+            | "geometry"
+            | "shortName"
+            | "user"
+        >;
+        $owner: Preset<
+            D2OrganisationUnitGroup,
+            | "symbol"
+            | "code"
+            | "color"
+            | "publicAccess"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "organisationUnits"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "userAccesses"
+            | "name"
+            | "geometry"
+            | "shortName"
+            | "user"
+        >;
+    };
+}
+
+export interface D2OrganisationUnitGroupSetSchema {
+    name: "D2OrganisationUnitGroupSet";
+    model: D2OrganisationUnitGroupSet;
+    fields: {
+        access: D2Access;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        allItems: boolean;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        compulsory: boolean;
+        created: string;
+        dataDimension: boolean;
+        dataDimensionType: "DISAGGREGATION" | "ATTRIBUTE";
+        description: string;
+        dimension: string;
+        dimensionType:
+            | "DATA_X"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "DATA_COLLAPSED"
+            | "CATEGORY_OPTION_COMBO"
+            | "ATTRIBUTE_OPTION_COMBO"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION_GROUP_SET"
+            | "DATA_ELEMENT_GROUP_SET"
+            | "ORGANISATION_UNIT_GROUP_SET"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY"
+            | "OPTION_GROUP_SET"
+            | "VALIDATION_RULE"
+            | "STATIC"
+            | "ORGANISATION_UNIT_LEVEL";
+        dimensionalKeywords: D2DimensionalKeywords;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        filter: string;
+        formName: string;
+        href: string;
+        id: Id;
+        includeSubhierarchyInAnalytics: boolean;
+        items: any[];
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendSet: D2LegendSetSchema;
+        name: string;
+        organisationUnitGroups: D2OrganisationUnitGroupSchema[];
+        publicAccess: string;
+        shortName: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2OrganisationUnitGroupSet, keyof D2OrganisationUnitGroupSet>;
+        $identifiable: Preset<D2OrganisationUnitGroupSet, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OrganisationUnitGroupSet, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2OrganisationUnitGroupSet,
+            | "code"
+            | "publicAccess"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "organisationUnitGroups"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "compulsory"
+            | "includeSubhierarchyInAnalytics"
+            | "userAccesses"
+            | "name"
+            | "dataDimension"
+            | "user"
+        >;
+        $owner: Preset<
+            D2OrganisationUnitGroupSet,
+            | "code"
+            | "publicAccess"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "organisationUnitGroups"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "compulsory"
+            | "includeSubhierarchyInAnalytics"
+            | "userAccesses"
+            | "name"
+            | "dataDimension"
+            | "user"
+        >;
+    };
+}
+
+export interface D2OrganisationUnitGroupSetDimensionSchema {
+    name: "D2OrganisationUnitGroupSetDimension";
+    model: D2OrganisationUnitGroupSetDimension;
+    fields: {
+        organisationUnitGroupSet: D2OrganisationUnitGroupSetSchema;
+        organisationUnitGroups: D2OrganisationUnitGroupSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<
+            D2OrganisationUnitGroupSetDimension,
+            keyof D2OrganisationUnitGroupSetDimension
+        >;
+        $identifiable: Preset<D2OrganisationUnitGroupSetDimension, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OrganisationUnitGroupSetDimension, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2OrganisationUnitGroupSetDimension,
+            "organisationUnitGroupSet" | "organisationUnitGroups"
+        >;
+        $owner: Preset<
+            D2OrganisationUnitGroupSetDimension,
+            "organisationUnitGroupSet" | "organisationUnitGroups"
+        >;
+    };
+}
+
+export interface D2OrganisationUnitLevelSchema {
+    name: "D2OrganisationUnitLevel";
+    model: D2OrganisationUnitLevel;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        level: number;
+        name: string;
+        offlineLevels: number;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2OrganisationUnitLevel, keyof D2OrganisationUnitLevel>;
+        $identifiable: Preset<D2OrganisationUnitLevel, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OrganisationUnitLevel, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2OrganisationUnitLevel,
+            | "lastUpdatedBy"
+            | "offlineLevels"
+            | "code"
+            | "level"
+            | "created"
+            | "lastUpdated"
+            | "translations"
+            | "name"
+            | "id"
+        >;
+        $owner: Preset<
+            D2OrganisationUnitLevel,
+            | "lastUpdatedBy"
+            | "offlineLevels"
+            | "code"
+            | "level"
+            | "created"
+            | "lastUpdated"
+            | "translations"
+            | "name"
+            | "id"
+        >;
+    };
+}
+
+export interface D2PredictorSchema {
+    name: "D2Predictor";
+    model: D2Predictor;
+    fields: {
+        access: D2Access;
+        annualSampleCount: number;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        created: string;
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        generator: D2ExpressionSchema;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        organisationUnitLevels: D2OrganisationUnitLevelSchema[];
+        output: D2DataElementSchema;
+        outputCombo: D2CategoryOptionComboSchema;
+        periodType: string;
+        predictorGroups: D2PredictorGroupSchema[];
+        publicAccess: string;
+        sampleSkipTest: D2ExpressionSchema;
+        sequentialSampleCount: number;
+        sequentialSkipCount: number;
+        shortName: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2Predictor, keyof D2Predictor>;
+        $identifiable: Preset<D2Predictor, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Predictor, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Predictor,
+            | "outputCombo"
+            | "code"
+            | "description"
+            | "generator"
+            | "organisationUnitLevels"
+            | "output"
+            | "lastUpdated"
+            | "sampleSkipTest"
+            | "id"
+            | "sequentialSampleCount"
+            | "annualSampleCount"
+            | "lastUpdatedBy"
+            | "created"
+            | "sequentialSkipCount"
+            | "predictorGroups"
+            | "periodType"
+            | "name"
+        >;
+        $owner: Preset<
+            D2Predictor,
+            | "outputCombo"
+            | "code"
+            | "description"
+            | "generator"
+            | "organisationUnitLevels"
+            | "output"
+            | "lastUpdated"
+            | "sampleSkipTest"
+            | "id"
+            | "sequentialSampleCount"
+            | "annualSampleCount"
+            | "lastUpdatedBy"
+            | "created"
+            | "sequentialSkipCount"
+            | "periodType"
+            | "name"
+        >;
+    };
+}
+
+export interface D2PredictorGroupSchema {
+    name: "D2PredictorGroup";
+    model: D2PredictorGroup;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        created: string;
+        description: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        predictors: D2PredictorSchema[];
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2PredictorGroup, keyof D2PredictorGroup>;
+        $identifiable: Preset<D2PredictorGroup, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2PredictorGroup, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2PredictorGroup,
+            | "predictors"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+        >;
+        $owner: Preset<
+            D2PredictorGroup,
+            | "predictors"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+        >;
+    };
+}
+
+export interface D2ProgramSchema {
+    name: "D2Program";
+    model: D2Program;
+    fields: {
+        access: D2Access;
+        accessLevel: "OPEN" | "AUDITED" | "PROTECTED" | "CLOSED";
+        attributeValues: D2AttributeValueSchema[];
+        categoryCombo: D2CategoryComboSchema;
+        code: Id;
+        completeEventsExpiryDays: number;
+        created: string;
+        dataEntryForm: D2DataEntryFormSchema;
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayFrontPageList: boolean;
+        displayIncidentDate: boolean;
+        displayName: string;
+        displayShortName: string;
+        enrollmentDateLabel: string;
+        expiryDays: number;
+        expiryPeriodType: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
+        formName: string;
+        href: string;
+        id: Id;
+        ignoreOverdueEvents: boolean;
+        incidentDateLabel: string;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        maxTeiCountToReturn: number;
+        minAttributesRequiredToSearch: number;
+        name: string;
+        notificationTemplates: D2ProgramNotificationTemplateSchema[];
+        onlyEnrollOnce: boolean;
+        organisationUnits: D2OrganisationUnitSchema[];
+        programIndicators: D2ProgramIndicatorSchema[];
+        programRuleVariables: D2ProgramRuleVariableSchema[];
+        programSections: D2ProgramSectionSchema[];
+        programStages: D2ProgramStageSchema[];
+        programTrackedEntityAttributes: D2ProgramTrackedEntityAttributeSchema[];
+        programType: "WITH_REGISTRATION" | "WITHOUT_REGISTRATION";
+        publicAccess: string;
+        registration: boolean;
+        relatedProgram: D2ProgramSchema;
+        selectEnrollmentDatesInFuture: boolean;
+        selectIncidentDatesInFuture: boolean;
+        shortName: string;
+        skipOffline: boolean;
+        style: D2Style;
+        trackedEntityType: D2TrackedEntityTypeSchema;
+        translations: D2Translation[];
+        useFirstStageDuringRegistration: boolean;
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        userRoles: D2UserAuthorityGroupSchema[];
+        version: number;
+        withoutRegistration: boolean;
+    };
+    fieldPresets: {
+        $all: Preset<D2Program, keyof D2Program>;
+        $identifiable: Preset<D2Program, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Program, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Program,
+            | "dataEntryForm"
+            | "publicAccess"
+            | "ignoreOverdueEvents"
+            | "skipOffline"
+            | "programIndicators"
+            | "lastUpdated"
+            | "categoryCombo"
+            | "translations"
+            | "id"
+            | "enrollmentDateLabel"
+            | "lastUpdatedBy"
+            | "onlyEnrollOnce"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "version"
+            | "maxTeiCountToReturn"
+            | "selectIncidentDatesInFuture"
+            | "incidentDateLabel"
+            | "userRoles"
+            | "expiryPeriodType"
+            | "userAccesses"
+            | "name"
+            | "selectEnrollmentDatesInFuture"
+            | "style"
+            | "shortName"
+            | "useFirstStageDuringRegistration"
+            | "code"
+            | "programRuleVariables"
+            | "programTrackedEntityAttributes"
+            | "completeEventsExpiryDays"
+            | "description"
+            | "relatedProgram"
+            | "notificationTemplates"
+            | "formName"
+            | "featureType"
+            | "minAttributesRequiredToSearch"
+            | "displayFrontPageList"
+            | "organisationUnits"
+            | "programType"
+            | "accessLevel"
+            | "programSections"
+            | "programStages"
+            | "trackedEntityType"
+            | "displayIncidentDate"
+            | "expiryDays"
+            | "user"
+        >;
+        $owner: Preset<
+            D2Program,
+            | "dataEntryForm"
+            | "publicAccess"
+            | "ignoreOverdueEvents"
+            | "skipOffline"
+            | "lastUpdated"
+            | "categoryCombo"
+            | "translations"
+            | "id"
+            | "enrollmentDateLabel"
+            | "lastUpdatedBy"
+            | "onlyEnrollOnce"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "version"
+            | "maxTeiCountToReturn"
+            | "selectIncidentDatesInFuture"
+            | "incidentDateLabel"
+            | "expiryPeriodType"
+            | "userAccesses"
+            | "name"
+            | "selectEnrollmentDatesInFuture"
+            | "style"
+            | "shortName"
+            | "useFirstStageDuringRegistration"
+            | "code"
+            | "programTrackedEntityAttributes"
+            | "completeEventsExpiryDays"
+            | "description"
+            | "relatedProgram"
+            | "notificationTemplates"
+            | "formName"
+            | "featureType"
+            | "minAttributesRequiredToSearch"
+            | "displayFrontPageList"
+            | "organisationUnits"
+            | "programType"
+            | "accessLevel"
+            | "programSections"
+            | "programStages"
+            | "trackedEntityType"
+            | "displayIncidentDate"
+            | "expiryDays"
+            | "user"
+        >;
+    };
+}
+
+export interface D2ProgramDataElementDimensionItemSchema {
+    name: "D2ProgramDataElementDimensionItem";
+    model: D2ProgramDataElementDimensionItem;
+    fields: {
+        access: D2Access;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        created: string;
+        dataElement: D2DataElementSchema;
+        description: string;
+        dimensionItem: string;
+        dimensionItemType:
+            | "DATA_ELEMENT"
+            | "DATA_ELEMENT_OPERAND"
+            | "INDICATOR"
+            | "REPORTING_RATE"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION"
+            | "OPTION_GROUP"
+            | "DATA_ELEMENT_GROUP"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY_OPTION_GROUP";
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendSet: D2LegendSetSchema;
+        legendSets: D2LegendSetSchema[];
+        name: string;
+        program: D2ProgramSchema;
+        publicAccess: string;
+        shortName: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        valueType:
+            | "TEXT"
+            | "LONG_TEXT"
+            | "LETTER"
+            | "PHONE_NUMBER"
+            | "EMAIL"
+            | "BOOLEAN"
+            | "TRUE_ONLY"
+            | "DATE"
+            | "DATETIME"
+            | "TIME"
+            | "NUMBER"
+            | "UNIT_INTERVAL"
+            | "PERCENTAGE"
+            | "INTEGER"
+            | "INTEGER_POSITIVE"
+            | "INTEGER_NEGATIVE"
+            | "INTEGER_ZERO_OR_POSITIVE"
+            | "TRACKER_ASSOCIATE"
+            | "USERNAME"
+            | "COORDINATE"
+            | "ORGANISATION_UNIT"
+            | "AGE"
+            | "URL"
+            | "FILE_RESOURCE"
+            | "IMAGE";
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramDataElementDimensionItem, keyof D2ProgramDataElementDimensionItem>;
+        $identifiable: Preset<D2ProgramDataElementDimensionItem, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramDataElementDimensionItem, FieldPresets["nameable"]>;
+        $persisted: Preset<D2ProgramDataElementDimensionItem, never>;
+        $owner: Preset<D2ProgramDataElementDimensionItem, never>;
+    };
+}
+
+export interface D2ProgramIndicatorSchema {
+    name: "D2ProgramIndicator";
+    model: D2ProgramIndicator;
+    fields: {
+        access: D2Access;
+        aggregateExportAttributeOptionCombo: string;
+        aggregateExportCategoryOptionCombo: string;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        analyticsPeriodBoundaries: D2AnalyticsPeriodBoundarySchema[];
+        analyticsType: "EVENT" | "ENROLLMENT";
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        created: string;
+        decimals: number;
+        description: string;
+        dimensionItem: string;
+        dimensionItemType:
+            | "DATA_ELEMENT"
+            | "DATA_ELEMENT_OPERAND"
+            | "INDICATOR"
+            | "REPORTING_RATE"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION"
+            | "OPTION_GROUP"
+            | "DATA_ELEMENT_GROUP"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY_OPTION_GROUP";
+        displayDescription: string;
+        displayFormName: string;
+        displayInForm: boolean;
+        displayName: string;
+        displayShortName: string;
+        expression: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        filter: string;
+        formName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendSet: D2LegendSetSchema;
+        legendSets: D2LegendSetSchema[];
+        name: string;
+        program: D2ProgramSchema;
+        programIndicatorGroups: D2ProgramIndicatorGroupSchema[];
+        publicAccess: string;
+        shortName: string;
+        style: D2Style;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramIndicator, keyof D2ProgramIndicator>;
+        $identifiable: Preset<D2ProgramIndicator, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramIndicator, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramIndicator,
+            | "aggregationType"
+            | "code"
+            | "displayInForm"
+            | "publicAccess"
+            | "aggregateExportCategoryOptionCombo"
+            | "description"
+            | "program"
+            | "lastUpdated"
+            | "translations"
+            | "formName"
+            | "id"
+            | "programIndicatorGroups"
+            | "analyticsPeriodBoundaries"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "expression"
+            | "created"
+            | "attributeValues"
+            | "filter"
+            | "userAccesses"
+            | "decimals"
+            | "name"
+            | "analyticsType"
+            | "legendSets"
+            | "style"
+            | "shortName"
+            | "user"
+            | "aggregateExportAttributeOptionCombo"
+        >;
+        $owner: Preset<
+            D2ProgramIndicator,
+            | "aggregationType"
+            | "code"
+            | "displayInForm"
+            | "publicAccess"
+            | "aggregateExportCategoryOptionCombo"
+            | "description"
+            | "program"
+            | "lastUpdated"
+            | "translations"
+            | "formName"
+            | "id"
+            | "analyticsPeriodBoundaries"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "expression"
+            | "created"
+            | "attributeValues"
+            | "filter"
+            | "userAccesses"
+            | "decimals"
+            | "name"
+            | "analyticsType"
+            | "legendSets"
+            | "style"
+            | "shortName"
+            | "user"
+            | "aggregateExportAttributeOptionCombo"
+        >;
+    };
+}
+
+export interface D2ProgramIndicatorGroupSchema {
+    name: "D2ProgramIndicatorGroup";
+    model: D2ProgramIndicatorGroup;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        created: string;
+        description: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        programIndicators: D2ProgramIndicatorSchema[];
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramIndicatorGroup, keyof D2ProgramIndicatorGroup>;
+        $identifiable: Preset<D2ProgramIndicatorGroup, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramIndicatorGroup, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramIndicatorGroup,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "attributeValues"
+            | "description"
+            | "programIndicators"
+            | "lastUpdated"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+        >;
+        $owner: Preset<
+            D2ProgramIndicatorGroup,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "attributeValues"
+            | "description"
+            | "programIndicators"
+            | "lastUpdated"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+        >;
+    };
+}
+
+export interface D2ProgramInstanceSchema {
+    name: "D2ProgramInstance";
+    model: D2ProgramInstance;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        created: string;
+        createdAtClient: string;
+        deleted: boolean;
+        displayName: string;
+        endDate: string;
+        enrollmentDate: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        followup: boolean;
+        href: string;
+        id: Id;
+        incidentDate: string;
+        lastUpdated: string;
+        lastUpdatedAtClient: string;
+        lastUpdatedBy: D2UserSchema;
+        messageConversations: D2MessageConversationSchema[];
+        name: string;
+        organisationUnit: D2OrganisationUnitSchema;
+        program: D2ProgramSchema;
+        programStageInstances: D2ProgramStageInstanceSchema[];
+        publicAccess: string;
+        relationshipItems: any[];
+        status: "ACTIVE" | "COMPLETED" | "CANCELLED";
+        storedBy: string;
+        trackedEntityComments: any[];
+        trackedEntityInstance: D2TrackedEntityInstanceSchema;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramInstance, keyof D2ProgramInstance>;
+        $identifiable: Preset<D2ProgramInstance, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramInstance, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramInstance,
+            | "storedBy"
+            | "endDate"
+            | "organisationUnit"
+            | "enrollmentDate"
+            | "createdAtClient"
+            | "program"
+            | "messageConversations"
+            | "trackedEntityComments"
+            | "lastUpdated"
+            | "relationshipItems"
+            | "id"
+            | "created"
+            | "programStageInstances"
+            | "trackedEntityInstance"
+            | "followup"
+            | "deleted"
+            | "incidentDate"
+            | "status"
+            | "lastUpdatedAtClient"
+        >;
+        $owner: Preset<
+            D2ProgramInstance,
+            | "storedBy"
+            | "endDate"
+            | "organisationUnit"
+            | "enrollmentDate"
+            | "createdAtClient"
+            | "program"
+            | "messageConversations"
+            | "trackedEntityComments"
+            | "lastUpdated"
+            | "id"
+            | "created"
+            | "programStageInstances"
+            | "trackedEntityInstance"
+            | "followup"
+            | "deleted"
+            | "incidentDate"
+            | "status"
+            | "lastUpdatedAtClient"
+        >;
+    };
+}
+
+export interface D2ProgramNotificationTemplateSchema {
+    name: "D2ProgramNotificationTemplate";
+    model: D2ProgramNotificationTemplate;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        created: string;
+        deliveryChannels: never[];
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        messageTemplate: string;
+        name: string;
+        notificationRecipient:
+            | "TRACKED_ENTITY_INSTANCE"
+            | "ORGANISATION_UNIT_CONTACT"
+            | "USERS_AT_ORGANISATION_UNIT"
+            | "USER_GROUP"
+            | "PROGRAM_ATTRIBUTE"
+            | "DATA_ELEMENT";
+        notificationTrigger:
+            | "ENROLLMENT"
+            | "COMPLETION"
+            | "PROGRAM_RULE"
+            | "SCHEDULED_DAYS_DUE_DATE"
+            | "SCHEDULED_DAYS_INCIDENT_DATE"
+            | "SCHEDULED_DAYS_ENROLLMENT_DATE";
+        notifyParentOrganisationUnitOnly: boolean;
+        notifyUsersInHierarchyOnly: boolean;
+        publicAccess: string;
+        recipientDataElement: D2DataElementSchema;
+        recipientProgramAttribute: D2TrackedEntityAttributeSchema;
+        recipientUserGroup: D2UserGroupSchema;
+        relativeScheduledDays: number;
+        subjectTemplate: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramNotificationTemplate, keyof D2ProgramNotificationTemplate>;
+        $identifiable: Preset<D2ProgramNotificationTemplate, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramNotificationTemplate, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramNotificationTemplate,
+            | "code"
+            | "notificationTrigger"
+            | "lastUpdated"
+            | "relativeScheduledDays"
+            | "id"
+            | "subjectTemplate"
+            | "lastUpdatedBy"
+            | "deliveryChannels"
+            | "recipientDataElement"
+            | "created"
+            | "notifyUsersInHierarchyOnly"
+            | "notificationRecipient"
+            | "recipientProgramAttribute"
+            | "notifyParentOrganisationUnitOnly"
+            | "name"
+            | "recipientUserGroup"
+            | "messageTemplate"
+        >;
+        $owner: Preset<
+            D2ProgramNotificationTemplate,
+            | "code"
+            | "notificationTrigger"
+            | "lastUpdated"
+            | "relativeScheduledDays"
+            | "id"
+            | "subjectTemplate"
+            | "lastUpdatedBy"
+            | "deliveryChannels"
+            | "recipientDataElement"
+            | "created"
+            | "notifyUsersInHierarchyOnly"
+            | "notificationRecipient"
+            | "recipientProgramAttribute"
+            | "notifyParentOrganisationUnitOnly"
+            | "name"
+            | "recipientUserGroup"
+            | "messageTemplate"
+        >;
+    };
+}
+
+export interface D2ProgramRuleSchema {
+    name: "D2ProgramRule";
+    model: D2ProgramRule;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        condition: string;
+        created: string;
+        description: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        priority: number;
+        program: D2ProgramSchema;
+        programRuleActions: D2ProgramRuleActionSchema[];
+        programStage: D2ProgramStageSchema;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramRule, keyof D2ProgramRule>;
+        $identifiable: Preset<D2ProgramRule, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramRule, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramRule,
+            | "code"
+            | "description"
+            | "program"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "priority"
+            | "condition"
+            | "programRuleActions"
+            | "name"
+        >;
+        $owner: Preset<
+            D2ProgramRule,
+            | "code"
+            | "description"
+            | "program"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "priority"
+            | "condition"
+            | "programRuleActions"
+            | "name"
+        >;
+    };
+}
+
+export interface D2ProgramRuleActionSchema {
+    name: "D2ProgramRuleAction";
+    model: D2ProgramRuleAction;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        content: string;
+        created: string;
+        data: string;
+        dataElement: D2DataElementSchema;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        location: string;
+        name: string;
+        option: D2OptionSchema;
+        optionGroup: D2OptionGroupSchema;
+        programIndicator: D2ProgramIndicatorSchema;
+        programRule: D2ProgramRuleSchema;
+        programRuleActionType:
+            | "DISPLAYTEXT"
+            | "DISPLAYKEYVALUEPAIR"
+            | "HIDEFIELD"
+            | "HIDESECTION"
+            | "HIDEPROGRAMSTAGE"
+            | "ASSIGN"
+            | "SHOWWARNING"
+            | "WARNINGONCOMPLETE"
+            | "SHOWERROR"
+            | "ERRORONCOMPLETE"
+            | "CREATEEVENT"
+            | "SETMANDATORYFIELD"
+            | "SENDMESSAGE"
+            | "SCHEDULEMESSAGE"
+            | "HIDEOPTION"
+            | "SHOWOPTIONGROUP"
+            | "HIDEOPTIONGROUP";
+        programStage: D2ProgramStageSchema;
+        programStageSection: D2ProgramStageSectionSchema;
+        publicAccess: string;
+        templateUid: string;
+        trackedEntityAttribute: D2TrackedEntityAttributeSchema;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramRuleAction, keyof D2ProgramRuleAction>;
+        $identifiable: Preset<D2ProgramRuleAction, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramRuleAction, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramRuleAction,
+            | "code"
+            | "data"
+            | "optionGroup"
+            | "templateUid"
+            | "content"
+            | "trackedEntityAttribute"
+            | "lastUpdated"
+            | "programIndicator"
+            | "id"
+            | "programRule"
+            | "programStageSection"
+            | "programRuleActionType"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "dataElement"
+            | "location"
+            | "option"
+        >;
+        $owner: Preset<
+            D2ProgramRuleAction,
+            | "code"
+            | "data"
+            | "optionGroup"
+            | "templateUid"
+            | "content"
+            | "trackedEntityAttribute"
+            | "lastUpdated"
+            | "programIndicator"
+            | "id"
+            | "programRule"
+            | "programStageSection"
+            | "programRuleActionType"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "dataElement"
+            | "location"
+            | "option"
+        >;
+    };
+}
+
+export interface D2ProgramRuleVariableSchema {
+    name: "D2ProgramRuleVariable";
+    model: D2ProgramRuleVariable;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        created: string;
+        dataElement: D2DataElementSchema;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        program: D2ProgramSchema;
+        programRuleVariableSourceType:
+            | "DATAELEMENT_NEWEST_EVENT_PROGRAM_STAGE"
+            | "DATAELEMENT_NEWEST_EVENT_PROGRAM"
+            | "DATAELEMENT_CURRENT_EVENT"
+            | "DATAELEMENT_PREVIOUS_EVENT"
+            | "CALCULATED_VALUE"
+            | "TEI_ATTRIBUTE";
+        programStage: D2ProgramStageSchema;
+        publicAccess: string;
+        trackedEntityAttribute: D2TrackedEntityAttributeSchema;
+        translations: D2Translation[];
+        useCodeForOptionSet: boolean;
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramRuleVariable, keyof D2ProgramRuleVariable>;
+        $identifiable: Preset<D2ProgramRuleVariable, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramRuleVariable, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramRuleVariable,
+            | "code"
+            | "programRuleVariableSourceType"
+            | "program"
+            | "trackedEntityAttribute"
+            | "lastUpdated"
+            | "id"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "useCodeForOptionSet"
+            | "dataElement"
+            | "name"
+        >;
+        $owner: Preset<
+            D2ProgramRuleVariable,
+            | "code"
+            | "programRuleVariableSourceType"
+            | "program"
+            | "trackedEntityAttribute"
+            | "lastUpdated"
+            | "id"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "useCodeForOptionSet"
+            | "dataElement"
+            | "name"
+        >;
+    };
+}
+
+export interface D2ProgramSectionSchema {
+    name: "D2ProgramSection";
+    model: D2ProgramSection;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        created: string;
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        program: D2ProgramSchema;
+        programTrackedEntityAttribute: D2TrackedEntityAttributeSchema[];
+        publicAccess: string;
+        renderType: any;
+        shortName: string;
+        sortOrder: number;
+        style: D2Style;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramSection, keyof D2ProgramSection>;
+        $identifiable: Preset<D2ProgramSection, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramSection, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramSection,
+            | "code"
+            | "description"
+            | "program"
+            | "programTrackedEntityAttribute"
+            | "lastUpdated"
+            | "translations"
+            | "formName"
+            | "id"
+            | "renderType"
+            | "lastUpdatedBy"
+            | "created"
+            | "sortOrder"
+            | "name"
+            | "style"
+        >;
+        $owner: Preset<
+            D2ProgramSection,
+            | "code"
+            | "description"
+            | "program"
+            | "programTrackedEntityAttribute"
+            | "lastUpdated"
+            | "translations"
+            | "formName"
+            | "id"
+            | "renderType"
+            | "lastUpdatedBy"
+            | "created"
+            | "sortOrder"
+            | "name"
+            | "style"
+        >;
+    };
+}
+
+export interface D2ProgramStageSchema {
+    name: "D2ProgramStage";
+    model: D2ProgramStage;
+    fields: {
+        access: D2Access;
+        allowGenerateNextVisit: boolean;
+        attributeValues: D2AttributeValueSchema[];
+        autoGenerateEvent: boolean;
+        blockEntryForm: boolean;
+        code: Id;
+        created: string;
+        dataEntryForm: D2DataEntryFormSchema;
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayGenerateEventBox: boolean;
+        displayName: string;
+        displayShortName: string;
+        dueDateLabel: string;
+        enableUserAssignment: boolean;
+        executionDateLabel: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
+        formName: string;
+        formType: "DEFAULT" | "CUSTOM" | "SECTION" | "SECTION_MULTIORG";
+        generatedByEnrollmentDate: boolean;
+        hideDueDate: boolean;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        minDaysFromStart: number;
+        name: string;
+        notificationTemplates: D2ProgramNotificationTemplateSchema[];
+        openAfterEnrollment: boolean;
+        periodType: string;
+        preGenerateUID: boolean;
+        program: D2ProgramSchema;
+        programStageDataElements: D2ProgramStageDataElementSchema[];
+        programStageSections: D2ProgramStageSectionSchema[];
+        publicAccess: string;
+        remindCompleted: boolean;
+        repeatable: boolean;
+        reportDateToUse: string;
+        shortName: string;
+        sortOrder: number;
+        standardInterval: number;
+        style: D2Style;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        validationStrategy: "ON_COMPLETE" | "ON_UPDATE_AND_INSERT";
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramStage, keyof D2ProgramStage>;
+        $identifiable: Preset<D2ProgramStage, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramStage, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramStage,
+            | "dataEntryForm"
+            | "allowGenerateNextVisit"
+            | "publicAccess"
+            | "reportDateToUse"
+            | "program"
+            | "lastUpdated"
+            | "programStageDataElements"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "generatedByEnrollmentDate"
+            | "created"
+            | "attributeValues"
+            | "sortOrder"
+            | "userAccesses"
+            | "name"
+            | "hideDueDate"
+            | "enableUserAssignment"
+            | "style"
+            | "minDaysFromStart"
+            | "standardInterval"
+            | "dueDateLabel"
+            | "executionDateLabel"
+            | "code"
+            | "preGenerateUID"
+            | "description"
+            | "notificationTemplates"
+            | "openAfterEnrollment"
+            | "repeatable"
+            | "formName"
+            | "featureType"
+            | "remindCompleted"
+            | "displayGenerateEventBox"
+            | "validationStrategy"
+            | "autoGenerateEvent"
+            | "periodType"
+            | "blockEntryForm"
+            | "user"
+            | "programStageSections"
+        >;
+        $owner: Preset<
+            D2ProgramStage,
+            | "dataEntryForm"
+            | "allowGenerateNextVisit"
+            | "publicAccess"
+            | "reportDateToUse"
+            | "program"
+            | "lastUpdated"
+            | "programStageDataElements"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "generatedByEnrollmentDate"
+            | "created"
+            | "attributeValues"
+            | "sortOrder"
+            | "userAccesses"
+            | "name"
+            | "hideDueDate"
+            | "enableUserAssignment"
+            | "style"
+            | "minDaysFromStart"
+            | "standardInterval"
+            | "dueDateLabel"
+            | "executionDateLabel"
+            | "code"
+            | "preGenerateUID"
+            | "description"
+            | "notificationTemplates"
+            | "openAfterEnrollment"
+            | "repeatable"
+            | "formName"
+            | "featureType"
+            | "remindCompleted"
+            | "displayGenerateEventBox"
+            | "validationStrategy"
+            | "autoGenerateEvent"
+            | "periodType"
+            | "blockEntryForm"
+            | "user"
+            | "programStageSections"
+        >;
+    };
+}
+
+export interface D2ProgramStageDataElementSchema {
+    name: "D2ProgramStageDataElement";
+    model: D2ProgramStageDataElement;
+    fields: {
+        access: D2Access;
+        allowFutureDate: boolean;
+        allowProvidedElsewhere: boolean;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        compulsory: boolean;
+        created: string;
+        dataElement: D2DataElementSchema;
+        displayInReports: boolean;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        programStage: D2ProgramStageSchema;
+        publicAccess: string;
+        renderOptionsAsRadio: boolean;
+        renderType: any;
+        skipSynchronization: boolean;
+        sortOrder: number;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramStageDataElement, keyof D2ProgramStageDataElement>;
+        $identifiable: Preset<D2ProgramStageDataElement, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramStageDataElement, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramStageDataElement,
+            | "displayInReports"
+            | "code"
+            | "skipSynchronization"
+            | "lastUpdated"
+            | "renderOptionsAsRadio"
+            | "id"
+            | "allowFutureDate"
+            | "renderType"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "dataElement"
+            | "compulsory"
+            | "allowProvidedElsewhere"
+            | "sortOrder"
+        >;
+        $owner: Preset<
+            D2ProgramStageDataElement,
+            | "displayInReports"
+            | "code"
+            | "skipSynchronization"
+            | "lastUpdated"
+            | "renderOptionsAsRadio"
+            | "id"
+            | "allowFutureDate"
+            | "renderType"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "dataElement"
+            | "compulsory"
+            | "allowProvidedElsewhere"
+            | "sortOrder"
+        >;
+    };
+}
+
+export interface D2ProgramStageInstanceSchema {
+    name: "D2ProgramStageInstance";
+    model: D2ProgramStageInstance;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        created: string;
+        displayName: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
@@ -11255,54 +11438,699 @@ export interface D2DocumentSchema {
         name: string;
         publicAccess: string;
         translations: D2Translation[];
-        url: string;
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2Document, keyof D2Document>;
-        $identifiable: Preset<D2Document, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Document, FieldPresets["nameable"]>;
+        $all: Preset<D2ProgramStageInstance, keyof D2ProgramStageInstance>;
+        $identifiable: Preset<D2ProgramStageInstance, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramStageInstance, FieldPresets["nameable"]>;
+        $persisted: Preset<D2ProgramStageInstance, "code" | "created" | "lastUpdated" | "id">;
+        $owner: Preset<D2ProgramStageInstance, "code" | "created" | "lastUpdated" | "id">;
+    };
+}
+
+export interface D2ProgramStageInstanceFilterSchema {
+    name: "D2ProgramStageInstanceFilter";
+    model: D2ProgramStageInstanceFilter;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        created: string;
+        description: string;
+        displayName: string;
+        eventQueryCriteria: any;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        program: Id;
+        programStage: Id;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramStageInstanceFilter, keyof D2ProgramStageInstanceFilter>;
+        $identifiable: Preset<D2ProgramStageInstanceFilter, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramStageInstanceFilter, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2Document,
+            D2ProgramStageInstanceFilter,
             | "lastUpdatedBy"
+            | "programStage"
+            | "eventQueryCriteria"
             | "userGroupAccesses"
-            | "code"
             | "created"
             | "publicAccess"
-            | "attributeValues"
-            | "url"
-            | "externalAccess"
+            | "description"
+            | "program"
             | "lastUpdated"
-            | "external"
-            | "attachment"
-            | "translations"
             | "userAccesses"
             | "name"
             | "id"
             | "user"
-            | "contentType"
         >;
         $owner: Preset<
-            D2Document,
+            D2ProgramStageInstanceFilter,
             | "lastUpdatedBy"
+            | "programStage"
+            | "eventQueryCriteria"
             | "userGroupAccesses"
-            | "code"
             | "created"
             | "publicAccess"
-            | "attributeValues"
-            | "url"
-            | "externalAccess"
+            | "description"
+            | "program"
             | "lastUpdated"
-            | "external"
-            | "attachment"
-            | "translations"
             | "userAccesses"
             | "name"
             | "id"
             | "user"
-            | "contentType"
+        >;
+    };
+}
+
+export interface D2ProgramStageSectionSchema {
+    name: "D2ProgramStageSection";
+    model: D2ProgramStageSection;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        created: string;
+        dataElements: D2DataElementSchema[];
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        programIndicators: D2ProgramIndicatorSchema[];
+        programStage: D2ProgramStageSchema;
+        publicAccess: string;
+        renderType: any;
+        shortName: string;
+        sortOrder: number;
+        style: D2Style;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramStageSection, keyof D2ProgramStageSection>;
+        $identifiable: Preset<D2ProgramStageSection, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramStageSection, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramStageSection,
+            | "code"
+            | "description"
+            | "programIndicators"
+            | "lastUpdated"
+            | "translations"
+            | "formName"
+            | "id"
+            | "renderType"
+            | "dataElements"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "sortOrder"
+            | "name"
+            | "style"
+        >;
+        $owner: Preset<
+            D2ProgramStageSection,
+            | "code"
+            | "description"
+            | "programIndicators"
+            | "lastUpdated"
+            | "translations"
+            | "formName"
+            | "id"
+            | "renderType"
+            | "dataElements"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "sortOrder"
+            | "name"
+            | "style"
+        >;
+    };
+}
+
+export interface D2ProgramTrackedEntityAttributeSchema {
+    name: "D2ProgramTrackedEntityAttribute";
+    model: D2ProgramTrackedEntityAttribute;
+    fields: {
+        access: D2Access;
+        allowFutureDate: boolean;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        created: string;
+        displayInList: boolean;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        mandatory: boolean;
+        name: string;
+        program: D2ProgramSchema;
+        programTrackedEntityAttributeGroups: D2ProgramTrackedEntityAttributeGroupSchema[];
+        publicAccess: string;
+        renderOptionsAsRadio: boolean;
+        renderType: any;
+        searchable: boolean;
+        sortOrder: number;
+        trackedEntityAttribute: D2TrackedEntityAttributeSchema;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        valueType:
+            | "TEXT"
+            | "LONG_TEXT"
+            | "LETTER"
+            | "PHONE_NUMBER"
+            | "EMAIL"
+            | "BOOLEAN"
+            | "TRUE_ONLY"
+            | "DATE"
+            | "DATETIME"
+            | "TIME"
+            | "NUMBER"
+            | "UNIT_INTERVAL"
+            | "PERCENTAGE"
+            | "INTEGER"
+            | "INTEGER_POSITIVE"
+            | "INTEGER_NEGATIVE"
+            | "INTEGER_ZERO_OR_POSITIVE"
+            | "TRACKER_ASSOCIATE"
+            | "USERNAME"
+            | "COORDINATE"
+            | "ORGANISATION_UNIT"
+            | "AGE"
+            | "URL"
+            | "FILE_RESOURCE"
+            | "IMAGE";
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramTrackedEntityAttribute, keyof D2ProgramTrackedEntityAttribute>;
+        $identifiable: Preset<D2ProgramTrackedEntityAttribute, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramTrackedEntityAttribute, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramTrackedEntityAttribute,
+            | "code"
+            | "programTrackedEntityAttributeGroups"
+            | "program"
+            | "mandatory"
+            | "trackedEntityAttribute"
+            | "lastUpdated"
+            | "renderOptionsAsRadio"
+            | "id"
+            | "allowFutureDate"
+            | "renderType"
+            | "lastUpdatedBy"
+            | "created"
+            | "searchable"
+            | "displayInList"
+            | "sortOrder"
+        >;
+        $owner: Preset<
+            D2ProgramTrackedEntityAttribute,
+            | "code"
+            | "programTrackedEntityAttributeGroups"
+            | "program"
+            | "mandatory"
+            | "trackedEntityAttribute"
+            | "lastUpdated"
+            | "renderOptionsAsRadio"
+            | "id"
+            | "allowFutureDate"
+            | "renderType"
+            | "lastUpdatedBy"
+            | "created"
+            | "searchable"
+            | "displayInList"
+            | "sortOrder"
+        >;
+    };
+}
+
+export interface D2ProgramTrackedEntityAttributeDimensionItemSchema {
+    name: "D2ProgramTrackedEntityAttributeDimensionItem";
+    model: D2ProgramTrackedEntityAttributeDimensionItem;
+    fields: {
+        access: D2Access;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        attribute: D2TrackedEntityAttributeSchema;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        created: string;
+        description: string;
+        dimensionItem: string;
+        dimensionItemType:
+            | "DATA_ELEMENT"
+            | "DATA_ELEMENT_OPERAND"
+            | "INDICATOR"
+            | "REPORTING_RATE"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION"
+            | "OPTION_GROUP"
+            | "DATA_ELEMENT_GROUP"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY_OPTION_GROUP";
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendSet: D2LegendSetSchema;
+        legendSets: D2LegendSetSchema[];
+        name: string;
+        program: D2ProgramSchema;
+        publicAccess: string;
+        shortName: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<
+            D2ProgramTrackedEntityAttributeDimensionItem,
+            keyof D2ProgramTrackedEntityAttributeDimensionItem
+        >;
+        $identifiable: Preset<
+            D2ProgramTrackedEntityAttributeDimensionItem,
+            FieldPresets["identifiable"]
+        >;
+        $nameable: Preset<D2ProgramTrackedEntityAttributeDimensionItem, FieldPresets["nameable"]>;
+        $persisted: Preset<D2ProgramTrackedEntityAttributeDimensionItem, never>;
+        $owner: Preset<D2ProgramTrackedEntityAttributeDimensionItem, never>;
+    };
+}
+
+export interface D2ProgramTrackedEntityAttributeGroupSchema {
+    name: "D2ProgramTrackedEntityAttributeGroup";
+    model: D2ProgramTrackedEntityAttributeGroup;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        attributes: D2ProgramTrackedEntityAttributeSchema[];
+        code: Id;
+        created: string;
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        shortName: string;
+        translations: D2Translation[];
+        uniqunessType: "NONE" | "STRICT" | "VALIDATION";
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<
+            D2ProgramTrackedEntityAttributeGroup,
+            keyof D2ProgramTrackedEntityAttributeGroup
+        >;
+        $identifiable: Preset<D2ProgramTrackedEntityAttributeGroup, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramTrackedEntityAttributeGroup, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramTrackedEntityAttributeGroup,
+            | "code"
+            | "uniqunessType"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "created"
+            | "name"
+            | "attributes"
+            | "shortName"
+        >;
+        $owner: Preset<
+            D2ProgramTrackedEntityAttributeGroup,
+            | "code"
+            | "uniqunessType"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "created"
+            | "name"
+            | "shortName"
+        >;
+    };
+}
+
+export interface D2PushAnalysisSchema {
+    name: "D2PushAnalysis";
+    model: D2PushAnalysis;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        created: string;
+        dashboard: D2DashboardSchema;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        message: string;
+        name: string;
+        publicAccess: string;
+        recipientUserGroups: D2UserGroupSchema[];
+        title: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2PushAnalysis, keyof D2PushAnalysis>;
+        $identifiable: Preset<D2PushAnalysis, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2PushAnalysis, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2PushAnalysis,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "recipientUserGroups"
+            | "message"
+            | "title"
+            | "lastUpdated"
+            | "name"
+            | "id"
+            | "dashboard"
+        >;
+        $owner: Preset<
+            D2PushAnalysis,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "recipientUserGroups"
+            | "message"
+            | "title"
+            | "lastUpdated"
+            | "name"
+            | "id"
+            | "dashboard"
+        >;
+    };
+}
+
+export interface D2RelationshipSchema {
+    name: "D2Relationship";
+    model: D2Relationship;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        created: string;
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        from: any;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        relationshipType: D2RelationshipTypeSchema;
+        shortName: string;
+        style: D2Style;
+        to: any;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2Relationship, keyof D2Relationship>;
+        $identifiable: Preset<D2Relationship, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Relationship, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Relationship,
+            | "code"
+            | "description"
+            | "lastUpdated"
+            | "formName"
+            | "from"
+            | "id"
+            | "lastUpdatedBy"
+            | "relationshipType"
+            | "created"
+            | "style"
+            | "to"
+        >;
+        $owner: Preset<
+            D2Relationship,
+            | "code"
+            | "description"
+            | "lastUpdated"
+            | "formName"
+            | "from"
+            | "id"
+            | "lastUpdatedBy"
+            | "relationshipType"
+            | "created"
+            | "style"
+            | "to"
+        >;
+    };
+}
+
+export interface D2RelationshipTypeSchema {
+    name: "D2RelationshipType";
+    model: D2RelationshipType;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        bidirectional: boolean;
+        code: Id;
+        created: string;
+        description: string;
+        displayFromToName: string;
+        displayName: string;
+        displayToFromName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        fromConstraint: D2RelationshipConstraint;
+        fromToName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        toConstraint: D2RelationshipConstraint;
+        toFromName: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2RelationshipType, keyof D2RelationshipType>;
+        $identifiable: Preset<D2RelationshipType, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2RelationshipType, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2RelationshipType,
+            | "bidirectional"
+            | "code"
+            | "publicAccess"
+            | "description"
+            | "fromToName"
+            | "lastUpdated"
+            | "translations"
+            | "toConstraint"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "toFromName"
+            | "fromConstraint"
+            | "userAccesses"
+            | "name"
+            | "user"
+        >;
+        $owner: Preset<
+            D2RelationshipType,
+            | "bidirectional"
+            | "code"
+            | "publicAccess"
+            | "description"
+            | "fromToName"
+            | "lastUpdated"
+            | "translations"
+            | "toConstraint"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "toFromName"
+            | "fromConstraint"
+            | "userAccesses"
+            | "name"
+            | "user"
+        >;
+    };
+}
+
+export interface D2ReportSchema {
+    name: "D2Report";
+    model: D2Report;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        cacheStrategy:
+            | "NO_CACHE"
+            | "CACHE_15_MINUTES"
+            | "CACHE_30_MINUTES"
+            | "CACHE_1_HOUR"
+            | "CACHE_6AM_TOMORROW"
+            | "CACHE_TWO_WEEKS"
+            | "RESPECT_SYSTEM_SETTING";
+        code: Id;
+        created: string;
+        designContent: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        relativePeriods: any;
+        reportParams: any;
+        reportTable: D2ReportTableSchema;
+        translations: D2Translation[];
+        type: "JASPER_REPORT_TABLE" | "JASPER_JDBC" | "HTML";
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2Report, keyof D2Report>;
+        $identifiable: Preset<D2Report, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Report, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Report,
+            | "designContent"
+            | "code"
+            | "publicAccess"
+            | "type"
+            | "externalAccess"
+            | "reportTable"
+            | "lastUpdated"
+            | "relativePeriods"
+            | "reportParams"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "userAccesses"
+            | "name"
+            | "cacheStrategy"
+            | "user"
+        >;
+        $owner: Preset<
+            D2Report,
+            | "designContent"
+            | "code"
+            | "publicAccess"
+            | "type"
+            | "externalAccess"
+            | "reportTable"
+            | "lastUpdated"
+            | "relativePeriods"
+            | "reportParams"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "userAccesses"
+            | "name"
+            | "cacheStrategy"
+            | "user"
         >;
     };
 }
@@ -11543,1183 +12371,6 @@ export interface D2ReportTableSchema {
     };
 }
 
-export interface D2ReportSchema {
-    name: "D2Report";
-    model: D2Report;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        cacheStrategy:
-            | "NO_CACHE"
-            | "CACHE_15_MINUTES"
-            | "CACHE_30_MINUTES"
-            | "CACHE_1_HOUR"
-            | "CACHE_6AM_TOMORROW"
-            | "CACHE_TWO_WEEKS"
-            | "RESPECT_SYSTEM_SETTING";
-        code: Id;
-        created: string;
-        designContent: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        relativePeriods: any;
-        reportParams: any;
-        reportTable: D2ReportTableSchema;
-        translations: D2Translation[];
-        type: "JASPER_REPORT_TABLE" | "JASPER_JDBC" | "HTML";
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Report, keyof D2Report>;
-        $identifiable: Preset<D2Report, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Report, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Report,
-            | "designContent"
-            | "code"
-            | "publicAccess"
-            | "type"
-            | "externalAccess"
-            | "reportTable"
-            | "lastUpdated"
-            | "relativePeriods"
-            | "reportParams"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "userAccesses"
-            | "name"
-            | "cacheStrategy"
-            | "user"
-        >;
-        $owner: Preset<
-            D2Report,
-            | "designContent"
-            | "code"
-            | "publicAccess"
-            | "type"
-            | "externalAccess"
-            | "reportTable"
-            | "lastUpdated"
-            | "relativePeriods"
-            | "reportParams"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "userAccesses"
-            | "name"
-            | "cacheStrategy"
-            | "user"
-        >;
-    };
-}
-
-export interface D2ValidationResultSchema {
-    name: "D2ValidationResult";
-    model: D2ValidationResult;
-    fields: {
-        attributeOptionCombo: D2CategoryOptionComboSchema;
-        created: string;
-        dayInPeriod: number;
-        id: string;
-        leftsideValue: number;
-        notificationSent: boolean;
-        organisationUnit: D2OrganisationUnitSchema;
-        period: any;
-        rightsideValue: number;
-        validationRule: D2ValidationRuleSchema;
-    };
-    fieldPresets: {
-        $all: Preset<D2ValidationResult, keyof D2ValidationResult>;
-        $identifiable: Preset<D2ValidationResult, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ValidationResult, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ValidationResult,
-            "created" | "rightsideValue" | "leftsideValue" | "notificationSent"
-        >;
-        $owner: Preset<
-            D2ValidationResult,
-            "created" | "rightsideValue" | "leftsideValue" | "notificationSent"
-        >;
-    };
-}
-
-export interface D2MapSchema {
-    name: "D2Map";
-    model: D2Map;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        basemap: string;
-        code: Id;
-        created: string;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        interpretations: D2InterpretationSchema[];
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        latitude: number;
-        longitude: number;
-        mapViews: D2MapViewSchema[];
-        name: string;
-        publicAccess: string;
-        shortName: string;
-        subscribed: boolean;
-        subscribers: string[];
-        title: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        zoom: number;
-    };
-    fieldPresets: {
-        $all: Preset<D2Map, keyof D2Map>;
-        $identifiable: Preset<D2Map, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Map, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Map,
-            | "favorites"
-            | "code"
-            | "publicAccess"
-            | "basemap"
-            | "latitude"
-            | "description"
-            | "title"
-            | "externalAccess"
-            | "lastUpdated"
-            | "translations"
-            | "mapViews"
-            | "id"
-            | "interpretations"
-            | "longitude"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "subscribers"
-            | "created"
-            | "zoom"
-            | "userAccesses"
-            | "name"
-            | "user"
-        >;
-        $owner: Preset<
-            D2Map,
-            | "favorites"
-            | "code"
-            | "publicAccess"
-            | "basemap"
-            | "latitude"
-            | "description"
-            | "title"
-            | "externalAccess"
-            | "lastUpdated"
-            | "translations"
-            | "mapViews"
-            | "id"
-            | "longitude"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "subscribers"
-            | "created"
-            | "zoom"
-            | "userAccesses"
-            | "name"
-            | "user"
-        >;
-    };
-}
-
-export interface D2PredictorSchema {
-    name: "D2Predictor";
-    model: D2Predictor;
-    fields: {
-        access: D2Access;
-        annualSampleCount: number;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        generator: D2ExpressionSchema;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        organisationUnitLevels: D2OrganisationUnitLevelSchema[];
-        output: D2DataElementSchema;
-        outputCombo: D2CategoryOptionComboSchema;
-        periodType: string;
-        predictorGroups: D2PredictorGroupSchema[];
-        publicAccess: string;
-        sampleSkipTest: D2ExpressionSchema;
-        sequentialSampleCount: number;
-        sequentialSkipCount: number;
-        shortName: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Predictor, keyof D2Predictor>;
-        $identifiable: Preset<D2Predictor, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Predictor, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Predictor,
-            | "outputCombo"
-            | "code"
-            | "description"
-            | "generator"
-            | "organisationUnitLevels"
-            | "output"
-            | "lastUpdated"
-            | "sampleSkipTest"
-            | "id"
-            | "sequentialSampleCount"
-            | "annualSampleCount"
-            | "lastUpdatedBy"
-            | "created"
-            | "sequentialSkipCount"
-            | "predictorGroups"
-            | "periodType"
-            | "name"
-        >;
-        $owner: Preset<
-            D2Predictor,
-            | "outputCombo"
-            | "code"
-            | "description"
-            | "generator"
-            | "organisationUnitLevels"
-            | "output"
-            | "lastUpdated"
-            | "sampleSkipTest"
-            | "id"
-            | "sequentialSampleCount"
-            | "annualSampleCount"
-            | "lastUpdatedBy"
-            | "created"
-            | "sequentialSkipCount"
-            | "periodType"
-            | "name"
-        >;
-    };
-}
-
-export interface D2PredictorGroupSchema {
-    name: "D2PredictorGroup";
-    model: D2PredictorGroup;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        description: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        predictors: D2PredictorSchema[];
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2PredictorGroup, keyof D2PredictorGroup>;
-        $identifiable: Preset<D2PredictorGroup, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2PredictorGroup, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2PredictorGroup,
-            | "predictors"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "description"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2PredictorGroup,
-            | "predictors"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "description"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
-export interface D2DashboardItemSchema {
-    name: "D2DashboardItem";
-    model: D2DashboardItem;
-    fields: {
-        access: D2Access;
-        appKey: string;
-        attributeValues: D2AttributeValueSchema[];
-        chart: D2ChartSchema;
-        code: Id;
-        contentCount: number;
-        created: string;
-        displayName: string;
-        eventChart: D2EventChartSchema;
-        eventReport: D2EventReportSchema;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        height: number;
-        href: string;
-        id: Id;
-        interpretationCount: number;
-        interpretationLikeCount: number;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        map: D2MapSchema;
-        messages: boolean;
-        name: string;
-        publicAccess: string;
-        reportTable: D2ReportTableSchema;
-        reports: D2ReportSchema[];
-        resources: D2DocumentSchema[];
-        shape: "NORMAL" | "DOUBLE_WIDTH" | "FULL_WIDTH";
-        text: string;
-        translations: D2Translation[];
-        type:
-            | "CHART"
-            | "EVENT_CHART"
-            | "MAP"
-            | "REPORT_TABLE"
-            | "EVENT_REPORT"
-            | "USERS"
-            | "REPORTS"
-            | "RESOURCES"
-            | "TEXT"
-            | "MESSAGES"
-            | "APP";
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        users: D2UserSchema[];
-        width: number;
-        x: number;
-        y: number;
-    };
-    fieldPresets: {
-        $all: Preset<D2DashboardItem, keyof D2DashboardItem>;
-        $identifiable: Preset<D2DashboardItem, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2DashboardItem, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2DashboardItem,
-            | "reports"
-            | "code"
-            | "reportTable"
-            | "lastUpdated"
-            | "translations"
-            | "appKey"
-            | "id"
-            | "text"
-            | "map"
-            | "height"
-            | "lastUpdatedBy"
-            | "shape"
-            | "created"
-            | "resources"
-            | "users"
-            | "eventReport"
-            | "eventChart"
-            | "width"
-            | "x"
-            | "messages"
-            | "y"
-            | "chart"
-        >;
-        $owner: Preset<
-            D2DashboardItem,
-            | "reports"
-            | "code"
-            | "reportTable"
-            | "lastUpdated"
-            | "translations"
-            | "appKey"
-            | "id"
-            | "text"
-            | "map"
-            | "height"
-            | "lastUpdatedBy"
-            | "shape"
-            | "created"
-            | "resources"
-            | "users"
-            | "eventReport"
-            | "eventChart"
-            | "width"
-            | "x"
-            | "messages"
-            | "y"
-            | "chart"
-        >;
-    };
-}
-
-export interface D2DashboardSchema {
-    name: "D2Dashboard";
-    model: D2Dashboard;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        dashboardItems: D2DashboardItemSchema[];
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        itemCount: number;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        shortName: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Dashboard, keyof D2Dashboard>;
-        $identifiable: Preset<D2Dashboard, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Dashboard, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Dashboard,
-            | "favorites"
-            | "code"
-            | "publicAccess"
-            | "description"
-            | "externalAccess"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "dashboardItems"
-            | "userAccesses"
-            | "name"
-            | "user"
-        >;
-        $owner: Preset<
-            D2Dashboard,
-            | "favorites"
-            | "code"
-            | "publicAccess"
-            | "description"
-            | "externalAccess"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "dashboardItems"
-            | "userAccesses"
-            | "name"
-            | "user"
-        >;
-    };
-}
-
-export interface D2PushAnalysisSchema {
-    name: "D2PushAnalysis";
-    model: D2PushAnalysis;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        dashboard: D2DashboardSchema;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        message: string;
-        name: string;
-        publicAccess: string;
-        recipientUserGroups: D2UserGroupSchema[];
-        title: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2PushAnalysis, keyof D2PushAnalysis>;
-        $identifiable: Preset<D2PushAnalysis, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2PushAnalysis, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2PushAnalysis,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "recipientUserGroups"
-            | "message"
-            | "title"
-            | "lastUpdated"
-            | "name"
-            | "id"
-            | "dashboard"
-        >;
-        $owner: Preset<
-            D2PushAnalysis,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "recipientUserGroups"
-            | "message"
-            | "title"
-            | "lastUpdated"
-            | "name"
-            | "id"
-            | "dashboard"
-        >;
-    };
-}
-
-export interface D2KeyJsonValueSchema {
-    name: "D2KeyJsonValue";
-    model: D2KeyJsonValue;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        key: string;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        namespace: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        value: string;
-    };
-    fieldPresets: {
-        $all: Preset<D2KeyJsonValue, keyof D2KeyJsonValue>;
-        $identifiable: Preset<D2KeyJsonValue, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2KeyJsonValue, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2KeyJsonValue,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "lastUpdated"
-            | "userAccesses"
-            | "namespace"
-            | "id"
-            | "user"
-            | "key"
-        >;
-        $owner: Preset<
-            D2KeyJsonValue,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "lastUpdated"
-            | "userAccesses"
-            | "namespace"
-            | "id"
-            | "user"
-            | "key"
-        >;
-    };
-}
-
-export interface D2OrganisationUnitGroupSetDimensionSchema {
-    name: "D2OrganisationUnitGroupSetDimension";
-    model: D2OrganisationUnitGroupSetDimension;
-    fields: {
-        organisationUnitGroupSet: D2OrganisationUnitGroupSetSchema;
-        organisationUnitGroups: D2OrganisationUnitGroupSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<
-            D2OrganisationUnitGroupSetDimension,
-            keyof D2OrganisationUnitGroupSetDimension
-        >;
-        $identifiable: Preset<D2OrganisationUnitGroupSetDimension, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OrganisationUnitGroupSetDimension, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2OrganisationUnitGroupSetDimension,
-            "organisationUnitGroupSet" | "organisationUnitGroups"
-        >;
-        $owner: Preset<
-            D2OrganisationUnitGroupSetDimension,
-            "organisationUnitGroupSet" | "organisationUnitGroups"
-        >;
-    };
-}
-
-export interface D2UserCredentialsSchema {
-    name: "D2UserCredentials";
-    model: D2UserCredentials;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        catDimensionConstraints: D2CategorySchema[];
-        code: Id;
-        cogsDimensionConstraints: D2CategoryOptionGroupSetSchema[];
-        created: string;
-        disabled: boolean;
-        displayName: string;
-        externalAccess: boolean;
-        externalAuth: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        invitation: boolean;
-        lastLogin: string;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        ldapId: string;
-        name: string;
-        openId: string;
-        password: string;
-        passwordLastUpdated: string;
-        publicAccess: string;
-        selfRegistered: boolean;
-        translations: D2Translation[];
-        twoFA: boolean;
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        userInfo: D2UserSchema;
-        userRoles: D2UserAuthorityGroupSchema[];
-        username: string;
-    };
-    fieldPresets: {
-        $all: Preset<D2UserCredentials, keyof D2UserCredentials>;
-        $identifiable: Preset<D2UserCredentials, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2UserCredentials, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2UserCredentials,
-            | "lastLogin"
-            | "userInfo"
-            | "code"
-            | "openId"
-            | "externalAuth"
-            | "cogsDimensionConstraints"
-            | "catDimensionConstraints"
-            | "lastUpdated"
-            | "password"
-            | "ldapId"
-            | "disabled"
-            | "id"
-            | "twoFA"
-            | "passwordLastUpdated"
-            | "lastUpdatedBy"
-            | "invitation"
-            | "created"
-            | "selfRegistered"
-            | "userRoles"
-            | "user"
-            | "username"
-        >;
-        $owner: Preset<
-            D2UserCredentials,
-            | "lastLogin"
-            | "userInfo"
-            | "code"
-            | "openId"
-            | "externalAuth"
-            | "cogsDimensionConstraints"
-            | "catDimensionConstraints"
-            | "lastUpdated"
-            | "password"
-            | "ldapId"
-            | "disabled"
-            | "id"
-            | "twoFA"
-            | "passwordLastUpdated"
-            | "lastUpdatedBy"
-            | "invitation"
-            | "created"
-            | "selfRegistered"
-            | "userRoles"
-            | "user"
-            | "username"
-        >;
-    };
-}
-
-export interface D2ProgramStageDataElementSchema {
-    name: "D2ProgramStageDataElement";
-    model: D2ProgramStageDataElement;
-    fields: {
-        access: D2Access;
-        allowFutureDate: boolean;
-        allowProvidedElsewhere: boolean;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        compulsory: boolean;
-        created: string;
-        dataElement: D2DataElementSchema;
-        displayInReports: boolean;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        programStage: D2ProgramStageSchema;
-        publicAccess: string;
-        renderOptionsAsRadio: boolean;
-        renderType: any;
-        skipSynchronization: boolean;
-        sortOrder: number;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramStageDataElement, keyof D2ProgramStageDataElement>;
-        $identifiable: Preset<D2ProgramStageDataElement, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramStageDataElement, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramStageDataElement,
-            | "displayInReports"
-            | "code"
-            | "skipSynchronization"
-            | "lastUpdated"
-            | "renderOptionsAsRadio"
-            | "id"
-            | "allowFutureDate"
-            | "renderType"
-            | "lastUpdatedBy"
-            | "programStage"
-            | "created"
-            | "dataElement"
-            | "compulsory"
-            | "allowProvidedElsewhere"
-            | "sortOrder"
-        >;
-        $owner: Preset<
-            D2ProgramStageDataElement,
-            | "displayInReports"
-            | "code"
-            | "skipSynchronization"
-            | "lastUpdated"
-            | "renderOptionsAsRadio"
-            | "id"
-            | "allowFutureDate"
-            | "renderType"
-            | "lastUpdatedBy"
-            | "programStage"
-            | "created"
-            | "dataElement"
-            | "compulsory"
-            | "allowProvidedElsewhere"
-            | "sortOrder"
-        >;
-    };
-}
-
-export interface D2FileResourceSchema {
-    name: "D2FileResource";
-    model: D2FileResource;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        contentLength: string;
-        contentMd5: string;
-        contentType: string;
-        created: string;
-        displayName: string;
-        domain: "DATA_VALUE" | "PUSH_ANALYSIS" | "DOCUMENT" | "MESSAGE_ATTACHMENT" | "USER_AVATAR";
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        storageStatus: "NONE" | "PENDING" | "FAILED" | "STORED";
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2FileResource, keyof D2FileResource>;
-        $identifiable: Preset<D2FileResource, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2FileResource, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2FileResource,
-            | "contentMd5"
-            | "code"
-            | "lastUpdated"
-            | "id"
-            | "contentType"
-            | "lastUpdatedBy"
-            | "created"
-            | "domain"
-            | "name"
-            | "contentLength"
-            | "user"
-        >;
-        $owner: Preset<
-            D2FileResource,
-            | "contentMd5"
-            | "code"
-            | "lastUpdated"
-            | "id"
-            | "contentType"
-            | "lastUpdatedBy"
-            | "created"
-            | "domain"
-            | "name"
-            | "contentLength"
-            | "user"
-        >;
-    };
-}
-
-export interface D2ProgramInstanceSchema {
-    name: "D2ProgramInstance";
-    model: D2ProgramInstance;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        createdAtClient: string;
-        deleted: boolean;
-        displayName: string;
-        endDate: string;
-        enrollmentDate: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        followup: boolean;
-        href: string;
-        id: Id;
-        incidentDate: string;
-        lastUpdated: string;
-        lastUpdatedAtClient: string;
-        lastUpdatedBy: D2UserSchema;
-        messageConversations: D2MessageConversationSchema[];
-        name: string;
-        organisationUnit: D2OrganisationUnitSchema;
-        program: D2ProgramSchema;
-        programStageInstances: D2ProgramStageInstanceSchema[];
-        publicAccess: string;
-        relationshipItems: any[];
-        status: "ACTIVE" | "COMPLETED" | "CANCELLED";
-        storedBy: string;
-        trackedEntityComments: any[];
-        trackedEntityInstance: D2TrackedEntityInstanceSchema;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramInstance, keyof D2ProgramInstance>;
-        $identifiable: Preset<D2ProgramInstance, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramInstance, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramInstance,
-            | "storedBy"
-            | "endDate"
-            | "organisationUnit"
-            | "enrollmentDate"
-            | "createdAtClient"
-            | "program"
-            | "messageConversations"
-            | "trackedEntityComments"
-            | "lastUpdated"
-            | "relationshipItems"
-            | "id"
-            | "created"
-            | "programStageInstances"
-            | "trackedEntityInstance"
-            | "followup"
-            | "deleted"
-            | "incidentDate"
-            | "status"
-            | "lastUpdatedAtClient"
-        >;
-        $owner: Preset<
-            D2ProgramInstance,
-            | "storedBy"
-            | "endDate"
-            | "organisationUnit"
-            | "enrollmentDate"
-            | "createdAtClient"
-            | "program"
-            | "messageConversations"
-            | "trackedEntityComments"
-            | "lastUpdated"
-            | "id"
-            | "created"
-            | "programStageInstances"
-            | "trackedEntityInstance"
-            | "followup"
-            | "deleted"
-            | "incidentDate"
-            | "status"
-            | "lastUpdatedAtClient"
-        >;
-    };
-}
-
-export interface D2UserAccessSchema {
-    name: "D2UserAccess";
-    model: D2UserAccess;
-    fields: { access: string; displayName: string; id: string; userUid: string };
-    fieldPresets: {
-        $all: Preset<D2UserAccess, keyof D2UserAccess>;
-        $identifiable: Preset<D2UserAccess, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2UserAccess, FieldPresets["nameable"]>;
-        $persisted: Preset<D2UserAccess, "access">;
-        $owner: Preset<D2UserAccess, "access">;
-    };
-}
-
-export interface D2TrackedEntityDataElementDimensionSchema {
-    name: "D2TrackedEntityDataElementDimension";
-    model: D2TrackedEntityDataElementDimension;
-    fields: { dataElement: D2DataElementSchema; filter: string; legendSet: D2LegendSetSchema };
-    fieldPresets: {
-        $all: Preset<
-            D2TrackedEntityDataElementDimension,
-            keyof D2TrackedEntityDataElementDimension
-        >;
-        $identifiable: Preset<D2TrackedEntityDataElementDimension, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2TrackedEntityDataElementDimension, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2TrackedEntityDataElementDimension,
-            "filter" | "legendSet" | "dataElement"
-        >;
-        $owner: Preset<D2TrackedEntityDataElementDimension, "filter" | "legendSet" | "dataElement">;
-    };
-}
-
-export interface D2IconSchema {
-    name: "D2Icon";
-    model: D2Icon;
-    fields: {};
-    fieldPresets: {
-        $all: Preset<D2Icon, keyof D2Icon>;
-        $identifiable: Preset<D2Icon, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Icon, FieldPresets["nameable"]>;
-        $persisted: Preset<D2Icon, never>;
-        $owner: Preset<D2Icon, never>;
-    };
-}
-
-export interface D2DataElementGroupSetDimensionSchema {
-    name: "D2DataElementGroupSetDimension";
-    model: D2DataElementGroupSetDimension;
-    fields: {
-        dataElementGroupSet: D2DataElementGroupSetSchema;
-        dataElementGroups: D2DataElementGroupSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2DataElementGroupSetDimension, keyof D2DataElementGroupSetDimension>;
-        $identifiable: Preset<D2DataElementGroupSetDimension, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2DataElementGroupSetDimension, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2DataElementGroupSetDimension,
-            "dataElementGroups" | "dataElementGroupSet"
-        >;
-        $owner: Preset<D2DataElementGroupSetDimension, "dataElementGroups" | "dataElementGroupSet">;
-    };
-}
-
-export interface D2ProgramTrackedEntityAttributeSchema {
-    name: "D2ProgramTrackedEntityAttribute";
-    model: D2ProgramTrackedEntityAttribute;
-    fields: {
-        access: D2Access;
-        allowFutureDate: boolean;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        displayInList: boolean;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        mandatory: boolean;
-        name: string;
-        program: D2ProgramSchema;
-        programTrackedEntityAttributeGroups: D2ProgramTrackedEntityAttributeGroupSchema[];
-        publicAccess: string;
-        renderOptionsAsRadio: boolean;
-        renderType: any;
-        searchable: boolean;
-        sortOrder: number;
-        trackedEntityAttribute: D2TrackedEntityAttributeSchema;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        valueType:
-            | "TEXT"
-            | "LONG_TEXT"
-            | "LETTER"
-            | "PHONE_NUMBER"
-            | "EMAIL"
-            | "BOOLEAN"
-            | "TRUE_ONLY"
-            | "DATE"
-            | "DATETIME"
-            | "TIME"
-            | "NUMBER"
-            | "UNIT_INTERVAL"
-            | "PERCENTAGE"
-            | "INTEGER"
-            | "INTEGER_POSITIVE"
-            | "INTEGER_NEGATIVE"
-            | "INTEGER_ZERO_OR_POSITIVE"
-            | "TRACKER_ASSOCIATE"
-            | "USERNAME"
-            | "COORDINATE"
-            | "ORGANISATION_UNIT"
-            | "AGE"
-            | "URL"
-            | "FILE_RESOURCE"
-            | "IMAGE";
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramTrackedEntityAttribute, keyof D2ProgramTrackedEntityAttribute>;
-        $identifiable: Preset<D2ProgramTrackedEntityAttribute, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramTrackedEntityAttribute, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramTrackedEntityAttribute,
-            | "code"
-            | "programTrackedEntityAttributeGroups"
-            | "program"
-            | "mandatory"
-            | "trackedEntityAttribute"
-            | "lastUpdated"
-            | "renderOptionsAsRadio"
-            | "id"
-            | "allowFutureDate"
-            | "renderType"
-            | "lastUpdatedBy"
-            | "created"
-            | "searchable"
-            | "displayInList"
-            | "sortOrder"
-        >;
-        $owner: Preset<
-            D2ProgramTrackedEntityAttribute,
-            | "code"
-            | "programTrackedEntityAttributeGroups"
-            | "program"
-            | "mandatory"
-            | "trackedEntityAttribute"
-            | "lastUpdated"
-            | "renderOptionsAsRadio"
-            | "id"
-            | "allowFutureDate"
-            | "renderType"
-            | "lastUpdatedBy"
-            | "created"
-            | "searchable"
-            | "displayInList"
-            | "sortOrder"
-        >;
-    };
-}
-
 export interface D2ReportingRateSchema {
     name: "D2ReportingRate";
     model: D2ReportingRate;
@@ -12797,27 +12448,19 @@ export interface D2ReportingRateSchema {
     };
 }
 
-export interface D2UserGroupAccessSchema {
-    name: "D2UserGroupAccess";
-    model: D2UserGroupAccess;
-    fields: { access: string; displayName: string; id: string; userGroupUid: string };
-    fieldPresets: {
-        $all: Preset<D2UserGroupAccess, keyof D2UserGroupAccess>;
-        $identifiable: Preset<D2UserGroupAccess, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2UserGroupAccess, FieldPresets["nameable"]>;
-        $persisted: Preset<D2UserGroupAccess, "access">;
-        $owner: Preset<D2UserGroupAccess, "access">;
-    };
-}
-
-export interface D2ProgramStageInstanceSchema {
-    name: "D2ProgramStageInstance";
-    model: D2ProgramStageInstance;
+export interface D2SMSCommandSchema {
+    name: "D2SMSCommand";
+    model: D2SMSCommand;
     fields: {
         access: D2Access;
         attributeValues: D2AttributeValueSchema[];
         code: Id;
+        codeValueSeparator: string;
+        completenessMethod: "ALL_DATAVALUE" | "AT_LEAST_ONE_DATAVALUE" | "DO_NOT_MARK_COMPLETE";
         created: string;
+        currentPeriodUsedForReporting: boolean;
+        dataset: D2DataSetSchema;
+        defaultMessage: string;
         displayName: string;
         externalAccess: boolean;
         favorite: boolean;
@@ -12826,284 +12469,444 @@ export interface D2ProgramStageInstanceSchema {
         id: Id;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
+        moreThanOneOrgUnitMessage: string;
         name: string;
+        noUserMessage: string;
+        parserType:
+            | "KEY_VALUE_PARSER"
+            | "J2ME_PARSER"
+            | "ALERT_PARSER"
+            | "UNREGISTERED_PARSER"
+            | "TRACKED_ENTITY_REGISTRATION_PARSER"
+            | "PROGRAM_STAGE_DATAENTRY_PARSER"
+            | "EVENT_REGISTRATION_PARSER";
+        program: D2ProgramSchema;
+        programStage: D2ProgramStageSchema;
         publicAccess: string;
+        receivedMessage: string;
+        separator: string;
+        smsCodes: any[];
+        specialCharacters: any[];
+        successMessage: string;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
+        userGroup: D2UserGroupSchema;
         userGroupAccesses: D2UserGroupAccessSchema[];
+        wrongFormatMessage: string;
     };
     fieldPresets: {
-        $all: Preset<D2ProgramStageInstance, keyof D2ProgramStageInstance>;
-        $identifiable: Preset<D2ProgramStageInstance, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramStageInstance, FieldPresets["nameable"]>;
-        $persisted: Preset<D2ProgramStageInstance, "code" | "created" | "lastUpdated" | "id">;
-        $owner: Preset<D2ProgramStageInstance, "code" | "created" | "lastUpdated" | "id">;
-    };
-}
-
-export interface D2InterpretationCommentSchema {
-    name: "D2InterpretationComment";
-    model: D2InterpretationComment;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        mentions: any[];
-        name: string;
-        publicAccess: string;
-        text: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2InterpretationComment, keyof D2InterpretationComment>;
-        $identifiable: Preset<D2InterpretationComment, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2InterpretationComment, FieldPresets["nameable"]>;
+        $all: Preset<D2SMSCommand, keyof D2SMSCommand>;
+        $identifiable: Preset<D2SMSCommand, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2SMSCommand, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2InterpretationComment,
-            "created" | "lastUpdated" | "mentions" | "text" | "id" | "user"
+            D2SMSCommand,
+            | "moreThanOneOrgUnitMessage"
+            | "smsCodes"
+            | "specialCharacters"
+            | "currentPeriodUsedForReporting"
+            | "program"
+            | "noUserMessage"
+            | "lastUpdated"
+            | "receivedMessage"
+            | "defaultMessage"
+            | "id"
+            | "userGroup"
+            | "programStage"
+            | "completenessMethod"
+            | "created"
+            | "wrongFormatMessage"
+            | "separator"
+            | "successMessage"
+            | "codeValueSeparator"
+            | "parserType"
+            | "name"
+            | "dataset"
         >;
         $owner: Preset<
-            D2InterpretationComment,
-            "created" | "lastUpdated" | "mentions" | "text" | "id" | "user"
+            D2SMSCommand,
+            | "moreThanOneOrgUnitMessage"
+            | "smsCodes"
+            | "specialCharacters"
+            | "currentPeriodUsedForReporting"
+            | "program"
+            | "noUserMessage"
+            | "lastUpdated"
+            | "receivedMessage"
+            | "defaultMessage"
+            | "id"
+            | "userGroup"
+            | "programStage"
+            | "completenessMethod"
+            | "created"
+            | "wrongFormatMessage"
+            | "separator"
+            | "successMessage"
+            | "codeValueSeparator"
+            | "parserType"
+            | "name"
+            | "dataset"
         >;
     };
 }
 
-export interface D2MinMaxDataElementSchema {
-    name: "D2MinMaxDataElement";
-    model: D2MinMaxDataElement;
+export interface D2SectionSchema {
+    name: "D2Section";
+    model: D2Section;
     fields: {
-        dataElement: D2DataElementSchema;
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        categoryCombos: D2CategoryComboSchema[];
+        code: Id;
+        created: string;
+        dataElements: D2DataElementSchema[];
+        dataSet: D2DataSetSchema;
+        description: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        greyedFields: D2DataElementOperandSchema[];
+        href: string;
+        id: Id;
+        indicators: D2IndicatorSchema[];
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        showColumnTotals: boolean;
+        showRowTotals: boolean;
+        sortOrder: number;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2Section, keyof D2Section>;
+        $identifiable: Preset<D2Section, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Section, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Section,
+            | "code"
+            | "greyedFields"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "dataSet"
+            | "dataElements"
+            | "showColumnTotals"
+            | "lastUpdatedBy"
+            | "created"
+            | "attributeValues"
+            | "indicators"
+            | "sortOrder"
+            | "name"
+            | "showRowTotals"
+        >;
+        $owner: Preset<
+            D2Section,
+            | "code"
+            | "greyedFields"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "dataSet"
+            | "dataElements"
+            | "showColumnTotals"
+            | "lastUpdatedBy"
+            | "created"
+            | "attributeValues"
+            | "indicators"
+            | "sortOrder"
+            | "name"
+            | "showRowTotals"
+        >;
+    };
+}
+
+export interface D2SqlViewSchema {
+    name: "D2SqlView";
+    model: D2SqlView;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        cacheStrategy:
+            | "NO_CACHE"
+            | "CACHE_15_MINUTES"
+            | "CACHE_30_MINUTES"
+            | "CACHE_1_HOUR"
+            | "CACHE_6AM_TOMORROW"
+            | "CACHE_TWO_WEEKS"
+            | "RESPECT_SYSTEM_SETTING";
+        code: Id;
+        created: string;
+        description: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        sqlQuery: string;
+        translations: D2Translation[];
+        type: "VIEW" | "MATERIALIZED_VIEW" | "QUERY";
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2SqlView, keyof D2SqlView>;
+        $identifiable: Preset<D2SqlView, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2SqlView, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2SqlView,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "sqlQuery"
+            | "created"
+            | "publicAccess"
+            | "attributeValues"
+            | "description"
+            | "type"
+            | "externalAccess"
+            | "lastUpdated"
+            | "userAccesses"
+            | "name"
+            | "cacheStrategy"
+            | "id"
+            | "user"
+        >;
+        $owner: Preset<
+            D2SqlView,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "sqlQuery"
+            | "created"
+            | "publicAccess"
+            | "attributeValues"
+            | "description"
+            | "type"
+            | "externalAccess"
+            | "lastUpdated"
+            | "userAccesses"
+            | "name"
+            | "cacheStrategy"
+            | "id"
+            | "user"
+        >;
+    };
+}
+
+export interface D2TrackedEntityAttributeSchema {
+    name: "D2TrackedEntityAttribute";
+    model: D2TrackedEntityAttribute;
+    fields: {
+        access: D2Access;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        confidential: boolean;
+        created: string;
+        description: string;
+        dimensionItem: string;
+        dimensionItemType:
+            | "DATA_ELEMENT"
+            | "DATA_ELEMENT_OPERAND"
+            | "INDICATOR"
+            | "REPORTING_RATE"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION"
+            | "OPTION_GROUP"
+            | "DATA_ELEMENT_GROUP"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY_OPTION_GROUP";
+        displayDescription: string;
+        displayFormName: string;
+        displayInListNoProgram: boolean;
+        displayName: string;
+        displayOnVisitSchedule: boolean;
+        displayShortName: string;
+        expression: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        fieldMask: string;
+        formName: string;
         generated: boolean;
-        max: number;
-        min: number;
-        optionCombo: D2CategoryOptionComboSchema;
-        source: D2OrganisationUnitSchema;
-    };
-    fieldPresets: {
-        $all: Preset<D2MinMaxDataElement, keyof D2MinMaxDataElement>;
-        $identifiable: Preset<D2MinMaxDataElement, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2MinMaxDataElement, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2MinMaxDataElement,
-            "min" | "generated" | "max" | "dataElement" | "source" | "optionCombo"
-        >;
-        $owner: Preset<
-            D2MinMaxDataElement,
-            "min" | "generated" | "max" | "dataElement" | "source" | "optionCombo"
-        >;
-    };
-}
-
-export interface D2MessageConversationSchema {
-    name: "D2MessageConversation";
-    model: D2MessageConversation;
-    fields: {
-        access: D2Access;
-        assignee: D2UserSchema;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        followUp: boolean;
         href: string;
         id: Id;
-        lastMessage: string;
-        lastSender: D2UserSchema;
-        lastSenderFirstname: string;
-        lastSenderSurname: string;
+        inherit: boolean;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
-        messageCount: number;
-        messageType: "PRIVATE" | "SYSTEM" | "VALIDATION_RESULT" | "TICKET";
-        messages: any[];
+        legendSet: D2LegendSetSchema;
+        legendSets: D2LegendSetSchema[];
         name: string;
-        priority: "NONE" | "LOW" | "MEDIUM" | "HIGH";
+        optionSet: D2OptionSetSchema;
+        optionSetValue: boolean;
+        orgunitScope: boolean;
+        pattern: string;
+        programScope: boolean;
         publicAccess: string;
-        read: boolean;
-        status: "NONE" | "OPEN" | "PENDING" | "INVALID" | "SOLVED";
-        subject: string;
+        shortName: string;
+        skipSynchronization: boolean;
+        sortOrderInListNoProgram: number;
+        sortOrderInVisitSchedule: number;
+        style: D2Style;
         translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userFirstname: string;
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        userMessages: any[];
-        userSurname: string;
-    };
-    fieldPresets: {
-        $all: Preset<D2MessageConversation, keyof D2MessageConversation>;
-        $identifiable: Preset<D2MessageConversation, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2MessageConversation, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2MessageConversation,
-            | "messageCount"
-            | "subject"
-            | "lastUpdated"
-            | "messageType"
-            | "userMessages"
-            | "id"
-            | "lastSender"
-            | "created"
-            | "lastMessage"
-            | "priority"
-            | "messages"
-            | "assignee"
-            | "user"
-            | "status"
-        >;
-        $owner: Preset<
-            D2MessageConversation,
-            | "messageCount"
-            | "subject"
-            | "lastUpdated"
-            | "messageType"
-            | "userMessages"
-            | "id"
-            | "lastSender"
-            | "created"
-            | "lastMessage"
-            | "priority"
-            | "messages"
-            | "assignee"
-            | "user"
-            | "status"
-        >;
-    };
-}
-
-export interface D2AnalyticsPeriodBoundarySchema {
-    name: "D2AnalyticsPeriodBoundary";
-    model: D2AnalyticsPeriodBoundary;
-    fields: {
-        access: D2Access;
-        analyticsPeriodBoundaryType:
-            | "BEFORE_START_OF_REPORTING_PERIOD"
-            | "BEFORE_END_OF_REPORTING_PERIOD"
-            | "AFTER_START_OF_REPORTING_PERIOD"
-            | "AFTER_END_OF_REPORTING_PERIOD";
-        attributeValues: D2AttributeValueSchema[];
-        boundaryTarget: string;
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        offsetPeriodType: string;
-        offsetPeriods: number;
-        publicAccess: string;
-        translations: D2Translation[];
+        unique: boolean;
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
+        valueType:
+            | "TEXT"
+            | "LONG_TEXT"
+            | "LETTER"
+            | "PHONE_NUMBER"
+            | "EMAIL"
+            | "BOOLEAN"
+            | "TRUE_ONLY"
+            | "DATE"
+            | "DATETIME"
+            | "TIME"
+            | "NUMBER"
+            | "UNIT_INTERVAL"
+            | "PERCENTAGE"
+            | "INTEGER"
+            | "INTEGER_POSITIVE"
+            | "INTEGER_NEGATIVE"
+            | "INTEGER_ZERO_OR_POSITIVE"
+            | "TRACKER_ASSOCIATE"
+            | "USERNAME"
+            | "COORDINATE"
+            | "ORGANISATION_UNIT"
+            | "AGE"
+            | "URL"
+            | "FILE_RESOURCE"
+            | "IMAGE";
     };
     fieldPresets: {
-        $all: Preset<D2AnalyticsPeriodBoundary, keyof D2AnalyticsPeriodBoundary>;
-        $identifiable: Preset<D2AnalyticsPeriodBoundary, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2AnalyticsPeriodBoundary, FieldPresets["nameable"]>;
+        $all: Preset<D2TrackedEntityAttribute, keyof D2TrackedEntityAttribute>;
+        $identifiable: Preset<D2TrackedEntityAttribute, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2TrackedEntityAttribute, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2AnalyticsPeriodBoundary,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
+            D2TrackedEntityAttribute,
+            | "programScope"
+            | "publicAccess"
             | "lastUpdated"
-            | "offsetPeriodType"
+            | "generated"
+            | "translations"
+            | "valueType"
             | "id"
-            | "analyticsPeriodBoundaryType"
-            | "boundaryTarget"
-            | "offsetPeriods"
-        >;
-        $owner: Preset<
-            D2AnalyticsPeriodBoundary,
+            | "confidential"
             | "lastUpdatedBy"
-            | "code"
+            | "userGroupAccesses"
             | "created"
-            | "lastUpdated"
-            | "offsetPeriodType"
-            | "id"
-            | "analyticsPeriodBoundaryType"
-            | "boundaryTarget"
-            | "offsetPeriods"
-        >;
-    };
-}
-
-export interface D2MetadataVersionSchema {
-    name: "D2MetadataVersion";
-    model: D2MetadataVersion;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        hashCode: string;
-        href: string;
-        id: Id;
-        importDate: string;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        type: "BEST_EFFORT" | "ATOMIC";
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2MetadataVersion, keyof D2MetadataVersion>;
-        $identifiable: Preset<D2MetadataVersion, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2MetadataVersion, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2MetadataVersion,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "type"
-            | "lastUpdated"
-            | "importDate"
-            | "hashCode"
+            | "attributeValues"
+            | "unique"
+            | "userAccesses"
             | "name"
-            | "id"
+            | "legendSets"
+            | "style"
+            | "shortName"
+            | "aggregationType"
+            | "code"
+            | "displayInListNoProgram"
+            | "pattern"
+            | "description"
+            | "skipSynchronization"
+            | "sortOrderInListNoProgram"
+            | "optionSet"
+            | "displayOnVisitSchedule"
+            | "formName"
+            | "sortOrderInVisitSchedule"
+            | "orgunitScope"
+            | "fieldMask"
+            | "expression"
+            | "inherit"
+            | "user"
         >;
         $owner: Preset<
-            D2MetadataVersion,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "type"
+            D2TrackedEntityAttribute,
+            | "programScope"
+            | "publicAccess"
             | "lastUpdated"
-            | "importDate"
-            | "hashCode"
-            | "name"
+            | "generated"
+            | "translations"
+            | "valueType"
             | "id"
+            | "confidential"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "unique"
+            | "userAccesses"
+            | "name"
+            | "legendSets"
+            | "style"
+            | "shortName"
+            | "aggregationType"
+            | "code"
+            | "displayInListNoProgram"
+            | "pattern"
+            | "description"
+            | "skipSynchronization"
+            | "sortOrderInListNoProgram"
+            | "optionSet"
+            | "displayOnVisitSchedule"
+            | "formName"
+            | "sortOrderInVisitSchedule"
+            | "orgunitScope"
+            | "fieldMask"
+            | "expression"
+            | "inherit"
+            | "user"
         >;
+    };
+}
+
+export interface D2TrackedEntityDataElementDimensionSchema {
+    name: "D2TrackedEntityDataElementDimension";
+    model: D2TrackedEntityDataElementDimension;
+    fields: { dataElement: D2DataElementSchema; filter: string; legendSet: D2LegendSetSchema };
+    fieldPresets: {
+        $all: Preset<
+            D2TrackedEntityDataElementDimension,
+            keyof D2TrackedEntityDataElementDimension
+        >;
+        $identifiable: Preset<D2TrackedEntityDataElementDimension, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2TrackedEntityDataElementDimension, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2TrackedEntityDataElementDimension,
+            "filter" | "legendSet" | "dataElement"
+        >;
+        $owner: Preset<D2TrackedEntityDataElementDimension, "filter" | "legendSet" | "dataElement">;
     };
 }
 
@@ -13254,145 +13057,6 @@ export interface D2TrackedEntityInstanceFilterSchema {
     };
 }
 
-export interface D2ProgramStageInstanceFilterSchema {
-    name: "D2ProgramStageInstanceFilter";
-    model: D2ProgramStageInstanceFilter;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        description: string;
-        displayName: string;
-        eventQueryCriteria: any;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        program: Id;
-        programStage: Id;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramStageInstanceFilter, keyof D2ProgramStageInstanceFilter>;
-        $identifiable: Preset<D2ProgramStageInstanceFilter, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramStageInstanceFilter, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramStageInstanceFilter,
-            | "lastUpdatedBy"
-            | "programStage"
-            | "eventQueryCriteria"
-            | "userGroupAccesses"
-            | "created"
-            | "publicAccess"
-            | "description"
-            | "program"
-            | "lastUpdated"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2ProgramStageInstanceFilter,
-            | "lastUpdatedBy"
-            | "programStage"
-            | "eventQueryCriteria"
-            | "userGroupAccesses"
-            | "created"
-            | "publicAccess"
-            | "description"
-            | "program"
-            | "lastUpdated"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
-export interface D2DataElementOperandSchema {
-    name: "D2DataElementOperand";
-    model: D2DataElementOperand;
-    fields: {
-        access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
-        attributeOptionCombo: D2CategoryOptionComboSchema;
-        attributeValues: D2AttributeValueSchema[];
-        categoryOptionCombo: D2CategoryOptionComboSchema;
-        code: Id;
-        created: string;
-        dataElement: D2DataElementSchema;
-        description: string;
-        dimensionItem: string;
-        dimensionItemType:
-            | "DATA_ELEMENT"
-            | "DATA_ELEMENT_OPERAND"
-            | "INDICATOR"
-            | "REPORTING_RATE"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION"
-            | "OPTION_GROUP"
-            | "DATA_ELEMENT_GROUP"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY_OPTION_GROUP";
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        legendSet: D2LegendSetSchema;
-        legendSets: D2LegendSetSchema[];
-        name: string;
-        publicAccess: string;
-        shortName: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2DataElementOperand, keyof D2DataElementOperand>;
-        $identifiable: Preset<D2DataElementOperand, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2DataElementOperand, FieldPresets["nameable"]>;
-        $persisted: Preset<D2DataElementOperand, "categoryOptionCombo" | "dataElement">;
-        $owner: Preset<D2DataElementOperand, "categoryOptionCombo" | "dataElement">;
-    };
-}
-
 export interface D2TrackedEntityProgramIndicatorDimensionSchema {
     name: "D2TrackedEntityProgramIndicatorDimension";
     model: D2TrackedEntityProgramIndicatorDimension;
@@ -13422,136 +13086,16 @@ export interface D2TrackedEntityProgramIndicatorDimensionSchema {
     };
 }
 
-export interface D2InterpretationSchema {
-    name: "D2Interpretation";
-    model: D2Interpretation;
+export interface D2TrackedEntityTypeSchema {
+    name: "D2TrackedEntityType";
+    model: D2TrackedEntityType;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        chart: D2ChartSchema;
-        code: Id;
-        comments: D2InterpretationCommentSchema[];
-        created: string;
-        dataSet: D2DataSetSchema;
-        displayName: string;
-        eventChart: D2EventChartSchema;
-        eventReport: D2EventReportSchema;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        likedBy: D2UserSchema[];
-        likes: number;
-        map: D2MapSchema;
-        mentions: any[];
-        name: string;
-        organisationUnit: D2OrganisationUnitSchema;
-        period: any;
-        publicAccess: string;
-        reportTable: D2ReportTableSchema;
-        text: string;
-        translations: D2Translation[];
-        type: "REPORT_TABLE" | "CHART" | "MAP" | "EVENT_REPORT" | "EVENT_CHART" | "DATASET_REPORT";
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Interpretation, keyof D2Interpretation>;
-        $identifiable: Preset<D2Interpretation, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Interpretation, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Interpretation,
-            | "likedBy"
-            | "organisationUnit"
-            | "publicAccess"
-            | "reportTable"
-            | "lastUpdated"
-            | "id"
-            | "text"
-            | "map"
-            | "dataSet"
-            | "likes"
-            | "period"
-            | "userGroupAccesses"
-            | "comments"
-            | "created"
-            | "eventReport"
-            | "userAccesses"
-            | "mentions"
-            | "eventChart"
-            | "user"
-            | "chart"
-        >;
-        $owner: Preset<
-            D2Interpretation,
-            | "likedBy"
-            | "organisationUnit"
-            | "publicAccess"
-            | "reportTable"
-            | "lastUpdated"
-            | "id"
-            | "text"
-            | "map"
-            | "dataSet"
-            | "likes"
-            | "period"
-            | "userGroupAccesses"
-            | "comments"
-            | "created"
-            | "eventReport"
-            | "userAccesses"
-            | "mentions"
-            | "eventChart"
-            | "user"
-            | "chart"
-        >;
-    };
-}
-
-export interface D2ProgramDataElementDimensionItemSchema {
-    name: "D2ProgramDataElementDimensionItem";
-    model: D2ProgramDataElementDimensionItem;
-    fields: {
-        access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
+        allowAuditLog: boolean;
         attributeValues: D2AttributeValueSchema[];
         code: Id;
         created: string;
-        dataElement: D2DataElementSchema;
         description: string;
-        dimensionItem: string;
-        dimensionItemType:
-            | "DATA_ELEMENT"
-            | "DATA_ELEMENT_OPERAND"
-            | "INDICATOR"
-            | "REPORTING_RATE"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION"
-            | "OPTION_GROUP"
-            | "DATA_ELEMENT_GROUP"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY_OPTION_GROUP";
         displayDescription: string;
         displayFormName: string;
         displayName: string;
@@ -13559,17 +13103,101 @@ export interface D2ProgramDataElementDimensionItemSchema {
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
+        featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
         formName: string;
         href: string;
         id: Id;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
-        legendSet: D2LegendSetSchema;
-        legendSets: D2LegendSetSchema[];
+        maxTeiCountToReturn: number;
+        minAttributesRequiredToSearch: number;
         name: string;
-        program: D2ProgramSchema;
         publicAccess: string;
         shortName: string;
+        style: D2Style;
+        trackedEntityTypeAttributes: D2TrackedEntityTypeAttributeSchema[];
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2TrackedEntityType, keyof D2TrackedEntityType>;
+        $identifiable: Preset<D2TrackedEntityType, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2TrackedEntityType, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2TrackedEntityType,
+            | "code"
+            | "publicAccess"
+            | "trackedEntityTypeAttributes"
+            | "description"
+            | "lastUpdated"
+            | "allowAuditLog"
+            | "translations"
+            | "formName"
+            | "featureType"
+            | "minAttributesRequiredToSearch"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "maxTeiCountToReturn"
+            | "userAccesses"
+            | "name"
+            | "style"
+            | "user"
+        >;
+        $owner: Preset<
+            D2TrackedEntityType,
+            | "code"
+            | "publicAccess"
+            | "trackedEntityTypeAttributes"
+            | "description"
+            | "lastUpdated"
+            | "allowAuditLog"
+            | "translations"
+            | "formName"
+            | "featureType"
+            | "minAttributesRequiredToSearch"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "maxTeiCountToReturn"
+            | "userAccesses"
+            | "name"
+            | "style"
+            | "user"
+        >;
+    };
+}
+
+export interface D2TrackedEntityTypeAttributeSchema {
+    name: "D2TrackedEntityTypeAttribute";
+    model: D2TrackedEntityTypeAttribute;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        created: string;
+        displayInList: boolean;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        mandatory: boolean;
+        name: string;
+        publicAccess: string;
+        searchable: boolean;
+        trackedEntityAttribute: D2TrackedEntityAttributeSchema;
+        trackedEntityType: D2TrackedEntityTypeSchema;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
@@ -13602,53 +13230,184 @@ export interface D2ProgramDataElementDimensionItemSchema {
             | "IMAGE";
     };
     fieldPresets: {
-        $all: Preset<D2ProgramDataElementDimensionItem, keyof D2ProgramDataElementDimensionItem>;
-        $identifiable: Preset<D2ProgramDataElementDimensionItem, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramDataElementDimensionItem, FieldPresets["nameable"]>;
-        $persisted: Preset<D2ProgramDataElementDimensionItem, never>;
-        $owner: Preset<D2ProgramDataElementDimensionItem, never>;
+        $all: Preset<D2TrackedEntityTypeAttribute, keyof D2TrackedEntityTypeAttribute>;
+        $identifiable: Preset<D2TrackedEntityTypeAttribute, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2TrackedEntityTypeAttribute, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2TrackedEntityTypeAttribute,
+            | "code"
+            | "mandatory"
+            | "trackedEntityAttribute"
+            | "lastUpdated"
+            | "id"
+            | "lastUpdatedBy"
+            | "created"
+            | "searchable"
+            | "displayInList"
+            | "trackedEntityType"
+        >;
+        $owner: Preset<
+            D2TrackedEntityTypeAttribute,
+            | "code"
+            | "mandatory"
+            | "trackedEntityAttribute"
+            | "lastUpdated"
+            | "id"
+            | "lastUpdatedBy"
+            | "created"
+            | "searchable"
+            | "displayInList"
+            | "trackedEntityType"
+        >;
     };
 }
 
-export interface D2DataInputPeriodSchema {
-    name: "D2DataInputPeriod";
-    model: D2DataInputPeriod;
-    fields: { closingDate: string; openingDate: string; period: any };
-    fieldPresets: {
-        $all: Preset<D2DataInputPeriod, keyof D2DataInputPeriod>;
-        $identifiable: Preset<D2DataInputPeriod, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2DataInputPeriod, FieldPresets["nameable"]>;
-        $persisted: Preset<D2DataInputPeriod, "period" | "closingDate" | "openingDate">;
-        $owner: Preset<D2DataInputPeriod, "period" | "closingDate" | "openingDate">;
-    };
-}
-
-export interface D2DataSetElementSchema {
-    name: "D2DataSetElement";
-    model: D2DataSetElement;
-    fields: {
-        categoryCombo: D2CategoryComboSchema;
-        dataElement: D2DataElementSchema;
-        dataSet: D2DataSetSchema;
-    };
-    fieldPresets: {
-        $all: Preset<D2DataSetElement, keyof D2DataSetElement>;
-        $identifiable: Preset<D2DataSetElement, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2DataSetElement, FieldPresets["nameable"]>;
-        $persisted: Preset<D2DataSetElement, "dataElement" | "categoryCombo" | "dataSet">;
-        $owner: Preset<D2DataSetElement, "dataElement" | "categoryCombo" | "dataSet">;
-    };
-}
-
-export interface D2ColorSchema {
-    name: "D2Color";
-    model: D2Color;
+export interface D2UserSchema {
+    name: "D2User";
+    model: D2User;
     fields: {
         access: D2Access;
         attributeValues: D2AttributeValueSchema[];
+        avatar: D2FileResourceSchema;
+        birthday: string;
         code: Id;
-        color: string;
         created: string;
+        dataViewOrganisationUnits: D2OrganisationUnitSchema[];
+        displayName: string;
+        education: string;
+        email: string;
+        employer: string;
+        externalAccess: boolean;
+        facebookMessenger: string;
+        favorite: boolean;
+        favorites: string[];
+        firstName: string;
+        gender: string;
+        href: string;
+        id: Id;
+        interests: string;
+        introduction: string;
+        jobTitle: string;
+        languages: string;
+        lastCheckedInterpretations: string;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        nationality: string;
+        organisationUnits: D2OrganisationUnitSchema[];
+        phoneNumber: string;
+        publicAccess: string;
+        skype: string;
+        surname: string;
+        teiSearchOrganisationUnits: D2OrganisationUnitSchema[];
+        telegram: string;
+        translations: D2Translation[];
+        twitter: string;
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userCredentials: D2UserCredentialsSchema;
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        userGroups: D2UserGroupSchema[];
+        welcomeMessage: string;
+        whatsApp: string;
+    };
+    fieldPresets: {
+        $all: Preset<D2User, keyof D2User>;
+        $identifiable: Preset<D2User, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2User, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2User,
+            | "birthday"
+            | "code"
+            | "education"
+            | "gender"
+            | "jobTitle"
+            | "skype"
+            | "lastUpdated"
+            | "teiSearchOrganisationUnits"
+            | "twitter"
+            | "surname"
+            | "employer"
+            | "id"
+            | "organisationUnits"
+            | "facebookMessenger"
+            | "introduction"
+            | "email"
+            | "dataViewOrganisationUnits"
+            | "whatsApp"
+            | "languages"
+            | "created"
+            | "welcomeMessage"
+            | "userCredentials"
+            | "attributeValues"
+            | "telegram"
+            | "avatar"
+            | "lastCheckedInterpretations"
+            | "userGroups"
+            | "firstName"
+            | "phoneNumber"
+            | "nationality"
+            | "interests"
+        >;
+        $owner: Preset<
+            D2User,
+            | "birthday"
+            | "code"
+            | "education"
+            | "gender"
+            | "jobTitle"
+            | "skype"
+            | "lastUpdated"
+            | "teiSearchOrganisationUnits"
+            | "twitter"
+            | "surname"
+            | "employer"
+            | "id"
+            | "organisationUnits"
+            | "facebookMessenger"
+            | "introduction"
+            | "email"
+            | "dataViewOrganisationUnits"
+            | "whatsApp"
+            | "languages"
+            | "created"
+            | "welcomeMessage"
+            | "userCredentials"
+            | "attributeValues"
+            | "telegram"
+            | "avatar"
+            | "lastCheckedInterpretations"
+            | "firstName"
+            | "phoneNumber"
+            | "nationality"
+            | "interests"
+        >;
+    };
+}
+
+export interface D2UserAccessSchema {
+    name: "D2UserAccess";
+    model: D2UserAccess;
+    fields: { access: string; displayName: string; id: string; userUid: string };
+    fieldPresets: {
+        $all: Preset<D2UserAccess, keyof D2UserAccess>;
+        $identifiable: Preset<D2UserAccess, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2UserAccess, FieldPresets["nameable"]>;
+        $persisted: Preset<D2UserAccess, "access">;
+        $owner: Preset<D2UserAccess, "access">;
+    };
+}
+
+export interface D2UserAuthorityGroupSchema {
+    name: "D2UserAuthorityGroup";
+    model: D2UserAuthorityGroup;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        authorities: string[];
+        code: Id;
+        created: string;
+        description: string;
         displayName: string;
         externalAccess: boolean;
         favorite: boolean;
@@ -13663,125 +13422,325 @@ export interface D2ColorSchema {
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
+        users: D2UserSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2Color, keyof D2Color>;
-        $identifiable: Preset<D2Color, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Color, FieldPresets["nameable"]>;
+        $all: Preset<D2UserAuthorityGroup, keyof D2UserAuthorityGroup>;
+        $identifiable: Preset<D2UserAuthorityGroup, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2UserAuthorityGroup, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2Color,
+            D2UserAuthorityGroup,
             | "lastUpdatedBy"
+            | "userGroupAccesses"
             | "code"
-            | "color"
             | "created"
+            | "publicAccess"
+            | "description"
+            | "authorities"
             | "lastUpdated"
             | "translations"
+            | "userAccesses"
             | "name"
             | "id"
+            | "user"
         >;
         $owner: Preset<
-            D2Color,
+            D2UserAuthorityGroup,
             | "lastUpdatedBy"
+            | "userGroupAccesses"
             | "code"
-            | "color"
             | "created"
+            | "publicAccess"
+            | "description"
+            | "authorities"
             | "lastUpdated"
             | "translations"
+            | "userAccesses"
             | "name"
             | "id"
+            | "user"
         >;
     };
 }
 
-export interface D2CategoryOptionGroupSetDimensionSchema {
-    name: "D2CategoryOptionGroupSetDimension";
-    model: D2CategoryOptionGroupSetDimension;
+export interface D2UserCredentialsSchema {
+    name: "D2UserCredentials";
+    model: D2UserCredentials;
     fields: {
-        categoryOptionGroupSet: D2CategoryOptionGroupSetSchema;
-        categoryOptionGroups: D2CategoryOptionGroupSchema[];
+        access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        catDimensionConstraints: D2CategorySchema[];
+        code: Id;
+        cogsDimensionConstraints: D2CategoryOptionGroupSetSchema[];
+        created: string;
+        disabled: boolean;
+        displayName: string;
+        externalAccess: boolean;
+        externalAuth: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        invitation: boolean;
+        lastLogin: string;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        ldapId: string;
+        name: string;
+        openId: string;
+        password: string;
+        passwordLastUpdated: string;
+        publicAccess: string;
+        selfRegistered: boolean;
+        translations: D2Translation[];
+        twoFA: boolean;
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        userInfo: D2UserSchema;
+        userRoles: D2UserAuthorityGroupSchema[];
+        username: string;
     };
     fieldPresets: {
-        $all: Preset<D2CategoryOptionGroupSetDimension, keyof D2CategoryOptionGroupSetDimension>;
-        $identifiable: Preset<D2CategoryOptionGroupSetDimension, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2CategoryOptionGroupSetDimension, FieldPresets["nameable"]>;
+        $all: Preset<D2UserCredentials, keyof D2UserCredentials>;
+        $identifiable: Preset<D2UserCredentials, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2UserCredentials, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2CategoryOptionGroupSetDimension,
-            "categoryOptionGroups" | "categoryOptionGroupSet"
+            D2UserCredentials,
+            | "lastLogin"
+            | "userInfo"
+            | "code"
+            | "openId"
+            | "externalAuth"
+            | "cogsDimensionConstraints"
+            | "catDimensionConstraints"
+            | "lastUpdated"
+            | "password"
+            | "ldapId"
+            | "disabled"
+            | "id"
+            | "twoFA"
+            | "passwordLastUpdated"
+            | "lastUpdatedBy"
+            | "invitation"
+            | "created"
+            | "selfRegistered"
+            | "userRoles"
+            | "user"
+            | "username"
         >;
         $owner: Preset<
-            D2CategoryOptionGroupSetDimension,
-            "categoryOptionGroups" | "categoryOptionGroupSet"
+            D2UserCredentials,
+            | "lastLogin"
+            | "userInfo"
+            | "code"
+            | "openId"
+            | "externalAuth"
+            | "cogsDimensionConstraints"
+            | "catDimensionConstraints"
+            | "lastUpdated"
+            | "password"
+            | "ldapId"
+            | "disabled"
+            | "id"
+            | "twoFA"
+            | "passwordLastUpdated"
+            | "lastUpdatedBy"
+            | "invitation"
+            | "created"
+            | "selfRegistered"
+            | "userRoles"
+            | "user"
+            | "username"
         >;
     };
 }
 
-export interface D2LegendSchema {
-    name: "D2Legend";
-    model: D2Legend;
+export interface D2UserGroupSchema {
+    name: "D2UserGroup";
+    model: D2UserGroup;
     fields: {
         access: D2Access;
         attributeValues: D2AttributeValueSchema[];
         code: Id;
-        color: string;
         created: string;
         displayName: string;
-        endValue: number;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
         href: string;
         id: Id;
-        image: string;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
+        managedByGroups: D2UserGroupSchema[];
+        managedGroups: D2UserGroupSchema[];
         name: string;
         publicAccess: string;
-        startValue: number;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
+        users: D2UserSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2Legend, keyof D2Legend>;
-        $identifiable: Preset<D2Legend, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Legend, FieldPresets["nameable"]>;
+        $all: Preset<D2UserGroup, keyof D2UserGroup>;
+        $identifiable: Preset<D2UserGroup, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2UserGroup, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2Legend,
+            D2UserGroup,
             | "lastUpdatedBy"
-            | "image"
+            | "userGroupAccesses"
             | "code"
-            | "endValue"
-            | "color"
             | "created"
+            | "publicAccess"
+            | "managedByGroups"
+            | "attributeValues"
+            | "users"
+            | "managedGroups"
             | "lastUpdated"
             | "translations"
+            | "userAccesses"
             | "name"
-            | "startValue"
             | "id"
+            | "user"
         >;
         $owner: Preset<
-            D2Legend,
+            D2UserGroup,
             | "lastUpdatedBy"
-            | "image"
+            | "userGroupAccesses"
             | "code"
-            | "endValue"
-            | "color"
             | "created"
+            | "publicAccess"
+            | "attributeValues"
+            | "users"
+            | "managedGroups"
             | "lastUpdated"
             | "translations"
+            | "userAccesses"
             | "name"
-            | "startValue"
             | "id"
+            | "user"
         >;
     };
 }
 
-export interface D2ProgramTrackedEntityAttributeDimensionItemSchema {
-    name: "D2ProgramTrackedEntityAttributeDimensionItem";
-    model: D2ProgramTrackedEntityAttributeDimensionItem;
+export interface D2UserGroupAccessSchema {
+    name: "D2UserGroupAccess";
+    model: D2UserGroupAccess;
+    fields: { access: string; displayName: string; id: string; userGroupUid: string };
+    fieldPresets: {
+        $all: Preset<D2UserGroupAccess, keyof D2UserGroupAccess>;
+        $identifiable: Preset<D2UserGroupAccess, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2UserGroupAccess, FieldPresets["nameable"]>;
+        $persisted: Preset<D2UserGroupAccess, "access">;
+        $owner: Preset<D2UserGroupAccess, "access">;
+    };
+}
+
+export interface D2ValidationNotificationTemplateSchema {
+    name: "D2ValidationNotificationTemplate";
+    model: D2ValidationNotificationTemplate;
     fields: {
         access: D2Access;
+        attributeValues: D2AttributeValueSchema[];
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        messageTemplate: string;
+        name: string;
+        notifyParentOrganisationUnitOnly: boolean;
+        notifyUsersInHierarchyOnly: boolean;
+        publicAccess: string;
+        recipientUserGroups: D2UserGroupSchema[];
+        sendStrategy: "COLLECTIVE_SUMMARY" | "SINGLE_NOTIFICATION";
+        subjectTemplate: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        validationRules: D2ValidationRuleSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ValidationNotificationTemplate, keyof D2ValidationNotificationTemplate>;
+        $identifiable: Preset<D2ValidationNotificationTemplate, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ValidationNotificationTemplate, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ValidationNotificationTemplate,
+            | "code"
+            | "recipientUserGroups"
+            | "lastUpdated"
+            | "subjectTemplate"
+            | "id"
+            | "sendStrategy"
+            | "lastUpdatedBy"
+            | "validationRules"
+            | "created"
+            | "notifyUsersInHierarchyOnly"
+            | "name"
+            | "messageTemplate"
+        >;
+        $owner: Preset<
+            D2ValidationNotificationTemplate,
+            | "code"
+            | "recipientUserGroups"
+            | "lastUpdated"
+            | "subjectTemplate"
+            | "id"
+            | "sendStrategy"
+            | "lastUpdatedBy"
+            | "validationRules"
+            | "created"
+            | "notifyUsersInHierarchyOnly"
+            | "name"
+            | "messageTemplate"
+        >;
+    };
+}
+
+export interface D2ValidationResultSchema {
+    name: "D2ValidationResult";
+    model: D2ValidationResult;
+    fields: {
+        attributeOptionCombo: D2CategoryOptionComboSchema;
+        created: string;
+        dayInPeriod: number;
+        id: string;
+        leftsideValue: number;
+        notificationSent: boolean;
+        organisationUnit: D2OrganisationUnitSchema;
+        period: any;
+        rightsideValue: number;
+        validationRule: D2ValidationRuleSchema;
+    };
+    fieldPresets: {
+        $all: Preset<D2ValidationResult, keyof D2ValidationResult>;
+        $identifiable: Preset<D2ValidationResult, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ValidationResult, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ValidationResult,
+            "created" | "rightsideValue" | "leftsideValue" | "notificationSent"
+        >;
+        $owner: Preset<
+            D2ValidationResult,
+            "created" | "rightsideValue" | "leftsideValue" | "notificationSent"
+        >;
+    };
+}
+
+export interface D2ValidationRuleSchema {
+    name: "D2ValidationRule";
+    model: D2ValidationRule;
+    fields: {
+        access: D2Access;
+        aggregateExportAttributeOptionCombo: string;
+        aggregateExportCategoryOptionCombo: string;
         aggregationType:
             | "SUM"
             | "AVERAGE"
@@ -13796,7 +13755,6 @@ export interface D2ProgramTrackedEntityAttributeDimensionItemSchema {
             | "NONE"
             | "CUSTOM"
             | "DEFAULT";
-        attribute: D2TrackedEntityAttributeSchema;
         attributeValues: D2AttributeValueSchema[];
         code: Id;
         created: string;
@@ -13827,117 +13785,160 @@ export interface D2ProgramTrackedEntityAttributeDimensionItemSchema {
         formName: string;
         href: string;
         id: Id;
+        importance: "HIGH" | "MEDIUM" | "LOW";
+        instruction: string;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
+        leftSide: D2ExpressionSchema;
         legendSet: D2LegendSetSchema;
         legendSets: D2LegendSetSchema[];
         name: string;
-        program: D2ProgramSchema;
+        notificationTemplates: D2ValidationNotificationTemplateSchema[];
+        operator:
+            | "equal_to"
+            | "not_equal_to"
+            | "greater_than"
+            | "greater_than_or_equal_to"
+            | "less_than"
+            | "less_than_or_equal_to"
+            | "compulsory_pair"
+            | "exclusive_pair";
+        organisationUnitLevels: number[];
+        periodType: string;
         publicAccess: string;
+        rightSide: D2ExpressionSchema;
         shortName: string;
+        skipFormValidation: boolean;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
+        validationRuleGroups: D2ValidationRuleGroupSchema[];
     };
     fieldPresets: {
-        $all: Preset<
-            D2ProgramTrackedEntityAttributeDimensionItem,
-            keyof D2ProgramTrackedEntityAttributeDimensionItem
+        $all: Preset<D2ValidationRule, keyof D2ValidationRule>;
+        $identifiable: Preset<D2ValidationRule, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ValidationRule, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ValidationRule,
+            | "validationRuleGroups"
+            | "code"
+            | "importance"
+            | "publicAccess"
+            | "description"
+            | "operator"
+            | "organisationUnitLevels"
+            | "lastUpdated"
+            | "leftSide"
+            | "notificationTemplates"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "rightSide"
+            | "periodType"
+            | "instruction"
+            | "userAccesses"
+            | "name"
+            | "skipFormValidation"
+            | "user"
         >;
-        $identifiable: Preset<
-            D2ProgramTrackedEntityAttributeDimensionItem,
-            FieldPresets["identifiable"]
+        $owner: Preset<
+            D2ValidationRule,
+            | "code"
+            | "importance"
+            | "publicAccess"
+            | "description"
+            | "operator"
+            | "organisationUnitLevels"
+            | "lastUpdated"
+            | "leftSide"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "rightSide"
+            | "periodType"
+            | "instruction"
+            | "userAccesses"
+            | "name"
+            | "skipFormValidation"
+            | "user"
         >;
-        $nameable: Preset<D2ProgramTrackedEntityAttributeDimensionItem, FieldPresets["nameable"]>;
-        $persisted: Preset<D2ProgramTrackedEntityAttributeDimensionItem, never>;
-        $owner: Preset<D2ProgramTrackedEntityAttributeDimensionItem, never>;
     };
 }
 
-export interface D2RelationshipSchema {
-    name: "D2Relationship";
-    model: D2Relationship;
+export interface D2ValidationRuleGroupSchema {
+    name: "D2ValidationRuleGroup";
+    model: D2ValidationRuleGroup;
     fields: {
         access: D2Access;
         attributeValues: D2AttributeValueSchema[];
         code: Id;
         created: string;
         description: string;
-        displayDescription: string;
-        displayFormName: string;
         displayName: string;
-        displayShortName: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
-        formName: string;
-        from: any;
         href: string;
         id: Id;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
         name: string;
         publicAccess: string;
-        relationshipType: D2RelationshipTypeSchema;
-        shortName: string;
-        style: D2Style;
-        to: any;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
+        validationRules: D2ValidationRuleSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2Relationship, keyof D2Relationship>;
-        $identifiable: Preset<D2Relationship, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Relationship, FieldPresets["nameable"]>;
+        $all: Preset<D2ValidationRuleGroup, keyof D2ValidationRuleGroup>;
+        $identifiable: Preset<D2ValidationRuleGroup, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ValidationRuleGroup, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2Relationship,
+            D2ValidationRuleGroup,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
             | "code"
+            | "validationRules"
+            | "created"
+            | "publicAccess"
+            | "attributeValues"
             | "description"
             | "lastUpdated"
-            | "formName"
-            | "from"
+            | "translations"
+            | "userAccesses"
+            | "name"
             | "id"
-            | "lastUpdatedBy"
-            | "relationshipType"
-            | "created"
-            | "style"
-            | "to"
+            | "user"
         >;
         $owner: Preset<
-            D2Relationship,
+            D2ValidationRuleGroup,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
             | "code"
+            | "validationRules"
+            | "created"
+            | "publicAccess"
+            | "attributeValues"
             | "description"
             | "lastUpdated"
-            | "formName"
-            | "from"
+            | "translations"
+            | "userAccesses"
+            | "name"
             | "id"
-            | "lastUpdatedBy"
-            | "relationshipType"
-            | "created"
-            | "style"
-            | "to"
+            | "user"
         >;
-    };
-}
-
-export interface D2CategoryDimensionSchema {
-    name: "D2CategoryDimension";
-    model: D2CategoryDimension;
-    fields: { category: D2CategorySchema; categoryOptions: D2CategoryOptionSchema[] };
-    fieldPresets: {
-        $all: Preset<D2CategoryDimension, keyof D2CategoryDimension>;
-        $identifiable: Preset<D2CategoryDimension, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2CategoryDimension, FieldPresets["nameable"]>;
-        $persisted: Preset<D2CategoryDimension, "categoryOptions" | "category">;
-        $owner: Preset<D2CategoryDimension, "categoryOptions" | "category">;
     };
 }
 
 export type D2Model =
-    | D2Predictor
     | D2AnalyticsPeriodBoundary
     | D2AnalyticsTableHook
     | D2Attribute
@@ -13959,7 +13960,6 @@ export type D2Model =
     | D2DataApprovalLevel
     | D2DataApprovalWorkflow
     | D2DataElement
-    | D2TrackedEntityDataElementDimension
     | D2DataElementGroup
     | D2DataElementGroupSet
     | D2DataElementGroupSetDimension
@@ -13973,13 +13973,10 @@ export type D2Model =
     | D2EventChart
     | D2EventReport
     | D2Expression
-    | D2ExternalMapLayer
-    | D2Icon
     | D2ExternalFileResource
-    | D2ValidationNotificationTemplate
-    | D2KeyJsonValue
+    | D2ExternalMapLayer
     | D2FileResource
-    | D2ProgramStageInstance
+    | D2Icon
     | D2Indicator
     | D2IndicatorGroup
     | D2IndicatorGroupSet
@@ -13987,6 +13984,7 @@ export type D2Model =
     | D2Interpretation
     | D2InterpretationComment
     | D2JobConfiguration
+    | D2KeyJsonValue
     | D2Legend
     | D2LegendSet
     | D2Map
@@ -14004,12 +14002,11 @@ export type D2Model =
     | D2OrganisationUnitGroupSet
     | D2OrganisationUnitGroupSetDimension
     | D2OrganisationUnitLevel
+    | D2Predictor
     | D2PredictorGroup
     | D2Program
-    | D2ProgramTrackedEntityAttributeDimensionItem
     | D2ProgramDataElementDimensionItem
     | D2ProgramIndicator
-    | D2TrackedEntityProgramIndicatorDimension
     | D2ProgramIndicatorGroup
     | D2ProgramInstance
     | D2ProgramNotificationTemplate
@@ -14019,9 +14016,11 @@ export type D2Model =
     | D2ProgramSection
     | D2ProgramStage
     | D2ProgramStageDataElement
+    | D2ProgramStageInstance
     | D2ProgramStageInstanceFilter
     | D2ProgramStageSection
     | D2ProgramTrackedEntityAttribute
+    | D2ProgramTrackedEntityAttributeDimensionItem
     | D2ProgramTrackedEntityAttributeGroup
     | D2PushAnalysis
     | D2Relationship
@@ -14029,241 +14028,28 @@ export type D2Model =
     | D2Report
     | D2ReportTable
     | D2ReportingRate
-    | D2Section
     | D2SMSCommand
+    | D2Section
     | D2SqlView
     | D2TrackedEntityAttribute
+    | D2TrackedEntityDataElementDimension
     | D2TrackedEntityInstance
     | D2TrackedEntityInstanceFilter
+    | D2TrackedEntityProgramIndicatorDimension
     | D2TrackedEntityType
     | D2TrackedEntityTypeAttribute
     | D2User
     | D2UserAccess
+    | D2UserAuthorityGroup
     | D2UserCredentials
     | D2UserGroup
     | D2UserGroupAccess
-    | D2UserAuthorityGroup
+    | D2ValidationNotificationTemplate
     | D2ValidationResult
     | D2ValidationRule
     | D2ValidationRuleGroup;
 
 export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
-    predictors: {
-        klass: "org.hisp.dhis.predictor.Predictor",
-        shareable: false,
-        metadata: true,
-        relativeApiEndpoint: "/predictors",
-        plural: "predictors",
-        displayName: "Predictor",
-        collectionName: "predictors",
-        nameableObject: true,
-        translatable: false,
-        identifiableObject: true,
-        dataShareable: false,
-        name: "Predictor",
-        persisted: true,
-        embeddedObject: false,
-        properties: [
-            {
-                name: "favorite",
-                fieldName: "favorites",
-                propertyType: "COLLECTION",
-                itemPropertyType: "TEXT",
-                klass: "java.util.Set",
-                itemKlass: "java.lang.String",
-            },
-            {
-                name: "outputCombo",
-                fieldName: "outputCombo",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.category.CategoryOptionCombo",
-            },
-            {
-                name: "code",
-                fieldName: "code",
-                propertyType: "IDENTIFIER",
-                klass: "java.lang.String",
-            },
-            {
-                name: "access",
-                fieldName: "access",
-                propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.security.acl.Access",
-            },
-            {
-                name: "displayName",
-                fieldName: "displayName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "publicAccess",
-                fieldName: "publicAccess",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "description",
-                fieldName: "description",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "generator",
-                fieldName: "generator",
-                propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.expression.Expression",
-            },
-            {
-                name: "displayShortName",
-                fieldName: "displayShortName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "organisationUnitLevel",
-                fieldName: "organisationUnitLevels",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.organisationunit.OrganisationUnitLevel",
-            },
-            {
-                name: "externalAccess",
-                fieldName: "externalAccess",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "output",
-                fieldName: "output",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.dataelement.DataElement",
-            },
-            {
-                name: "lastUpdated",
-                fieldName: "lastUpdated",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "sampleSkipTest",
-                fieldName: "sampleSkipTest",
-                propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.expression.Expression",
-            },
-            {
-                name: "translation",
-                fieldName: "translations",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.translation.Translation",
-            },
-            {
-                name: "formName",
-                fieldName: "formName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
-            {
-                name: "sequentialSampleCount",
-                fieldName: "sequentialSampleCount",
-                propertyType: "INTEGER",
-                klass: "java.lang.Integer",
-            },
-            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
-            {
-                name: "displayDescription",
-                fieldName: "displayDescription",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "annualSampleCount",
-                fieldName: "annualSampleCount",
-                propertyType: "INTEGER",
-                klass: "java.lang.Integer",
-            },
-            {
-                name: "lastUpdatedBy",
-                fieldName: "lastUpdatedBy",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            {
-                name: "userGroupAccess",
-                fieldName: "userGroupAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
-            },
-            {
-                name: "created",
-                fieldName: "created",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "attributeValue",
-                fieldName: "attributeValues",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
-            },
-            {
-                name: "sequentialSkipCount",
-                fieldName: "sequentialSkipCount",
-                propertyType: "INTEGER",
-                klass: "java.lang.Integer",
-            },
-            {
-                name: "predictorGroup",
-                fieldName: "groups",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.predictor.PredictorGroup",
-            },
-            {
-                name: "displayFormName",
-                fieldName: "displayFormName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "periodType",
-                fieldName: "periodType",
-                propertyType: "TEXT",
-                klass: "org.hisp.dhis.period.PeriodType",
-            },
-            {
-                name: "userAccess",
-                fieldName: "userAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserAccess",
-            },
-            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
-            {
-                name: "shortName",
-                fieldName: "shortName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "user",
-                fieldName: "user",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
-        ],
-    },
     analyticsPeriodBoundaries: {
         klass: "org.hisp.dhis.program.AnalyticsPeriodBoundary",
         shareable: false,
@@ -18076,41 +17862,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             },
         ],
     },
-    trackedEntityDataElementDimensions: {
-        klass: "org.hisp.dhis.trackedentity.TrackedEntityDataElementDimension",
-        shareable: false,
-        metadata: false,
-        plural: "trackedEntityDataElementDimensions",
-        displayName: "Tracked Entity Data Element Dimension",
-        collectionName: "trackedEntityDataElementDimensions",
-        nameableObject: false,
-        translatable: false,
-        identifiableObject: false,
-        dataShareable: false,
-        name: "dataElementDimension",
-        persisted: true,
-        embeddedObject: false,
-        properties: [
-            {
-                name: "filter",
-                fieldName: "filter",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "legendSet",
-                fieldName: "legendSet",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.legend.LegendSet",
-            },
-            {
-                name: "dataElement",
-                fieldName: "dataElement",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.dataelement.DataElement",
-            },
-        ],
-    },
     dataElementGroups: {
         klass: "org.hisp.dhis.dataelement.DataElementGroup",
         shareable: true,
@@ -20823,6 +20574,122 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             },
         ],
     },
+    externalFileResources: {
+        klass: "org.hisp.dhis.fileresource.ExternalFileResource",
+        shareable: false,
+        metadata: true,
+        relativeApiEndpoint: "/externalFileResources",
+        plural: "externalFileResources",
+        displayName: "External File Resource",
+        collectionName: "externalFileResources",
+        nameableObject: false,
+        translatable: false,
+        identifiableObject: true,
+        dataShareable: false,
+        name: "identifiableObject",
+        persisted: true,
+        embeddedObject: false,
+        properties: [
+            {
+                name: "favorite",
+                fieldName: "favorites",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.Set",
+                itemKlass: "java.lang.String",
+            },
+            {
+                name: "lastUpdatedBy",
+                fieldName: "lastUpdatedBy",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "access",
+                fieldName: "access",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.security.acl.Access",
+            },
+            {
+                name: "userGroupAccess",
+                fieldName: "userGroupAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
+            },
+            {
+                name: "code",
+                fieldName: "code",
+                propertyType: "IDENTIFIER",
+                klass: "java.lang.String",
+            },
+            {
+                name: "created",
+                fieldName: "created",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "displayName",
+                fieldName: "displayName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "publicAccess",
+                fieldName: "publicAccess",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "attributeValue",
+                fieldName: "attributeValues",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
+            },
+            {
+                name: "externalAccess",
+                fieldName: "externalAccess",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "lastUpdated",
+                fieldName: "lastUpdated",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "translation",
+                fieldName: "translations",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.translation.Translation",
+            },
+            {
+                name: "userAccess",
+                fieldName: "userAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserAccess",
+            },
+            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
+            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
+            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
+            {
+                name: "user",
+                fieldName: "user",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+        ],
+    },
     externalMapLayers: {
         klass: "org.hisp.dhis.mapping.ExternalMapLayer",
         shareable: true,
@@ -20982,425 +20849,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
         ],
     },
-    icons: {
-        klass: "org.hisp.dhis.icon.Icon",
-        shareable: false,
-        metadata: false,
-        relativeApiEndpoint: "/icons",
-        plural: "icons",
-        displayName: "Icon",
-        collectionName: "icons",
-        nameableObject: false,
-        translatable: false,
-        identifiableObject: false,
-        dataShareable: false,
-        name: "icon",
-        persisted: false,
-        embeddedObject: false,
-        properties: [],
-    },
-    externalFileResources: {
-        klass: "org.hisp.dhis.fileresource.ExternalFileResource",
-        shareable: false,
-        metadata: true,
-        relativeApiEndpoint: "/externalFileResources",
-        plural: "externalFileResources",
-        displayName: "External File Resource",
-        collectionName: "externalFileResources",
-        nameableObject: false,
-        translatable: false,
-        identifiableObject: true,
-        dataShareable: false,
-        name: "identifiableObject",
-        persisted: true,
-        embeddedObject: false,
-        properties: [
-            {
-                name: "favorite",
-                fieldName: "favorites",
-                propertyType: "COLLECTION",
-                itemPropertyType: "TEXT",
-                klass: "java.util.Set",
-                itemKlass: "java.lang.String",
-            },
-            {
-                name: "lastUpdatedBy",
-                fieldName: "lastUpdatedBy",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            {
-                name: "access",
-                fieldName: "access",
-                propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.security.acl.Access",
-            },
-            {
-                name: "userGroupAccess",
-                fieldName: "userGroupAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
-            },
-            {
-                name: "code",
-                fieldName: "code",
-                propertyType: "IDENTIFIER",
-                klass: "java.lang.String",
-            },
-            {
-                name: "created",
-                fieldName: "created",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "displayName",
-                fieldName: "displayName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "publicAccess",
-                fieldName: "publicAccess",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "attributeValue",
-                fieldName: "attributeValues",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
-            },
-            {
-                name: "externalAccess",
-                fieldName: "externalAccess",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "lastUpdated",
-                fieldName: "lastUpdated",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "translation",
-                fieldName: "translations",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.translation.Translation",
-            },
-            {
-                name: "userAccess",
-                fieldName: "userAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserAccess",
-            },
-            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
-            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
-            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
-            {
-                name: "user",
-                fieldName: "user",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
-        ],
-    },
-    validationNotificationTemplates: {
-        klass: "org.hisp.dhis.validation.notification.ValidationNotificationTemplate",
-        shareable: false,
-        metadata: true,
-        relativeApiEndpoint: "/validationNotificationTemplates",
-        plural: "validationNotificationTemplates",
-        displayName: "Validation Notification Template",
-        collectionName: "validationNotificationTemplates",
-        nameableObject: false,
-        translatable: false,
-        identifiableObject: true,
-        dataShareable: false,
-        name: "identifiableObject",
-        persisted: true,
-        embeddedObject: false,
-        properties: [
-            {
-                name: "favorite",
-                fieldName: "favorites",
-                propertyType: "COLLECTION",
-                itemPropertyType: "TEXT",
-                klass: "java.util.Set",
-                itemKlass: "java.lang.String",
-            },
-            {
-                name: "access",
-                fieldName: "access",
-                propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.security.acl.Access",
-            },
-            {
-                name: "code",
-                fieldName: "code",
-                propertyType: "IDENTIFIER",
-                klass: "java.lang.String",
-            },
-            {
-                name: "displayName",
-                fieldName: "displayName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "publicAccess",
-                fieldName: "publicAccess",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "recipientUserGroups",
-                fieldName: "recipientUserGroups",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserGroup",
-            },
-            {
-                name: "externalAccess",
-                fieldName: "externalAccess",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "lastUpdated",
-                fieldName: "lastUpdated",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "translation",
-                fieldName: "translations",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.translation.Translation",
-            },
-            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
-            {
-                name: "subjectTemplate",
-                fieldName: "subjectTemplate",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
-            {
-                name: "sendStrategy",
-                fieldName: "sendStrategy",
-                propertyType: "CONSTANT",
-                klass: "org.hisp.dhis.notification.SendStrategy",
-            },
-            {
-                name: "lastUpdatedBy",
-                fieldName: "lastUpdatedBy",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            {
-                name: "userGroupAccess",
-                fieldName: "userGroupAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
-            },
-            {
-                name: "validationRules",
-                fieldName: "validationRules",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.validation.ValidationRule",
-            },
-            {
-                name: "created",
-                fieldName: "created",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "notifyUsersInHierarchyOnly",
-                fieldName: "notifyUsersInHierarchyOnly",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "attributeValue",
-                fieldName: "attributeValues",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
-            },
-            {
-                name: "notifyParentOrganisationUnitOnly",
-                fieldName: "notifyParentOrganisationUnitOnly",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "userAccess",
-                fieldName: "userAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserAccess",
-            },
-            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
-            {
-                name: "user",
-                fieldName: "user",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
-            {
-                name: "messageTemplate",
-                fieldName: "messageTemplate",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-        ],
-    },
-    dataStores: {
-        klass: "org.hisp.dhis.keyjsonvalue.KeyJsonValue",
-        shareable: true,
-        metadata: false,
-        relativeApiEndpoint: "/dataStore",
-        plural: "dataStores",
-        displayName: "Key Json Value",
-        collectionName: "dataStores",
-        nameableObject: false,
-        translatable: false,
-        identifiableObject: true,
-        dataShareable: false,
-        name: "identifiableObject",
-        persisted: true,
-        embeddedObject: false,
-        properties: [
-            {
-                name: "favorite",
-                fieldName: "favorites",
-                propertyType: "COLLECTION",
-                itemPropertyType: "TEXT",
-                klass: "java.util.Set",
-                itemKlass: "java.lang.String",
-            },
-            {
-                name: "lastUpdatedBy",
-                fieldName: "lastUpdatedBy",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            {
-                name: "access",
-                fieldName: "access",
-                propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.security.acl.Access",
-            },
-            {
-                name: "userGroupAccess",
-                fieldName: "userGroupAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
-            },
-            {
-                name: "code",
-                fieldName: "code",
-                propertyType: "IDENTIFIER",
-                klass: "java.lang.String",
-            },
-            {
-                name: "created",
-                fieldName: "created",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "displayName",
-                fieldName: "displayName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "publicAccess",
-                fieldName: "publicAccess",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "attributeValue",
-                fieldName: "attributeValues",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
-            },
-            {
-                name: "externalAccess",
-                fieldName: "externalAccess",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "lastUpdated",
-                fieldName: "lastUpdated",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "translation",
-                fieldName: "translations",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.translation.Translation",
-            },
-            {
-                name: "userAccess",
-                fieldName: "userAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserAccess",
-            },
-            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
-            {
-                name: "namespace",
-                fieldName: "namespace",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
-            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
-            {
-                name: "user",
-                fieldName: "user",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            { name: "value", fieldName: "value", propertyType: "TEXT", klass: "java.lang.String" },
-            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
-            { name: "key", fieldName: "key", propertyType: "TEXT", klass: "java.lang.String" },
-        ],
-    },
     fileResources: {
         klass: "org.hisp.dhis.fileresource.FileResource",
         shareable: false,
@@ -21547,121 +20995,22 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
         ],
     },
-    programStageInstances: {
-        klass: "org.hisp.dhis.program.ProgramStageInstance",
+    icons: {
+        klass: "org.hisp.dhis.icon.Icon",
         shareable: false,
         metadata: false,
-        relativeApiEndpoint: "/programStageInstances",
-        plural: "programStageInstances",
-        displayName: "Program Stage Instance",
-        collectionName: "programStageInstances",
+        relativeApiEndpoint: "/icons",
+        plural: "icons",
+        displayName: "Icon",
+        collectionName: "icons",
         nameableObject: false,
         translatable: false,
-        identifiableObject: true,
+        identifiableObject: false,
         dataShareable: false,
-        name: "identifiableObject",
-        persisted: true,
+        name: "icon",
+        persisted: false,
         embeddedObject: false,
-        properties: [
-            {
-                name: "favorite",
-                fieldName: "favorites",
-                propertyType: "COLLECTION",
-                itemPropertyType: "TEXT",
-                klass: "java.util.Set",
-                itemKlass: "java.lang.String",
-            },
-            {
-                name: "lastUpdatedBy",
-                fieldName: "lastUpdatedBy",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            {
-                name: "access",
-                fieldName: "access",
-                propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.security.acl.Access",
-            },
-            {
-                name: "userGroupAccess",
-                fieldName: "userGroupAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
-            },
-            {
-                name: "code",
-                fieldName: "code",
-                propertyType: "IDENTIFIER",
-                klass: "java.lang.String",
-            },
-            {
-                name: "created",
-                fieldName: "created",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "displayName",
-                fieldName: "displayName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "publicAccess",
-                fieldName: "publicAccess",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "attributeValue",
-                fieldName: "attributeValues",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
-            },
-            {
-                name: "externalAccess",
-                fieldName: "externalAccess",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "lastUpdated",
-                fieldName: "lastUpdated",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "translation",
-                fieldName: "translations",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.translation.Translation",
-            },
-            {
-                name: "userAccess",
-                fieldName: "userAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserAccess",
-            },
-            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
-            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
-            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
-            {
-                name: "user",
-                fieldName: "user",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
-        ],
+        properties: [],
     },
     indicators: {
         klass: "org.hisp.dhis.indicator.Indicator",
@@ -22835,6 +22184,130 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 propertyType: "TEXT",
                 klass: "java.lang.String",
             },
+        ],
+    },
+    dataStores: {
+        klass: "org.hisp.dhis.keyjsonvalue.KeyJsonValue",
+        shareable: true,
+        metadata: false,
+        relativeApiEndpoint: "/dataStore",
+        plural: "dataStores",
+        displayName: "Key Json Value",
+        collectionName: "dataStores",
+        nameableObject: false,
+        translatable: false,
+        identifiableObject: true,
+        dataShareable: false,
+        name: "identifiableObject",
+        persisted: true,
+        embeddedObject: false,
+        properties: [
+            {
+                name: "favorite",
+                fieldName: "favorites",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.Set",
+                itemKlass: "java.lang.String",
+            },
+            {
+                name: "lastUpdatedBy",
+                fieldName: "lastUpdatedBy",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "access",
+                fieldName: "access",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.security.acl.Access",
+            },
+            {
+                name: "userGroupAccess",
+                fieldName: "userGroupAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
+            },
+            {
+                name: "code",
+                fieldName: "code",
+                propertyType: "IDENTIFIER",
+                klass: "java.lang.String",
+            },
+            {
+                name: "created",
+                fieldName: "created",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "displayName",
+                fieldName: "displayName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "publicAccess",
+                fieldName: "publicAccess",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "attributeValue",
+                fieldName: "attributeValues",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
+            },
+            {
+                name: "externalAccess",
+                fieldName: "externalAccess",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "lastUpdated",
+                fieldName: "lastUpdated",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "translation",
+                fieldName: "translations",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.translation.Translation",
+            },
+            {
+                name: "userAccess",
+                fieldName: "userAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserAccess",
+            },
+            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
+            {
+                name: "namespace",
+                fieldName: "namespace",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
+            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
+            {
+                name: "user",
+                fieldName: "user",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            { name: "value", fieldName: "value", propertyType: "TEXT", klass: "java.lang.String" },
+            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+            { name: "key", fieldName: "key", propertyType: "TEXT", klass: "java.lang.String" },
         ],
     },
     legends: {
@@ -26032,6 +25505,222 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
         ],
     },
+    predictors: {
+        klass: "org.hisp.dhis.predictor.Predictor",
+        shareable: false,
+        metadata: true,
+        relativeApiEndpoint: "/predictors",
+        plural: "predictors",
+        displayName: "Predictor",
+        collectionName: "predictors",
+        nameableObject: true,
+        translatable: false,
+        identifiableObject: true,
+        dataShareable: false,
+        name: "Predictor",
+        persisted: true,
+        embeddedObject: false,
+        properties: [
+            {
+                name: "favorite",
+                fieldName: "favorites",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.Set",
+                itemKlass: "java.lang.String",
+            },
+            {
+                name: "outputCombo",
+                fieldName: "outputCombo",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.category.CategoryOptionCombo",
+            },
+            {
+                name: "code",
+                fieldName: "code",
+                propertyType: "IDENTIFIER",
+                klass: "java.lang.String",
+            },
+            {
+                name: "access",
+                fieldName: "access",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.security.acl.Access",
+            },
+            {
+                name: "displayName",
+                fieldName: "displayName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "publicAccess",
+                fieldName: "publicAccess",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "description",
+                fieldName: "description",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "generator",
+                fieldName: "generator",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.expression.Expression",
+            },
+            {
+                name: "displayShortName",
+                fieldName: "displayShortName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "organisationUnitLevel",
+                fieldName: "organisationUnitLevels",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.organisationunit.OrganisationUnitLevel",
+            },
+            {
+                name: "externalAccess",
+                fieldName: "externalAccess",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "output",
+                fieldName: "output",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.dataelement.DataElement",
+            },
+            {
+                name: "lastUpdated",
+                fieldName: "lastUpdated",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "sampleSkipTest",
+                fieldName: "sampleSkipTest",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.expression.Expression",
+            },
+            {
+                name: "translation",
+                fieldName: "translations",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.translation.Translation",
+            },
+            {
+                name: "formName",
+                fieldName: "formName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
+            {
+                name: "sequentialSampleCount",
+                fieldName: "sequentialSampleCount",
+                propertyType: "INTEGER",
+                klass: "java.lang.Integer",
+            },
+            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
+            {
+                name: "displayDescription",
+                fieldName: "displayDescription",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "annualSampleCount",
+                fieldName: "annualSampleCount",
+                propertyType: "INTEGER",
+                klass: "java.lang.Integer",
+            },
+            {
+                name: "lastUpdatedBy",
+                fieldName: "lastUpdatedBy",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "userGroupAccess",
+                fieldName: "userGroupAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
+            },
+            {
+                name: "created",
+                fieldName: "created",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "attributeValue",
+                fieldName: "attributeValues",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
+            },
+            {
+                name: "sequentialSkipCount",
+                fieldName: "sequentialSkipCount",
+                propertyType: "INTEGER",
+                klass: "java.lang.Integer",
+            },
+            {
+                name: "predictorGroup",
+                fieldName: "groups",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.predictor.PredictorGroup",
+            },
+            {
+                name: "displayFormName",
+                fieldName: "displayFormName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "periodType",
+                fieldName: "periodType",
+                propertyType: "TEXT",
+                klass: "org.hisp.dhis.period.PeriodType",
+            },
+            {
+                name: "userAccess",
+                fieldName: "userAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserAccess",
+            },
+            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
+            {
+                name: "shortName",
+                fieldName: "shortName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "user",
+                fieldName: "user",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+        ],
+    },
     predictorGroups: {
         klass: "org.hisp.dhis.predictor.PredictorGroup",
         shareable: true,
@@ -26524,195 +26213,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             },
         ],
     },
-    ProgramTrackedEntityAttributeDimensionItems: {
-        klass: "org.hisp.dhis.program.ProgramTrackedEntityAttributeDimensionItem",
-        shareable: false,
-        metadata: false,
-        plural: "ProgramTrackedEntityAttributeDimensionItems",
-        displayName: "Program Tracked Entity Attribute Dimension Item",
-        collectionName: "ProgramTrackedEntityAttributeDimensionItems",
-        nameableObject: true,
-        translatable: false,
-        identifiableObject: true,
-        dataShareable: false,
-        name: "programAttributeDimension",
-        persisted: false,
-        embeddedObject: true,
-        properties: [
-            {
-                name: "favorite",
-                fieldName: "favorites",
-                propertyType: "COLLECTION",
-                itemPropertyType: "TEXT",
-                klass: "java.util.Set",
-                itemKlass: "java.lang.String",
-            },
-            {
-                name: "aggregationType",
-                fieldName: "aggregationType",
-                propertyType: "CONSTANT",
-                klass: "org.hisp.dhis.analytics.AggregationType",
-            },
-            {
-                name: "code",
-                fieldName: "code",
-                propertyType: "IDENTIFIER",
-                klass: "java.lang.String",
-            },
-            {
-                name: "access",
-                fieldName: "access",
-                propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.security.acl.Access",
-            },
-            {
-                name: "displayName",
-                fieldName: "displayName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "publicAccess",
-                fieldName: "publicAccess",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "description",
-                fieldName: "description",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "program",
-                fieldName: "program",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.program.Program",
-            },
-            {
-                name: "displayShortName",
-                fieldName: "displayShortName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "externalAccess",
-                fieldName: "externalAccess",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "lastUpdated",
-                fieldName: "lastUpdated",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "translation",
-                fieldName: "translations",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.translation.Translation",
-            },
-            {
-                name: "formName",
-                fieldName: "formName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
-            {
-                name: "attribute",
-                fieldName: "attribute",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.trackedentity.TrackedEntityAttribute",
-            },
-            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
-            {
-                name: "displayDescription",
-                fieldName: "displayDescription",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "lastUpdatedBy",
-                fieldName: "lastUpdatedBy",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            {
-                name: "userGroupAccess",
-                fieldName: "userGroupAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
-            },
-            { name: "dimensionItem", propertyType: "TEXT", klass: "java.lang.String" },
-            {
-                name: "created",
-                fieldName: "created",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "attributeValue",
-                fieldName: "attributeValues",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
-            },
-            {
-                name: "displayFormName",
-                fieldName: "displayFormName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "userAccess",
-                fieldName: "userAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserAccess",
-            },
-            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
-            {
-                name: "legendSet",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.legend.LegendSet",
-            },
-            {
-                name: "legendSets",
-                fieldName: "legendSets",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.List",
-                itemKlass: "org.hisp.dhis.legend.LegendSet",
-            },
-            {
-                name: "shortName",
-                fieldName: "shortName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "user",
-                fieldName: "user",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
-            {
-                name: "dimensionItemType",
-                fieldName: "dimensionItemType",
-                propertyType: "CONSTANT",
-                klass: "org.hisp.dhis.common.DimensionItemType",
-            },
-        ],
-    },
     programDataElements: {
         klass: "org.hisp.dhis.program.ProgramDataElementDimensionItem",
         shareable: false,
@@ -27153,41 +26653,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 fieldName: "dimensionItemType",
                 propertyType: "CONSTANT",
                 klass: "org.hisp.dhis.common.DimensionItemType",
-            },
-        ],
-    },
-    dataElementDimensions: {
-        klass: "org.hisp.dhis.trackedentity.TrackedEntityProgramIndicatorDimension",
-        shareable: false,
-        metadata: false,
-        plural: "dataElementDimensions",
-        displayName: "Tracked Entity Program Indicator Dimension",
-        collectionName: "dataElementDimensions",
-        nameableObject: false,
-        translatable: false,
-        identifiableObject: false,
-        dataShareable: false,
-        name: "programIndicatorDimension",
-        persisted: true,
-        embeddedObject: false,
-        properties: [
-            {
-                name: "filter",
-                fieldName: "filter",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "legendSet",
-                fieldName: "legendSet",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.legend.LegendSet",
-            },
-            {
-                name: "programIndicator",
-                fieldName: "programIndicator",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.program.ProgramIndicator",
             },
         ],
     },
@@ -28894,6 +28359,122 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
         ],
     },
+    programStageInstances: {
+        klass: "org.hisp.dhis.program.ProgramStageInstance",
+        shareable: false,
+        metadata: false,
+        relativeApiEndpoint: "/programStageInstances",
+        plural: "programStageInstances",
+        displayName: "Program Stage Instance",
+        collectionName: "programStageInstances",
+        nameableObject: false,
+        translatable: false,
+        identifiableObject: true,
+        dataShareable: false,
+        name: "identifiableObject",
+        persisted: true,
+        embeddedObject: false,
+        properties: [
+            {
+                name: "favorite",
+                fieldName: "favorites",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.Set",
+                itemKlass: "java.lang.String",
+            },
+            {
+                name: "lastUpdatedBy",
+                fieldName: "lastUpdatedBy",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "access",
+                fieldName: "access",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.security.acl.Access",
+            },
+            {
+                name: "userGroupAccess",
+                fieldName: "userGroupAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
+            },
+            {
+                name: "code",
+                fieldName: "code",
+                propertyType: "IDENTIFIER",
+                klass: "java.lang.String",
+            },
+            {
+                name: "created",
+                fieldName: "created",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "displayName",
+                fieldName: "displayName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "publicAccess",
+                fieldName: "publicAccess",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "attributeValue",
+                fieldName: "attributeValues",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
+            },
+            {
+                name: "externalAccess",
+                fieldName: "externalAccess",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "lastUpdated",
+                fieldName: "lastUpdated",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "translation",
+                fieldName: "translations",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.translation.Translation",
+            },
+            {
+                name: "userAccess",
+                fieldName: "userAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserAccess",
+            },
+            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
+            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
+            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
+            {
+                name: "user",
+                fieldName: "user",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+        ],
+    },
     eventFilters: {
         klass: "org.hisp.dhis.programstagefilter.ProgramStageInstanceFilter",
         shareable: true,
@@ -29407,6 +28988,195 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "org.hisp.dhis.user.User",
             },
             { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+        ],
+    },
+    ProgramTrackedEntityAttributeDimensionItems: {
+        klass: "org.hisp.dhis.program.ProgramTrackedEntityAttributeDimensionItem",
+        shareable: false,
+        metadata: false,
+        plural: "ProgramTrackedEntityAttributeDimensionItems",
+        displayName: "Program Tracked Entity Attribute Dimension Item",
+        collectionName: "ProgramTrackedEntityAttributeDimensionItems",
+        nameableObject: true,
+        translatable: false,
+        identifiableObject: true,
+        dataShareable: false,
+        name: "programAttributeDimension",
+        persisted: false,
+        embeddedObject: true,
+        properties: [
+            {
+                name: "favorite",
+                fieldName: "favorites",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.Set",
+                itemKlass: "java.lang.String",
+            },
+            {
+                name: "aggregationType",
+                fieldName: "aggregationType",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.analytics.AggregationType",
+            },
+            {
+                name: "code",
+                fieldName: "code",
+                propertyType: "IDENTIFIER",
+                klass: "java.lang.String",
+            },
+            {
+                name: "access",
+                fieldName: "access",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.security.acl.Access",
+            },
+            {
+                name: "displayName",
+                fieldName: "displayName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "publicAccess",
+                fieldName: "publicAccess",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "description",
+                fieldName: "description",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "program",
+                fieldName: "program",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.program.Program",
+            },
+            {
+                name: "displayShortName",
+                fieldName: "displayShortName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "externalAccess",
+                fieldName: "externalAccess",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "lastUpdated",
+                fieldName: "lastUpdated",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "translation",
+                fieldName: "translations",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.translation.Translation",
+            },
+            {
+                name: "formName",
+                fieldName: "formName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
+            {
+                name: "attribute",
+                fieldName: "attribute",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.trackedentity.TrackedEntityAttribute",
+            },
+            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
+            {
+                name: "displayDescription",
+                fieldName: "displayDescription",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "lastUpdatedBy",
+                fieldName: "lastUpdatedBy",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "userGroupAccess",
+                fieldName: "userGroupAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
+            },
+            { name: "dimensionItem", propertyType: "TEXT", klass: "java.lang.String" },
+            {
+                name: "created",
+                fieldName: "created",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "attributeValue",
+                fieldName: "attributeValues",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
+            },
+            {
+                name: "displayFormName",
+                fieldName: "displayFormName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "userAccess",
+                fieldName: "userAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserAccess",
+            },
+            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
+            {
+                name: "legendSet",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.legend.LegendSet",
+            },
+            {
+                name: "legendSets",
+                fieldName: "legendSets",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.legend.LegendSet",
+            },
+            {
+                name: "shortName",
+                fieldName: "shortName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "user",
+                fieldName: "user",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+            {
+                name: "dimensionItemType",
+                fieldName: "dimensionItemType",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.common.DimensionItemType",
+            },
         ],
     },
     programTrackedEntityAttributeGroups: {
@@ -30923,183 +30693,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             },
         ],
     },
-    sections: {
-        klass: "org.hisp.dhis.dataset.Section",
-        shareable: false,
-        metadata: true,
-        relativeApiEndpoint: "/sections",
-        plural: "sections",
-        displayName: "Section",
-        collectionName: "sections",
-        nameableObject: false,
-        translatable: true,
-        identifiableObject: true,
-        dataShareable: false,
-        name: "section",
-        persisted: true,
-        embeddedObject: false,
-        properties: [
-            {
-                name: "favorite",
-                fieldName: "favorites",
-                propertyType: "COLLECTION",
-                itemPropertyType: "TEXT",
-                klass: "java.util.Set",
-                itemKlass: "java.lang.String",
-            },
-            {
-                name: "code",
-                fieldName: "code",
-                propertyType: "IDENTIFIER",
-                klass: "java.lang.String",
-            },
-            {
-                name: "access",
-                fieldName: "access",
-                propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.security.acl.Access",
-            },
-            {
-                name: "greyedField",
-                fieldName: "greyedFields",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.dataelement.DataElementOperand",
-            },
-            {
-                name: "displayName",
-                fieldName: "displayName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "publicAccess",
-                fieldName: "publicAccess",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "description",
-                fieldName: "description",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "externalAccess",
-                fieldName: "externalAccess",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "lastUpdated",
-                fieldName: "lastUpdated",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "translation",
-                fieldName: "translations",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.translation.Translation",
-            },
-            {
-                name: "categoryCombos",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.category.CategoryCombo",
-            },
-            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
-            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
-            {
-                name: "dataSet",
-                fieldName: "dataSet",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.dataset.DataSet",
-            },
-            {
-                name: "dataElement",
-                fieldName: "dataElements",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.List",
-                itemKlass: "org.hisp.dhis.dataelement.DataElement",
-            },
-            {
-                name: "showColumnTotals",
-                fieldName: "showColumnTotals",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "lastUpdatedBy",
-                fieldName: "lastUpdatedBy",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            {
-                name: "userGroupAccess",
-                fieldName: "userGroupAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
-            },
-            {
-                name: "created",
-                fieldName: "created",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "attributeValue",
-                fieldName: "attributeValues",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
-            },
-            {
-                name: "indicator",
-                fieldName: "indicators",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.List",
-                itemKlass: "org.hisp.dhis.indicator.Indicator",
-            },
-            {
-                name: "sortOrder",
-                fieldName: "sortOrder",
-                propertyType: "INTEGER",
-                klass: "java.lang.Integer",
-            },
-            {
-                name: "userAccess",
-                fieldName: "userAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserAccess",
-            },
-            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
-            {
-                name: "user",
-                fieldName: "user",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            {
-                name: "showRowTotals",
-                fieldName: "showRowTotals",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
-        ],
-    },
     smsCommands: {
         klass: "org.hisp.dhis.sms.command.SMSCommand",
         shareable: false,
@@ -31318,6 +30911,183 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 fieldName: "dataset",
                 propertyType: "REFERENCE",
                 klass: "org.hisp.dhis.dataset.DataSet",
+            },
+            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+        ],
+    },
+    sections: {
+        klass: "org.hisp.dhis.dataset.Section",
+        shareable: false,
+        metadata: true,
+        relativeApiEndpoint: "/sections",
+        plural: "sections",
+        displayName: "Section",
+        collectionName: "sections",
+        nameableObject: false,
+        translatable: true,
+        identifiableObject: true,
+        dataShareable: false,
+        name: "section",
+        persisted: true,
+        embeddedObject: false,
+        properties: [
+            {
+                name: "favorite",
+                fieldName: "favorites",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.Set",
+                itemKlass: "java.lang.String",
+            },
+            {
+                name: "code",
+                fieldName: "code",
+                propertyType: "IDENTIFIER",
+                klass: "java.lang.String",
+            },
+            {
+                name: "access",
+                fieldName: "access",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.security.acl.Access",
+            },
+            {
+                name: "greyedField",
+                fieldName: "greyedFields",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.dataelement.DataElementOperand",
+            },
+            {
+                name: "displayName",
+                fieldName: "displayName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "publicAccess",
+                fieldName: "publicAccess",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "description",
+                fieldName: "description",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "externalAccess",
+                fieldName: "externalAccess",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "lastUpdated",
+                fieldName: "lastUpdated",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "translation",
+                fieldName: "translations",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.translation.Translation",
+            },
+            {
+                name: "categoryCombos",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.category.CategoryCombo",
+            },
+            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
+            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
+            {
+                name: "dataSet",
+                fieldName: "dataSet",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.dataset.DataSet",
+            },
+            {
+                name: "dataElement",
+                fieldName: "dataElements",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.dataelement.DataElement",
+            },
+            {
+                name: "showColumnTotals",
+                fieldName: "showColumnTotals",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "lastUpdatedBy",
+                fieldName: "lastUpdatedBy",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "userGroupAccess",
+                fieldName: "userGroupAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
+            },
+            {
+                name: "created",
+                fieldName: "created",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "attributeValue",
+                fieldName: "attributeValues",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
+            },
+            {
+                name: "indicator",
+                fieldName: "indicators",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.indicator.Indicator",
+            },
+            {
+                name: "sortOrder",
+                fieldName: "sortOrder",
+                propertyType: "INTEGER",
+                klass: "java.lang.Integer",
+            },
+            {
+                name: "userAccess",
+                fieldName: "userAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserAccess",
+            },
+            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
+            {
+                name: "user",
+                fieldName: "user",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "showRowTotals",
+                fieldName: "showRowTotals",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
             },
             { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
         ],
@@ -31743,6 +31513,41 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             { name: "optionSetValue", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
         ],
     },
+    trackedEntityDataElementDimensions: {
+        klass: "org.hisp.dhis.trackedentity.TrackedEntityDataElementDimension",
+        shareable: false,
+        metadata: false,
+        plural: "trackedEntityDataElementDimensions",
+        displayName: "Tracked Entity Data Element Dimension",
+        collectionName: "trackedEntityDataElementDimensions",
+        nameableObject: false,
+        translatable: false,
+        identifiableObject: false,
+        dataShareable: false,
+        name: "dataElementDimension",
+        persisted: true,
+        embeddedObject: false,
+        properties: [
+            {
+                name: "filter",
+                fieldName: "filter",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "legendSet",
+                fieldName: "legendSet",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.legend.LegendSet",
+            },
+            {
+                name: "dataElement",
+                fieldName: "dataElement",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.dataelement.DataElement",
+            },
+        ],
+    },
     trackedEntityInstances: {
         klass: "org.hisp.dhis.trackedentity.TrackedEntityInstance",
         shareable: false,
@@ -32096,6 +31901,41 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "org.hisp.dhis.user.User",
             },
             { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+        ],
+    },
+    dataElementDimensions: {
+        klass: "org.hisp.dhis.trackedentity.TrackedEntityProgramIndicatorDimension",
+        shareable: false,
+        metadata: false,
+        plural: "dataElementDimensions",
+        displayName: "Tracked Entity Program Indicator Dimension",
+        collectionName: "dataElementDimensions",
+        nameableObject: false,
+        translatable: false,
+        identifiableObject: false,
+        dataShareable: false,
+        name: "programIndicatorDimension",
+        persisted: true,
+        embeddedObject: false,
+        properties: [
+            {
+                name: "filter",
+                fieldName: "filter",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "legendSet",
+                fieldName: "legendSet",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.legend.LegendSet",
+            },
+            {
+                name: "programIndicator",
+                fieldName: "programIndicator",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.program.ProgramIndicator",
+            },
         ],
     },
     trackedEntityTypes: {
@@ -32735,6 +32575,143 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             { name: "userUid", propertyType: "TEXT", klass: "java.lang.String" },
         ],
     },
+    userRoles: {
+        klass: "org.hisp.dhis.user.UserAuthorityGroup",
+        shareable: true,
+        metadata: true,
+        relativeApiEndpoint: "/userRoles",
+        plural: "userRoles",
+        displayName: "User Authority Group",
+        collectionName: "userRoles",
+        nameableObject: false,
+        translatable: true,
+        identifiableObject: true,
+        dataShareable: false,
+        name: "userRole",
+        persisted: true,
+        embeddedObject: false,
+        properties: [
+            {
+                name: "favorite",
+                fieldName: "favorites",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.Set",
+                itemKlass: "java.lang.String",
+            },
+            {
+                name: "lastUpdatedBy",
+                fieldName: "lastUpdatedBy",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "access",
+                fieldName: "access",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.security.acl.Access",
+            },
+            {
+                name: "userGroupAccess",
+                fieldName: "userGroupAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
+            },
+            {
+                name: "code",
+                fieldName: "code",
+                propertyType: "IDENTIFIER",
+                klass: "java.lang.String",
+            },
+            {
+                name: "created",
+                fieldName: "created",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "displayName",
+                fieldName: "displayName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "publicAccess",
+                fieldName: "publicAccess",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "attributeValue",
+                fieldName: "attributeValues",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
+            },
+            {
+                name: "description",
+                fieldName: "description",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "authority",
+                fieldName: "authorities",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.Set",
+                itemKlass: "java.lang.String",
+            },
+            {
+                name: "userObject",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "externalAccess",
+                fieldName: "externalAccess",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "lastUpdated",
+                fieldName: "lastUpdated",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "translation",
+                fieldName: "translations",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.translation.Translation",
+            },
+            {
+                name: "userAccess",
+                fieldName: "userAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserAccess",
+            },
+            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
+            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
+            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
+            {
+                name: "user",
+                fieldName: "user",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+        ],
+    },
     userCredentials: {
         klass: "org.hisp.dhis.user.UserCredentials",
         shareable: false,
@@ -33112,19 +33089,19 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             { name: "displayName", propertyType: "TEXT", klass: "java.lang.String" },
         ],
     },
-    userRoles: {
-        klass: "org.hisp.dhis.user.UserAuthorityGroup",
-        shareable: true,
+    validationNotificationTemplates: {
+        klass: "org.hisp.dhis.validation.notification.ValidationNotificationTemplate",
+        shareable: false,
         metadata: true,
-        relativeApiEndpoint: "/userRoles",
-        plural: "userRoles",
-        displayName: "User Authority Group",
-        collectionName: "userRoles",
+        relativeApiEndpoint: "/validationNotificationTemplates",
+        plural: "validationNotificationTemplates",
+        displayName: "Validation Notification Template",
+        collectionName: "validationNotificationTemplates",
         nameableObject: false,
-        translatable: true,
+        translatable: false,
         identifiableObject: true,
         dataShareable: false,
-        name: "userRole",
+        name: "identifiableObject",
         persisted: true,
         embeddedObject: false,
         properties: [
@@ -33137,36 +33114,16 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 itemKlass: "java.lang.String",
             },
             {
-                name: "lastUpdatedBy",
-                fieldName: "lastUpdatedBy",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            {
                 name: "access",
                 fieldName: "access",
                 propertyType: "COMPLEX",
                 klass: "org.hisp.dhis.security.acl.Access",
             },
             {
-                name: "userGroupAccess",
-                fieldName: "userGroupAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
-            },
-            {
                 name: "code",
                 fieldName: "code",
                 propertyType: "IDENTIFIER",
                 klass: "java.lang.String",
-            },
-            {
-                name: "created",
-                fieldName: "created",
-                propertyType: "DATE",
-                klass: "java.util.Date",
             },
             {
                 name: "displayName",
@@ -33181,33 +33138,12 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "java.lang.String",
             },
             {
-                name: "attributeValue",
-                fieldName: "attributeValues",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
-            },
-            {
-                name: "description",
-                fieldName: "description",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "authority",
-                fieldName: "authorities",
-                propertyType: "COLLECTION",
-                itemPropertyType: "TEXT",
-                klass: "java.util.Set",
-                itemKlass: "java.lang.String",
-            },
-            {
-                name: "userObject",
+                name: "recipientUserGroups",
+                fieldName: "recipientUserGroups",
                 propertyType: "COLLECTION",
                 itemPropertyType: "REFERENCE",
-                klass: "java.util.List",
-                itemKlass: "org.hisp.dhis.user.User",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserGroup",
             },
             {
                 name: "externalAccess",
@@ -33229,6 +33165,68 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "java.util.Set",
                 itemKlass: "org.hisp.dhis.translation.Translation",
             },
+            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
+            {
+                name: "subjectTemplate",
+                fieldName: "subjectTemplate",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
+            {
+                name: "sendStrategy",
+                fieldName: "sendStrategy",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.notification.SendStrategy",
+            },
+            {
+                name: "lastUpdatedBy",
+                fieldName: "lastUpdatedBy",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "userGroupAccess",
+                fieldName: "userGroupAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
+            },
+            {
+                name: "validationRules",
+                fieldName: "validationRules",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.validation.ValidationRule",
+            },
+            {
+                name: "created",
+                fieldName: "created",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "notifyUsersInHierarchyOnly",
+                fieldName: "notifyUsersInHierarchyOnly",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "attributeValue",
+                fieldName: "attributeValues",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
+            },
+            {
+                name: "notifyParentOrganisationUnitOnly",
+                fieldName: "notifyParentOrganisationUnitOnly",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
             {
                 name: "userAccess",
                 fieldName: "userAccesses",
@@ -33238,8 +33236,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 itemKlass: "org.hisp.dhis.user.UserAccess",
             },
             { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
-            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
-            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
             {
                 name: "user",
                 fieldName: "user",
@@ -33247,6 +33243,12 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "org.hisp.dhis.user.User",
             },
             { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+            {
+                name: "messageTemplate",
+                fieldName: "messageTemplate",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
         ],
     },
     validationResults: {
@@ -33711,7 +33713,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
 };
 
 export type D2ModelSchemas = {
-    predictors: D2PredictorSchema;
     analyticsPeriodBoundaries: D2AnalyticsPeriodBoundarySchema;
     analyticsTableHooks: D2AnalyticsTableHookSchema;
     attributes: D2AttributeSchema;
@@ -33733,7 +33734,6 @@ export type D2ModelSchemas = {
     dataApprovalLevels: D2DataApprovalLevelSchema;
     dataApprovalWorkflows: D2DataApprovalWorkflowSchema;
     dataElements: D2DataElementSchema;
-    trackedEntityDataElementDimensions: D2TrackedEntityDataElementDimensionSchema;
     dataElementGroups: D2DataElementGroupSchema;
     dataElementGroupSets: D2DataElementGroupSetSchema;
     dataElementGroupSetDimensions: D2DataElementGroupSetDimensionSchema;
@@ -33747,13 +33747,10 @@ export type D2ModelSchemas = {
     eventCharts: D2EventChartSchema;
     eventReports: D2EventReportSchema;
     expressions: D2ExpressionSchema;
-    externalMapLayers: D2ExternalMapLayerSchema;
-    icons: D2IconSchema;
     externalFileResources: D2ExternalFileResourceSchema;
-    validationNotificationTemplates: D2ValidationNotificationTemplateSchema;
-    dataStores: D2KeyJsonValueSchema;
+    externalMapLayers: D2ExternalMapLayerSchema;
     fileResources: D2FileResourceSchema;
-    programStageInstances: D2ProgramStageInstanceSchema;
+    icons: D2IconSchema;
     indicators: D2IndicatorSchema;
     indicatorGroups: D2IndicatorGroupSchema;
     indicatorGroupSets: D2IndicatorGroupSetSchema;
@@ -33761,6 +33758,7 @@ export type D2ModelSchemas = {
     interpretations: D2InterpretationSchema;
     interpretationComments: D2InterpretationCommentSchema;
     jobConfigurations: D2JobConfigurationSchema;
+    dataStores: D2KeyJsonValueSchema;
     legends: D2LegendSchema;
     legendSets: D2LegendSetSchema;
     maps: D2MapSchema;
@@ -33778,12 +33776,11 @@ export type D2ModelSchemas = {
     organisationUnitGroupSets: D2OrganisationUnitGroupSetSchema;
     organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimensionSchema;
     organisationUnitLevels: D2OrganisationUnitLevelSchema;
+    predictors: D2PredictorSchema;
     predictorGroups: D2PredictorGroupSchema;
     programs: D2ProgramSchema;
-    ProgramTrackedEntityAttributeDimensionItems: D2ProgramTrackedEntityAttributeDimensionItemSchema;
     programDataElements: D2ProgramDataElementDimensionItemSchema;
     programIndicators: D2ProgramIndicatorSchema;
-    dataElementDimensions: D2TrackedEntityProgramIndicatorDimensionSchema;
     programIndicatorGroups: D2ProgramIndicatorGroupSchema;
     programInstances: D2ProgramInstanceSchema;
     programNotificationTemplates: D2ProgramNotificationTemplateSchema;
@@ -33793,9 +33790,11 @@ export type D2ModelSchemas = {
     programSections: D2ProgramSectionSchema;
     programStages: D2ProgramStageSchema;
     programStageDataElements: D2ProgramStageDataElementSchema;
+    programStageInstances: D2ProgramStageInstanceSchema;
     eventFilters: D2ProgramStageInstanceFilterSchema;
     programStageSections: D2ProgramStageSectionSchema;
     programTrackedEntityAttributes: D2ProgramTrackedEntityAttributeSchema;
+    ProgramTrackedEntityAttributeDimensionItems: D2ProgramTrackedEntityAttributeDimensionItemSchema;
     programTrackedEntityAttributeGroups: D2ProgramTrackedEntityAttributeGroupSchema;
     pushAnalysis: D2PushAnalysisSchema;
     relationships: D2RelationshipSchema;
@@ -33803,20 +33802,23 @@ export type D2ModelSchemas = {
     reports: D2ReportSchema;
     reportTables: D2ReportTableSchema;
     reportingRates: D2ReportingRateSchema;
-    sections: D2SectionSchema;
     smsCommands: D2SMSCommandSchema;
+    sections: D2SectionSchema;
     sqlViews: D2SqlViewSchema;
     trackedEntityAttributes: D2TrackedEntityAttributeSchema;
+    trackedEntityDataElementDimensions: D2TrackedEntityDataElementDimensionSchema;
     trackedEntityInstances: D2TrackedEntityInstanceSchema;
     trackedEntityInstanceFilters: D2TrackedEntityInstanceFilterSchema;
+    dataElementDimensions: D2TrackedEntityProgramIndicatorDimensionSchema;
     trackedEntityTypes: D2TrackedEntityTypeSchema;
     trackedEntityTypeAttributes: D2TrackedEntityTypeAttributeSchema;
     users: D2UserSchema;
     userAccesses: D2UserAccessSchema;
+    userRoles: D2UserAuthorityGroupSchema;
     userCredentials: D2UserCredentialsSchema;
     userGroups: D2UserGroupSchema;
     userGroupAccesses: D2UserGroupAccessSchema;
-    userRoles: D2UserAuthorityGroupSchema;
+    validationNotificationTemplates: D2ValidationNotificationTemplateSchema;
     validationResults: D2ValidationResultSchema;
     validationRules: D2ValidationRuleSchema;
     validationRuleGroups: D2ValidationRuleGroupSchema;

--- a/src/2.33/schemas.ts
+++ b/src/2.33/schemas.ts
@@ -13,7 +13,83 @@ import {
     D2DimensionalKeywords,
     D2Expression,
     D2RelationshipConstraint,
+    D2ReportingParams,
+    D2Axis,
 } from "../schemas/base";
+
+export type D2AnalyticsPeriodBoundary = {
+    access: D2Access;
+    analyticsPeriodBoundaryType:
+        | "BEFORE_START_OF_REPORTING_PERIOD"
+        | "BEFORE_END_OF_REPORTING_PERIOD"
+        | "AFTER_START_OF_REPORTING_PERIOD"
+        | "AFTER_END_OF_REPORTING_PERIOD";
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    boundaryTarget: string;
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    offsetPeriodType: string;
+    offsetPeriods: number;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2AnalyticsTableHook = {
+    access: D2Access;
+    analyticsTableType:
+        | "DATA_VALUE"
+        | "COMPLETENESS"
+        | "COMPLETENESS_TARGET"
+        | "ORG_UNIT_TARGET"
+        | "EVENT"
+        | "ENROLLMENT"
+        | "VALIDATION_RESULT";
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    phase: "RESOURCE_TABLE_POPULATED" | "ANALYTICS_TABLE_POPULATED";
+    publicAccess: string;
+    resourceTableType:
+        | "ORG_UNIT_STRUCTURE"
+        | "DATA_SET_ORG_UNIT_CATEGORY"
+        | "CATEGORY_OPTION_COMBO_NAME"
+        | "DATA_ELEMENT_GROUP_SET_STRUCTURE"
+        | "INDICATOR_GROUP_SET_STRUCTURE"
+        | "ORG_UNIT_GROUP_SET_STRUCTURE"
+        | "CATEGORY_STRUCTURE"
+        | "DATA_ELEMENT_STRUCTURE"
+        | "PERIOD_STRUCTURE"
+        | "DATE_PERIOD_STRUCTURE"
+        | "DATA_ELEMENT_CATEGORY_OPTION_COMBO"
+        | "DATA_APPROVAL_REMAP_LEVEL"
+        | "DATA_APPROVAL_MIN_LEVEL";
+    sql: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
 
 export type D2Attribute = {
     access: D2Access;
@@ -102,361 +178,7 @@ export type D2Attribute = {
         | "IMAGE";
 };
 
-export type D2UserAuthorityGroup = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    authorities: string[];
-    code: Id;
-    created: string;
-    description: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    users: D2User[];
-};
-
-export type D2User = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    avatar: D2FileResource;
-    birthday: string;
-    code: Id;
-    created: string;
-    dataViewOrganisationUnits: D2OrganisationUnit[];
-    displayName: string;
-    education: string;
-    email: string;
-    employer: string;
-    externalAccess: boolean;
-    facebookMessenger: string;
-    favorite: boolean;
-    favorites: string[];
-    firstName: string;
-    gender: string;
-    href: string;
-    id: Id;
-    interests: string;
-    introduction: string;
-    jobTitle: string;
-    languages: string;
-    lastCheckedInterpretations: string;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    nationality: string;
-    organisationUnits: D2OrganisationUnit[];
-    phoneNumber: string;
-    publicAccess: string;
-    skype: string;
-    surname: string;
-    teiSearchOrganisationUnits: D2OrganisationUnit[];
-    telegram: string;
-    translations: D2Translation[];
-    twitter: string;
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userCredentials: D2UserCredentials;
-    userGroupAccesses: D2UserGroupAccess[];
-    userGroups: D2UserGroup[];
-    welcomeMessage: string;
-    whatsApp: string;
-};
-
-export type D2UserGroup = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    managedByGroups: D2UserGroup[];
-    managedGroups: D2UserGroup[];
-    name: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    users: D2User[];
-};
-
-export type D2Expression = {
-    description: string;
-    expression: string;
-    missingValueStrategy: "SKIP_IF_ANY_VALUE_MISSING" | "SKIP_IF_ALL_VALUES_MISSING" | "NEVER_SKIP";
-    slidingWindow: boolean;
-};
-
-export type D2ExternalFileResource = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2SqlView = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    cacheStrategy:
-        | "NO_CACHE"
-        | "CACHE_15_MINUTES"
-        | "CACHE_30_MINUTES"
-        | "CACHE_1_HOUR"
-        | "CACHE_6AM_TOMORROW"
-        | "CACHE_TWO_WEEKS"
-        | "RESPECT_SYSTEM_SETTING";
-    code: Id;
-    created: string;
-    description: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    sqlQuery: string;
-    translations: D2Translation[];
-    type: "VIEW" | "MATERIALIZED_VIEW" | "QUERY";
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2OAuth2Client = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    cid: Id;
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    grantTypes: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    redirectUris: string[];
-    secret: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2Constant = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    shortName: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    value: number;
-};
-
-export type D2Option = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: string;
-    created: string;
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    optionSet: D2OptionSet;
-    publicAccess: string;
-    shortName: string;
-    sortOrder: number;
-    style: D2Style;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2JobConfiguration = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    configurable: boolean;
-    continuousExecution: boolean;
-    created: string;
-    cronExpression: string;
-    displayName: string;
-    enabled: boolean;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    jobParameters: string;
-    jobStatus: "RUNNING" | "COMPLETED" | "STOPPED" | "SCHEDULED" | "DISABLED" | "FAILED";
-    jobType:
-        | "DATA_STATISTICS"
-        | "DATA_INTEGRITY"
-        | "RESOURCE_TABLE"
-        | "ANALYTICS_TABLE"
-        | "DATA_SYNC"
-        | "TRACKER_PROGRAMS_DATA_SYNC"
-        | "EVENT_PROGRAMS_DATA_SYNC"
-        | "FILE_RESOURCE_CLEANUP"
-        | "IMAGE_PROCESSING"
-        | "META_DATA_SYNC"
-        | "SMS_SEND"
-        | "SEND_SCHEDULED_MESSAGE"
-        | "PROGRAM_NOTIFICATIONS"
-        | "VALIDATION_RESULTS_NOTIFICATION"
-        | "CREDENTIALS_EXPIRY_ALERT"
-        | "MONITORING"
-        | "PUSH_ANALYSIS"
-        | "PREDICTOR"
-        | "DATA_SET_NOTIFICATION"
-        | "REMOVE_EXPIRED_RESERVED_VALUES"
-        | "MOCK"
-        | "DATAVALUE_IMPORT"
-        | "ANALYTICSTABLE_UPDATE"
-        | "METADATA_IMPORT"
-        | "GML_IMPORT"
-        | "DATAVALUE_IMPORT_INTERNAL"
-        | "EVENT_IMPORT"
-        | "ENROLLMENT_IMPORT"
-        | "TEI_IMPORT"
-        | "LEADER_ELECTION"
-        | "LEADER_RENEWAL"
-        | "COMPLETE_DATA_SET_REGISTRATION_IMPORT"
-        | "PROGRAM_DATA_SYNC";
-    lastExecuted: string;
-    lastExecutedStatus: "RUNNING" | "COMPLETED" | "STOPPED" | "SCHEDULED" | "DISABLED" | "FAILED";
-    lastRuntimeExecution: string;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    leaderOnlyJob: boolean;
-    name: string;
-    nextExecutionTime: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    userUid: string;
-};
-
-export type D2OptionSet = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    options: D2Option[];
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    valueType:
-        | "TEXT"
-        | "LONG_TEXT"
-        | "LETTER"
-        | "PHONE_NUMBER"
-        | "EMAIL"
-        | "BOOLEAN"
-        | "TRUE_ONLY"
-        | "DATE"
-        | "DATETIME"
-        | "TIME"
-        | "NUMBER"
-        | "UNIT_INTERVAL"
-        | "PERCENTAGE"
-        | "INTEGER"
-        | "INTEGER_POSITIVE"
-        | "INTEGER_NEGATIVE"
-        | "INTEGER_ZERO_OR_POSITIVE"
-        | "TRACKER_ASSOCIATE"
-        | "USERNAME"
-        | "COORDINATE"
-        | "ORGANISATION_UNIT"
-        | "AGE"
-        | "URL"
-        | "FILE_RESOURCE"
-        | "IMAGE";
-    version: number;
-};
-
-export type D2OptionGroupSet = {
+export type D2Category = {
     access: D2Access;
     aggregationType:
         | "SUM"
@@ -476,6 +198,8 @@ export type D2OptionGroupSet = {
         | "DEFAULT";
     allItems: boolean;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    categoryCombos: D2CategoryCombo[];
+    categoryOptions: D2CategoryOption[];
     code: Id;
     created: string;
     dataDimension: boolean;
@@ -518,8 +242,6 @@ export type D2OptionGroupSet = {
     lastUpdatedBy: D2User;
     legendSet: D2LegendSet;
     name: string;
-    optionGroups: D2OptionGroup[];
-    optionSet: D2OptionSet;
     programStage: D2ProgramStage;
     publicAccess: string;
     shortName: string;
@@ -529,358 +251,35 @@ export type D2OptionGroupSet = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2OptionGroup = {
-    access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "FIRST"
-        | "FIRST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
-    name: string;
-    optionSet: D2OptionSet;
-    options: D2Option[];
-    publicAccess: string;
-    shortName: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2LegendSet = {
+export type D2CategoryCombo = {
     access: D2Access;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    categories: D2Category[];
+    categoryOptionCombos: D2CategoryOptionCombo[];
     code: Id;
     created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    legends: D2Legend[];
-    name: string;
-    publicAccess: string;
-    symbolizer: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2ColorSet = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    colors: D2Color[];
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2OrganisationUnit = {
-    access: D2Access;
-    address: string;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "FIRST"
-        | "FIRST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    ancestors: D2OrganisationUnit[];
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    children: D2OrganisationUnit[];
-    closedDate: string;
-    code: Id;
-    comment: string;
-    contactPerson: string;
-    created: string;
-    dataSets: D2DataSet[];
-    description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    email: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    geometry: D2Geometry;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    leaf: boolean;
-    legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
-    level: number;
-    memberCount: number;
-    name: string;
-    openingDate: string;
-    organisationUnitGroups: D2OrganisationUnitGroup[];
-    parent: D2OrganisationUnit;
-    path: string;
-    phoneNumber: string;
-    programs: D2Program[];
-    publicAccess: string;
-    shortName: string;
-    translations: D2Translation[];
-    type: string;
-    url: string;
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    users: D2User[];
-};
-
-export type D2OrganisationUnitLevel = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    level: number;
-    name: string;
-    offlineLevels: number;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2OrganisationUnitGroup = {
-    access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "FIRST"
-        | "FIRST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    color: string;
-    created: string;
-    description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
-    formName: string;
-    geometry: D2Geometry;
-    groupSets: D2OrganisationUnitGroupSet[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
-    name: string;
-    organisationUnits: D2OrganisationUnit[];
-    publicAccess: string;
-    shortName: string;
-    symbol: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2OrganisationUnitGroupSet = {
-    access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "FIRST"
-        | "FIRST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    allItems: boolean;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    compulsory: boolean;
-    created: string;
-    dataDimension: boolean;
     dataDimensionType: "DISAGGREGATION" | "ATTRIBUTE";
-    description: string;
-    dimension: string;
-    dimensionType:
-        | "DATA_X"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "DATA_COLLAPSED"
-        | "CATEGORY_OPTION_COMBO"
-        | "ATTRIBUTE_OPTION_COMBO"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION_GROUP_SET"
-        | "DATA_ELEMENT_GROUP_SET"
-        | "ORGANISATION_UNIT_GROUP_SET"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY"
-        | "OPTION_GROUP_SET"
-        | "VALIDATION_RULE"
-        | "STATIC"
-        | "ORGANISATION_UNIT_LEVEL";
-    dimensionalKeywords: D2DimensionalKeywords;
-    displayDescription: string;
-    displayFormName: string;
     displayName: string;
-    displayShortName: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
-    filter: string;
-    formName: string;
     href: string;
     id: Id;
-    includeSubhierarchyInAnalytics: boolean;
-    items: any[];
+    isDefault: boolean;
     lastUpdated: string;
     lastUpdatedBy: D2User;
-    legendSet: D2LegendSet;
     name: string;
-    organisationUnitGroups: D2OrganisationUnitGroup[];
-    programStage: D2ProgramStage;
     publicAccess: string;
-    shortName: string;
+    skipTotal: boolean;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2CategoryDimension = {
+    category: D2Category;
+    categoryOptions: D2CategoryOption[];
 };
 
 export type D2CategoryOption = {
@@ -946,6 +345,70 @@ export type D2CategoryOption = {
     shortName: string;
     startDate: string;
     style: D2Style;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2CategoryOptionCombo = {
+    access: D2Access;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    categoryCombo: D2CategoryCombo;
+    categoryOptions: D2CategoryOption[];
+    code: Id;
+    created: string;
+    description: string;
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    ignoreApproval: boolean;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
+    name: string;
+    publicAccess: string;
+    shortName: string;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
@@ -1088,7 +551,12 @@ export type D2CategoryOptionGroupSet = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2Category = {
+export type D2CategoryOptionGroupSetDimension = {
+    categoryOptionGroupSet: D2CategoryOptionGroupSet;
+    categoryOptionGroups: D2CategoryOptionGroup[];
+};
+
+export type D2Chart = {
     access: D2Access;
     aggregationType:
         | "SUM"
@@ -1106,36 +574,154 @@ export type D2Category = {
         | "NONE"
         | "CUSTOM"
         | "DEFAULT";
-    allItems: boolean;
+    attributeDimensions: any[];
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    categoryCombos: D2CategoryCombo[];
-    categoryOptions: D2CategoryOption[];
+    baseLineLabel: string;
+    baseLineValue: number;
+    category: string;
+    categoryDimensions: D2CategoryDimension[];
+    categoryOptionGroupSetDimensions: D2CategoryOptionGroupSetDimension[];
+    code: Id;
+    colorSet: D2ColorSet;
+    columns: any[];
+    completedOnly: boolean;
+    created: string;
+    cumulativeValues: boolean;
+    dataDimensionItems: any[];
+    dataElementDimensions: D2TrackedEntityDataElementDimension[];
+    dataElementGroupSetDimensions: D2DataElementGroupSetDimension[];
+    description: string;
+    digitGroupSeparator: "COMMA" | "SPACE" | "NONE";
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    domainAxisLabel: string;
+    endDate: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    filterDimensions: string[];
+    filters: any[];
+    formName: string;
+    hideEmptyRowItems: "NONE" | "BEFORE_FIRST" | "AFTER_LAST" | "BEFORE_FIRST_AFTER_LAST" | "ALL";
+    hideLegend: boolean;
+    hideSubtitle: boolean;
+    hideTitle: boolean;
+    href: string;
+    id: Id;
+    interpretations: D2Interpretation[];
+    itemOrganisationUnitGroups: D2OrganisationUnitGroup[];
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendDisplayStrategy: "FIXED" | "BY_DATA_ITEM";
+    legendSet: D2LegendSet;
+    name: string;
+    noSpaceBetweenColumns: boolean;
+    orgUnitField: string;
+    organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimension[];
+    organisationUnitLevels: number[];
+    organisationUnits: D2OrganisationUnit[];
+    parentGraphMap: D2Map;
+    percentStackedValues: boolean;
+    periods: any[];
+    programIndicatorDimensions: D2TrackedEntityProgramIndicatorDimension[];
+    publicAccess: string;
+    rangeAxisDecimals: number;
+    rangeAxisLabel: string;
+    rangeAxisMaxValue: number;
+    rangeAxisMinValue: number;
+    rangeAxisSteps: number;
+    regressionType: "NONE" | "LINEAR" | "POLYNOMIAL" | "LOESS";
+    relativePeriods: any;
+    rows: any[];
+    series: string;
+    seriesItems: any[];
+    shortName: string;
+    showData: boolean;
+    sortOrder: number;
+    startDate: string;
+    subscribed: boolean;
+    subscribers: string[];
+    subtitle: string;
+    targetLineLabel: string;
+    targetLineValue: number;
+    timeField: string;
+    title: string;
+    topLimit: number;
+    translations: D2Translation[];
+    type:
+        | "COLUMN"
+        | "STACKED_COLUMN"
+        | "BAR"
+        | "STACKED_BAR"
+        | "LINE"
+        | "AREA"
+        | "PIE"
+        | "RADAR"
+        | "GAUGE"
+        | "YEAR_OVER_YEAR_LINE"
+        | "YEAR_OVER_YEAR_COLUMN"
+        | "SINGLE_VALUE";
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    userOrganisationUnit: boolean;
+    userOrganisationUnitChildren: boolean;
+    userOrganisationUnitGrandChildren: boolean;
+    yearlySeries: string[];
+};
+
+export type D2Color = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    color: string;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ColorSet = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    colors: D2Color[];
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2Constant = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
-    dataDimension: boolean;
-    dataDimensionType: "DISAGGREGATION" | "ATTRIBUTE";
     description: string;
-    dimension: string;
-    dimensionType:
-        | "DATA_X"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "DATA_COLLAPSED"
-        | "CATEGORY_OPTION_COMBO"
-        | "ATTRIBUTE_OPTION_COMBO"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION_GROUP_SET"
-        | "DATA_ELEMENT_GROUP_SET"
-        | "ORGANISATION_UNIT_GROUP_SET"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY"
-        | "OPTION_GROUP_SET"
-        | "VALIDATION_RULE"
-        | "STATIC"
-        | "ORGANISATION_UNIT_LEVEL";
-    dimensionalKeywords: D2DimensionalKeywords;
     displayDescription: string;
     displayFormName: string;
     displayName: string;
@@ -1143,16 +729,42 @@ export type D2Category = {
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
-    filter: string;
     formName: string;
     href: string;
     id: Id;
-    items: any[];
     lastUpdated: string;
     lastUpdatedBy: D2User;
-    legendSet: D2LegendSet;
     name: string;
-    programStage: D2ProgramStage;
+    publicAccess: string;
+    shortName: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    value: number;
+};
+
+export type D2Dashboard = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    dashboardItems: D2DashboardItem[];
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    itemCount: number;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
     publicAccess: string;
     shortName: string;
     translations: D2Translation[];
@@ -1161,90 +773,102 @@ export type D2Category = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2CategoryCombo = {
+export type D2DashboardItem = {
+    access: D2Access;
+    appKey: string;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    chart: D2Chart;
+    code: Id;
+    contentCount: number;
+    created: string;
+    displayName: string;
+    eventChart: D2EventChart;
+    eventReport: D2EventReport;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    height: number;
+    href: string;
+    id: Id;
+    interpretationCount: number;
+    interpretationLikeCount: number;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    map: D2Map;
+    messages: boolean;
+    name: string;
+    publicAccess: string;
+    reportTable: D2ReportTable;
+    reports: D2Report[];
+    resources: D2Document[];
+    shape: "NORMAL" | "DOUBLE_WIDTH" | "FULL_WIDTH";
+    text: string;
+    translations: D2Translation[];
+    type:
+        | "CHART"
+        | "EVENT_CHART"
+        | "MAP"
+        | "REPORT_TABLE"
+        | "EVENT_REPORT"
+        | "USERS"
+        | "REPORTS"
+        | "RESOURCES"
+        | "TEXT"
+        | "MESSAGES"
+        | "APP";
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    users: D2User[];
+    width: number;
+    x: number;
+    y: number;
+};
+
+export type D2DataApprovalLevel = {
     access: D2Access;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    categories: D2Category[];
-    categoryOptionCombos: D2CategoryOptionCombo[];
+    categoryOptionGroupSet: D2CategoryOptionGroupSet;
     code: Id;
     created: string;
-    dataDimensionType: "DISAGGREGATION" | "ATTRIBUTE";
     displayName: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
     href: string;
     id: Id;
-    isDefault: boolean;
     lastUpdated: string;
     lastUpdatedBy: D2User;
+    level: number;
     name: string;
+    orgUnitLevel: number;
+    orgUnitLevelName: string;
     publicAccess: string;
-    skipTotal: boolean;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2CategoryOptionCombo = {
+export type D2DataApprovalWorkflow = {
     access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "FIRST"
-        | "FIRST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     categoryCombo: D2CategoryCombo;
-    categoryOptions: D2CategoryOption[];
     code: Id;
     created: string;
-    description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
-    displayDescription: string;
-    displayFormName: string;
+    dataApprovalLevels: D2DataApprovalLevel[];
+    dataSets: D2DataSet[];
     displayName: string;
-    displayShortName: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
-    formName: string;
     href: string;
     id: Id;
-    ignoreApproval: boolean;
     lastUpdated: string;
     lastUpdatedBy: D2User;
-    legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
     name: string;
+    periodType: string;
     publicAccess: string;
-    shortName: string;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
@@ -1486,78 +1110,13 @@ export type D2DataElementGroupSet = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2IndicatorType = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    factor: number;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    number: boolean;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
+export type D2DataElementGroupSetDimension = {
+    dataElementGroupSet: D2DataElementGroupSet;
+    dataElementGroups: D2DataElementGroup[];
 };
 
-export type D2AnalyticsTableHook = {
+export type D2DataElementOperand = {
     access: D2Access;
-    analyticsTableType:
-        | "DATA_VALUE"
-        | "COMPLETENESS"
-        | "COMPLETENESS_TARGET"
-        | "ORG_UNIT_TARGET"
-        | "EVENT"
-        | "ENROLLMENT"
-        | "VALIDATION_RESULT";
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    phase: "RESOURCE_TABLE_POPULATED" | "ANALYTICS_TABLE_POPULATED";
-    publicAccess: string;
-    resourceTableType:
-        | "ORG_UNIT_STRUCTURE"
-        | "DATA_SET_ORG_UNIT_CATEGORY"
-        | "CATEGORY_OPTION_COMBO_NAME"
-        | "DATA_ELEMENT_GROUP_SET_STRUCTURE"
-        | "INDICATOR_GROUP_SET_STRUCTURE"
-        | "ORG_UNIT_GROUP_SET_STRUCTURE"
-        | "CATEGORY_STRUCTURE"
-        | "DATA_ELEMENT_STRUCTURE"
-        | "PERIOD_STRUCTURE"
-        | "DATE_PERIOD_STRUCTURE"
-        | "DATA_ELEMENT_CATEGORY_OPTION_COMBO"
-        | "DATA_APPROVAL_REMAP_LEVEL"
-        | "DATA_APPROVAL_MIN_LEVEL";
-    sql: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2Indicator = {
-    access: D2Access;
-    aggregateExportAttributeOptionCombo: string;
-    aggregateExportCategoryOptionCombo: string;
     aggregationType:
         | "SUM"
         | "AVERAGE"
@@ -1574,14 +1133,12 @@ export type D2Indicator = {
         | "NONE"
         | "CUSTOM"
         | "DEFAULT";
-    annualized: boolean;
+    attributeOptionCombo: D2CategoryOptionCombo;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    categoryOptionCombo: D2CategoryOptionCombo;
     code: Id;
     created: string;
-    dataSets: D2DataSet[];
-    decimals: number;
-    denominator: string;
-    denominatorDescription: string;
+    dataElement: D2DataElement;
     description: string;
     dimensionItem: string;
     dimensionItemType:
@@ -1599,11 +1156,9 @@ export type D2Indicator = {
         | "DATA_ELEMENT_GROUP"
         | "ORGANISATION_UNIT_GROUP"
         | "CATEGORY_OPTION_GROUP";
-    displayDenominatorDescription: string;
     displayDescription: string;
     displayFormName: string;
     displayName: string;
-    displayNumeratorDescription: string;
     displayShortName: string;
     externalAccess: boolean;
     favorite: boolean;
@@ -1611,66 +1166,13 @@ export type D2Indicator = {
     formName: string;
     href: string;
     id: Id;
-    indicatorGroups: D2IndicatorGroup[];
-    indicatorType: D2IndicatorType;
     lastUpdated: string;
     lastUpdatedBy: D2User;
     legendSet: D2LegendSet;
     legendSets: D2LegendSet[];
     name: string;
-    numerator: string;
-    numeratorDescription: string;
     publicAccess: string;
     shortName: string;
-    style: D2Style;
-    translations: D2Translation[];
-    url: string;
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2IndicatorGroup = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    indicatorGroupSet: D2IndicatorGroupSet;
-    indicators: D2Indicator[];
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2IndicatorGroupSet = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    compulsory: boolean;
-    created: string;
-    description: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    indicatorGroups: D2IndicatorGroup[];
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
@@ -1699,6 +1201,12 @@ export type D2DataEntryForm = {
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2DataInputPeriod = {
+    closingDate: string;
+    openingDate: string;
+    period: any;
 };
 
 export type D2DataSet = {
@@ -1791,6 +1299,12 @@ export type D2DataSet = {
     workflow: D2DataApprovalWorkflow;
 };
 
+export type D2DataSetElement = {
+    categoryCombo: D2CategoryCombo;
+    dataElement: D2DataElement;
+    dataSet: D2DataSet;
+};
+
 export type D2DataSetNotificationTemplate = {
     access: D2Access;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
@@ -1823,174 +1337,15 @@ export type D2DataSetNotificationTemplate = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2Section = {
+export type D2Document = {
     access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    categoryCombos: D2CategoryCombo[];
-    code: Id;
-    created: string;
-    dataElements: D2DataElement[];
-    dataSet: D2DataSet;
-    description: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    greyedFields: D2DataElementOperand[];
-    href: string;
-    id: Id;
-    indicators: D2Indicator[];
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    showColumnTotals: boolean;
-    showRowTotals: boolean;
-    sortOrder: number;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2DataApprovalLevel = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    categoryOptionGroupSet: D2CategoryOptionGroupSet;
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    level: number;
-    name: string;
-    orgUnitLevel: number;
-    orgUnitLevelName: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2DataApprovalWorkflow = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    categoryCombo: D2CategoryCombo;
-    code: Id;
-    created: string;
-    dataApprovalLevels: D2DataApprovalLevel[];
-    dataSets: D2DataSet[];
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    periodType: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2ValidationRule = {
-    access: D2Access;
-    aggregateExportAttributeOptionCombo: string;
-    aggregateExportCategoryOptionCombo: string;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "FIRST"
-        | "FIRST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
+    attachment: boolean;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
+    contentType: string;
     created: string;
-    description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
-    displayDescription: string;
-    displayFormName: string;
     displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    importance: "HIGH" | "MEDIUM" | "LOW";
-    instruction: string;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    leftSide: D2Expression;
-    legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
-    name: string;
-    notificationTemplates: D2ValidationNotificationTemplate[];
-    operator:
-        | "equal_to"
-        | "not_equal_to"
-        | "greater_than"
-        | "greater_than_or_equal_to"
-        | "less_than"
-        | "less_than_or_equal_to"
-        | "compulsory_pair"
-        | "exclusive_pair";
-    organisationUnitLevels: number[];
-    periodType: string;
-    publicAccess: string;
-    rightSide: D2Expression;
-    shortName: string;
-    skipFormValidation: boolean;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    validationRuleGroups: D2ValidationRuleGroup[];
-};
-
-export type D2ValidationRuleGroup = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    description: string;
-    displayName: string;
+    external: boolean;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
@@ -2001,595 +1356,10 @@ export type D2ValidationRuleGroup = {
     name: string;
     publicAccess: string;
     translations: D2Translation[];
+    url: string;
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
-    validationRules: D2ValidationRule[];
-};
-
-export type D2ValidationNotificationTemplate = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    messageTemplate: string;
-    name: string;
-    notifyParentOrganisationUnitOnly: boolean;
-    notifyUsersInHierarchyOnly: boolean;
-    publicAccess: string;
-    recipientUserGroups: D2UserGroup[];
-    sendStrategy: "COLLECTIVE_SUMMARY" | "SINGLE_NOTIFICATION";
-    subjectTemplate: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    validationRules: D2ValidationRule[];
-};
-
-export type D2TrackedEntityAttribute = {
-    access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "FIRST"
-        | "FIRST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    confidential: boolean;
-    created: string;
-    description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
-    displayDescription: string;
-    displayFormName: string;
-    displayInListNoProgram: boolean;
-    displayName: string;
-    displayOnVisitSchedule: boolean;
-    displayShortName: string;
-    expression: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    fieldMask: string;
-    formName: string;
-    generated: boolean;
-    href: string;
-    id: Id;
-    inherit: boolean;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
-    name: string;
-    optionSet: D2OptionSet;
-    optionSetValue: boolean;
-    orgunitScope: boolean;
-    pattern: string;
-    publicAccess: string;
-    shortName: string;
-    skipSynchronization: boolean;
-    sortOrderInListNoProgram: number;
-    sortOrderInVisitSchedule: number;
-    style: D2Style;
-    translations: D2Translation[];
-    unique: boolean;
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    valueType:
-        | "TEXT"
-        | "LONG_TEXT"
-        | "LETTER"
-        | "PHONE_NUMBER"
-        | "EMAIL"
-        | "BOOLEAN"
-        | "TRUE_ONLY"
-        | "DATE"
-        | "DATETIME"
-        | "TIME"
-        | "NUMBER"
-        | "UNIT_INTERVAL"
-        | "PERCENTAGE"
-        | "INTEGER"
-        | "INTEGER_POSITIVE"
-        | "INTEGER_NEGATIVE"
-        | "INTEGER_ZERO_OR_POSITIVE"
-        | "TRACKER_ASSOCIATE"
-        | "USERNAME"
-        | "COORDINATE"
-        | "ORGANISATION_UNIT"
-        | "AGE"
-        | "URL"
-        | "FILE_RESOURCE"
-        | "IMAGE";
-};
-
-export type D2TrackedEntityType = {
-    access: D2Access;
-    allowAuditLog: boolean;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    maxTeiCountToReturn: number;
-    minAttributesRequiredToSearch: number;
-    name: string;
-    publicAccess: string;
-    shortName: string;
-    style: D2Style;
-    trackedEntityTypeAttributes: D2TrackedEntityTypeAttribute[];
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2ProgramTrackedEntityAttributeGroup = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    attributes: D2ProgramTrackedEntityAttribute[];
-    code: Id;
-    created: string;
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    shortName: string;
-    translations: D2Translation[];
-    uniqunessType: "NONE" | "STRICT" | "VALIDATION";
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2TrackedEntityTypeAttribute = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    displayInList: boolean;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    mandatory: boolean;
-    name: string;
-    publicAccess: string;
-    searchable: boolean;
-    trackedEntityAttribute: D2TrackedEntityAttribute;
-    trackedEntityType: D2TrackedEntityType;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    valueType:
-        | "TEXT"
-        | "LONG_TEXT"
-        | "LETTER"
-        | "PHONE_NUMBER"
-        | "EMAIL"
-        | "BOOLEAN"
-        | "TRUE_ONLY"
-        | "DATE"
-        | "DATETIME"
-        | "TIME"
-        | "NUMBER"
-        | "UNIT_INTERVAL"
-        | "PERCENTAGE"
-        | "INTEGER"
-        | "INTEGER_POSITIVE"
-        | "INTEGER_NEGATIVE"
-        | "INTEGER_ZERO_OR_POSITIVE"
-        | "TRACKER_ASSOCIATE"
-        | "USERNAME"
-        | "COORDINATE"
-        | "ORGANISATION_UNIT"
-        | "AGE"
-        | "URL"
-        | "FILE_RESOURCE"
-        | "IMAGE";
-};
-
-export type D2ProgramNotificationTemplate = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    deliveryChannels: never[];
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    messageTemplate: string;
-    name: string;
-    notificationRecipient:
-        | "TRACKED_ENTITY_INSTANCE"
-        | "ORGANISATION_UNIT_CONTACT"
-        | "USERS_AT_ORGANISATION_UNIT"
-        | "USER_GROUP"
-        | "PROGRAM_ATTRIBUTE"
-        | "DATA_ELEMENT";
-    notificationTrigger:
-        | "ENROLLMENT"
-        | "COMPLETION"
-        | "PROGRAM_RULE"
-        | "SCHEDULED_DAYS_DUE_DATE"
-        | "SCHEDULED_DAYS_INCIDENT_DATE"
-        | "SCHEDULED_DAYS_ENROLLMENT_DATE";
-    notifyParentOrganisationUnitOnly: boolean;
-    notifyUsersInHierarchyOnly: boolean;
-    publicAccess: string;
-    recipientDataElement: D2DataElement;
-    recipientProgramAttribute: D2TrackedEntityAttribute;
-    recipientUserGroup: D2UserGroup;
-    relativeScheduledDays: number;
-    subjectTemplate: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2ProgramStageSection = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    dataElements: D2DataElement[];
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    programIndicators: D2ProgramIndicator[];
-    programStage: D2ProgramStage;
-    publicAccess: string;
-    renderType: any;
-    shortName: string;
-    sortOrder: number;
-    style: D2Style;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2SMSCommand = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    codeValueSeparator: string;
-    completenessMethod: "ALL_DATAVALUE" | "AT_LEAST_ONE_DATAVALUE" | "DO_NOT_MARK_COMPLETE";
-    created: string;
-    currentPeriodUsedForReporting: boolean;
-    dataset: D2DataSet;
-    defaultMessage: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    moreThanOneOrgUnitMessage: string;
-    name: string;
-    noUserMessage: string;
-    parserType:
-        | "KEY_VALUE_PARSER"
-        | "J2ME_PARSER"
-        | "ALERT_PARSER"
-        | "UNREGISTERED_PARSER"
-        | "TRACKED_ENTITY_REGISTRATION_PARSER"
-        | "PROGRAM_STAGE_DATAENTRY_PARSER"
-        | "EVENT_REGISTRATION_PARSER";
-    program: D2Program;
-    programStage: D2ProgramStage;
-    publicAccess: string;
-    receivedMessage: string;
-    separator: string;
-    smsCodes: any[];
-    specialCharacters: any[];
-    successMessage: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroup: D2UserGroup;
-    userGroupAccesses: D2UserGroupAccess[];
-    wrongFormatMessage: string;
-};
-
-export type D2ProgramStage = {
-    access: D2Access;
-    allowGenerateNextVisit: boolean;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    autoGenerateEvent: boolean;
-    blockEntryForm: boolean;
-    code: Id;
-    created: string;
-    dataEntryForm: D2DataEntryForm;
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayGenerateEventBox: boolean;
-    displayName: string;
-    displayShortName: string;
-    dueDateLabel: string;
-    enableUserAssignment: boolean;
-    executionDateLabel: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
-    formName: string;
-    formType: "DEFAULT" | "CUSTOM" | "SECTION" | "SECTION_MULTIORG";
-    generatedByEnrollmentDate: boolean;
-    hideDueDate: boolean;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    minDaysFromStart: number;
-    name: string;
-    nextScheduleDate: D2DataElement;
-    notificationTemplates: D2ProgramNotificationTemplate[];
-    openAfterEnrollment: boolean;
-    periodType: string;
-    preGenerateUID: boolean;
-    program: D2Program;
-    programStageDataElements: D2ProgramStageDataElement[];
-    programStageSections: D2ProgramStageSection[];
-    publicAccess: string;
-    remindCompleted: boolean;
-    repeatable: boolean;
-    reportDateToUse: string;
-    shortName: string;
-    sortOrder: number;
-    standardInterval: number;
-    style: D2Style;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    validationStrategy: "ON_COMPLETE" | "ON_UPDATE_AND_INSERT";
-};
-
-export type D2Program = {
-    access: D2Access;
-    accessLevel: "OPEN" | "AUDITED" | "PROTECTED" | "CLOSED";
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    categoryCombo: D2CategoryCombo;
-    code: Id;
-    completeEventsExpiryDays: number;
-    created: string;
-    dataEntryForm: D2DataEntryForm;
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayFrontPageList: boolean;
-    displayIncidentDate: boolean;
-    displayName: string;
-    displayShortName: string;
-    enrollmentDateLabel: string;
-    expiryDays: number;
-    expiryPeriodType: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
-    formName: string;
-    href: string;
-    id: Id;
-    ignoreOverdueEvents: boolean;
-    incidentDateLabel: string;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    maxTeiCountToReturn: number;
-    minAttributesRequiredToSearch: number;
-    name: string;
-    notificationTemplates: D2ProgramNotificationTemplate[];
-    onlyEnrollOnce: boolean;
-    organisationUnits: D2OrganisationUnit[];
-    programIndicators: D2ProgramIndicator[];
-    programRuleVariables: D2ProgramRuleVariable[];
-    programSections: D2ProgramSection[];
-    programStages: D2ProgramStage[];
-    programTrackedEntityAttributes: D2ProgramTrackedEntityAttribute[];
-    programType: "WITH_REGISTRATION" | "WITHOUT_REGISTRATION";
-    publicAccess: string;
-    registration: boolean;
-    relatedProgram: D2Program;
-    selectEnrollmentDatesInFuture: boolean;
-    selectIncidentDatesInFuture: boolean;
-    shortName: string;
-    skipOffline: boolean;
-    style: D2Style;
-    trackedEntityType: D2TrackedEntityType;
-    translations: D2Translation[];
-    useFirstStageDuringRegistration: boolean;
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    userRoles: D2UserAuthorityGroup[];
-    version: number;
-    withoutRegistration: boolean;
-};
-
-export type D2EventReport = {
-    access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "FIRST"
-        | "FIRST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    attributeDimensions: any[];
-    attributeValueDimension: D2TrackedEntityAttribute;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    categoryDimensions: D2CategoryDimension[];
-    categoryOptionGroupSetDimensions: D2CategoryOptionGroupSetDimension[];
-    code: Id;
-    colSubTotals: boolean;
-    colTotals: boolean;
-    collapseDataDimensions: boolean;
-    columnDimensions: string[];
-    columns: any[];
-    completedOnly: boolean;
-    created: string;
-    dataDimensionItems: any[];
-    dataElementDimensions: D2TrackedEntityDataElementDimension[];
-    dataElementGroupSetDimensions: D2DataElementGroupSetDimension[];
-    dataElementValueDimension: D2DataElement;
-    dataType: "AGGREGATED_VALUES" | "EVENTS";
-    description: string;
-    digitGroupSeparator: "COMMA" | "SPACE" | "NONE";
-    displayDensity: "COMFORTABLE" | "NORMAL" | "COMPACT" | "NONE";
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    endDate: string;
-    eventStatus: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    filterDimensions: string[];
-    filters: any[];
-    fontSize: "LARGE" | "NORMAL" | "SMALL";
-    formName: string;
-    hideEmptyRows: boolean;
-    hideNaData: boolean;
-    hideSubtitle: boolean;
-    hideTitle: boolean;
-    href: string;
-    id: Id;
-    interpretations: D2Interpretation[];
-    itemOrganisationUnitGroups: D2OrganisationUnitGroup[];
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    orgUnitField: string;
-    organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimension[];
-    organisationUnitLevels: number[];
-    organisationUnits: D2OrganisationUnit[];
-    outputType: "EVENT" | "ENROLLMENT" | "TRACKED_ENTITY_INSTANCE";
-    parentGraphMap: D2Map;
-    periods: any[];
-    program: D2Program;
-    programIndicatorDimensions: D2TrackedEntityProgramIndicatorDimension[];
-    programStage: D2ProgramStage;
-    programStatus: "ACTIVE" | "COMPLETED" | "CANCELLED";
-    publicAccess: string;
-    relativePeriods: any;
-    rowDimensions: string[];
-    rowSubTotals: boolean;
-    rowTotals: boolean;
-    rows: any[];
-    shortName: string;
-    showDimensionLabels: boolean;
-    showHierarchy: boolean;
-    sortOrder: number;
-    startDate: string;
-    subscribed: boolean;
-    subscribers: string[];
-    subtitle: string;
-    timeField: string;
-    title: string;
-    topLimit: number;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    userOrganisationUnit: boolean;
-    userOrganisationUnitChildren: boolean;
-    userOrganisationUnitGrandChildren: boolean;
-    value: any;
 };
 
 export type D2EventChart = {
@@ -2717,39 +1487,194 @@ export type D2EventChart = {
     yearlySeries: string[];
 };
 
-export type D2ProgramSection = {
+export type D2EventReport = {
     access: D2Access;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    attributeDimensions: any[];
+    attributeValueDimension: D2TrackedEntityAttribute;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    categoryDimensions: D2CategoryDimension[];
+    categoryOptionGroupSetDimensions: D2CategoryOptionGroupSetDimension[];
     code: Id;
+    colSubTotals: boolean;
+    colTotals: boolean;
+    collapseDataDimensions: boolean;
+    columnDimensions: string[];
+    columns: any[];
+    completedOnly: boolean;
     created: string;
+    dataDimensionItems: any[];
+    dataElementDimensions: D2TrackedEntityDataElementDimension[];
+    dataElementGroupSetDimensions: D2DataElementGroupSetDimension[];
+    dataElementValueDimension: D2DataElement;
+    dataType: "AGGREGATED_VALUES" | "EVENTS";
     description: string;
+    digitGroupSeparator: "COMMA" | "SPACE" | "NONE";
+    displayDensity: "COMFORTABLE" | "NORMAL" | "COMPACT" | "NONE";
     displayDescription: string;
     displayFormName: string;
     displayName: string;
     displayShortName: string;
+    endDate: string;
+    eventStatus: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
+    filterDimensions: string[];
+    filters: any[];
+    fontSize: "LARGE" | "NORMAL" | "SMALL";
     formName: string;
+    hideEmptyRows: boolean;
+    hideNaData: boolean;
+    hideSubtitle: boolean;
+    hideTitle: boolean;
+    href: string;
+    id: Id;
+    interpretations: D2Interpretation[];
+    itemOrganisationUnitGroups: D2OrganisationUnitGroup[];
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    orgUnitField: string;
+    organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimension[];
+    organisationUnitLevels: number[];
+    organisationUnits: D2OrganisationUnit[];
+    outputType: "EVENT" | "ENROLLMENT" | "TRACKED_ENTITY_INSTANCE";
+    parentGraphMap: D2Map;
+    periods: any[];
+    program: D2Program;
+    programIndicatorDimensions: D2TrackedEntityProgramIndicatorDimension[];
+    programStage: D2ProgramStage;
+    programStatus: "ACTIVE" | "COMPLETED" | "CANCELLED";
+    publicAccess: string;
+    relativePeriods: any;
+    rowDimensions: string[];
+    rowSubTotals: boolean;
+    rowTotals: boolean;
+    rows: any[];
+    shortName: string;
+    showDimensionLabels: boolean;
+    showHierarchy: boolean;
+    sortOrder: number;
+    startDate: string;
+    subscribed: boolean;
+    subscribers: string[];
+    subtitle: string;
+    timeField: string;
+    title: string;
+    topLimit: number;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    userOrganisationUnit: boolean;
+    userOrganisationUnitChildren: boolean;
+    userOrganisationUnitGrandChildren: boolean;
+    value: any;
+};
+
+export type D2Expression = {
+    description: string;
+    expression: string;
+    missingValueStrategy: "SKIP_IF_ANY_VALUE_MISSING" | "SKIP_IF_ALL_VALUES_MISSING" | "NEVER_SKIP";
+    slidingWindow: boolean;
+};
+
+export type D2ExternalFileResource = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
     href: string;
     id: Id;
     lastUpdated: string;
     lastUpdatedBy: D2User;
     name: string;
-    program: D2Program;
     publicAccess: string;
-    renderType: any;
-    shortName: string;
-    sortOrder: number;
-    style: D2Style;
-    trackedEntityAttributes: D2TrackedEntityAttribute[];
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2ProgramIndicator = {
+export type D2ExternalMapLayer = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    attribution: string;
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    imageFormat: "PNG" | "JPG";
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    layers: string;
+    legendSet: D2LegendSet;
+    legendSetUrl: string;
+    mapLayerPosition: "BASEMAP" | "OVERLAY";
+    mapService: "WMS" | "TMS" | "XYZ";
+    name: string;
+    publicAccess: string;
+    translations: D2Translation[];
+    url: string;
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2FileResource = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    contentLength: string;
+    contentMd5: string;
+    contentType: string;
+    created: string;
+    displayName: string;
+    domain: "DATA_VALUE" | "PUSH_ANALYSIS" | "DOCUMENT" | "MESSAGE_ATTACHMENT" | "USER_AVATAR";
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    hasMultipleStorageFiles: boolean;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    storageStatus: "NONE" | "PENDING" | "FAILED" | "STORED";
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2Icon = {};
+
+export type D2Indicator = {
     access: D2Access;
     aggregateExportAttributeOptionCombo: string;
     aggregateExportCategoryOptionCombo: string;
@@ -2769,12 +1694,14 @@ export type D2ProgramIndicator = {
         | "NONE"
         | "CUSTOM"
         | "DEFAULT";
-    analyticsPeriodBoundaries: D2AnalyticsPeriodBoundary[];
-    analyticsType: "EVENT" | "ENROLLMENT";
+    annualized: boolean;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
+    dataSets: D2DataSet[];
     decimals: number;
+    denominator: string;
+    denominatorDescription: string;
     description: string;
     dimensionItem: string;
     dimensionItemType:
@@ -2792,68 +1719,65 @@ export type D2ProgramIndicator = {
         | "DATA_ELEMENT_GROUP"
         | "ORGANISATION_UNIT_GROUP"
         | "CATEGORY_OPTION_GROUP";
+    displayDenominatorDescription: string;
     displayDescription: string;
     displayFormName: string;
-    displayInForm: boolean;
     displayName: string;
+    displayNumeratorDescription: string;
     displayShortName: string;
-    expression: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
-    filter: string;
     formName: string;
     href: string;
     id: Id;
+    indicatorGroups: D2IndicatorGroup[];
+    indicatorType: D2IndicatorType;
     lastUpdated: string;
     lastUpdatedBy: D2User;
     legendSet: D2LegendSet;
     legendSets: D2LegendSet[];
     name: string;
-    program: D2Program;
-    programIndicatorGroups: D2ProgramIndicatorGroup[];
+    numerator: string;
+    numeratorDescription: string;
     publicAccess: string;
     shortName: string;
     style: D2Style;
     translations: D2Translation[];
+    url: string;
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2RelationshipType = {
+export type D2IndicatorGroup = {
     access: D2Access;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    bidirectional: boolean;
     code: Id;
     created: string;
-    description: string;
-    displayFromToName: string;
     displayName: string;
-    displayToFromName: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
-    fromConstraint: D2RelationshipConstraint;
-    fromToName: string;
     href: string;
     id: Id;
+    indicatorGroupSet: D2IndicatorGroupSet;
+    indicators: D2Indicator[];
     lastUpdated: string;
     lastUpdatedBy: D2User;
     name: string;
     publicAccess: string;
-    toConstraint: D2RelationshipConstraint;
-    toFromName: string;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2ProgramIndicatorGroup = {
+export type D2IndicatorGroupSet = {
     access: D2Access;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
+    compulsory: boolean;
     created: string;
     description: string;
     displayName: string;
@@ -2862,10 +1786,10 @@ export type D2ProgramIndicatorGroup = {
     favorites: string[];
     href: string;
     id: Id;
+    indicatorGroups: D2IndicatorGroup[];
     lastUpdated: string;
     lastUpdatedBy: D2User;
     name: string;
-    programIndicators: D2ProgramIndicator[];
     publicAccess: string;
     translations: D2Translation[];
     user: D2User;
@@ -2873,12 +1797,69 @@ export type D2ProgramIndicatorGroup = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2ProgramRuleVariable = {
+export type D2IndicatorType = {
     access: D2Access;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
-    dataElement: D2DataElement;
+    displayName: string;
+    externalAccess: boolean;
+    factor: number;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    number: boolean;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2Interpretation = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    chart: D2Chart;
+    code: Id;
+    comments: D2InterpretationComment[];
+    created: string;
+    dataSet: D2DataSet;
+    displayName: string;
+    eventChart: D2EventChart;
+    eventReport: D2EventReport;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    likedBy: D2User[];
+    likes: number;
+    map: D2Map;
+    mentions: any[];
+    name: string;
+    organisationUnit: D2OrganisationUnit;
+    period: any;
+    publicAccess: string;
+    reportTable: D2ReportTable;
+    text: string;
+    translations: D2Translation[];
+    type: "REPORT_TABLE" | "CHART" | "MAP" | "EVENT_REPORT" | "EVENT_CHART" | "DATASET_REPORT";
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2InterpretationComment = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
     displayName: string;
     externalAccess: boolean;
     favorite: boolean;
@@ -2887,33 +1868,137 @@ export type D2ProgramRuleVariable = {
     id: Id;
     lastUpdated: string;
     lastUpdatedBy: D2User;
+    mentions: any[];
     name: string;
-    program: D2Program;
-    programRuleVariableSourceType:
-        | "DATAELEMENT_NEWEST_EVENT_PROGRAM_STAGE"
-        | "DATAELEMENT_NEWEST_EVENT_PROGRAM"
-        | "DATAELEMENT_CURRENT_EVENT"
-        | "DATAELEMENT_PREVIOUS_EVENT"
-        | "CALCULATED_VALUE"
-        | "TEI_ATTRIBUTE";
-    programStage: D2ProgramStage;
     publicAccess: string;
-    trackedEntityAttribute: D2TrackedEntityAttribute;
+    text: string;
     translations: D2Translation[];
-    useCodeForOptionSet: boolean;
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2ProgramRuleAction = {
+export type D2JobConfiguration = {
     access: D2Access;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
-    content: string;
+    configurable: boolean;
+    continuousExecution: boolean;
     created: string;
-    data: string;
-    dataElement: D2DataElement;
+    cronExpression: string;
+    displayName: string;
+    enabled: boolean;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    jobParameters: string;
+    jobStatus: "RUNNING" | "COMPLETED" | "STOPPED" | "SCHEDULED" | "DISABLED" | "FAILED";
+    jobType:
+        | "DATA_STATISTICS"
+        | "DATA_INTEGRITY"
+        | "RESOURCE_TABLE"
+        | "ANALYTICS_TABLE"
+        | "DATA_SYNC"
+        | "TRACKER_PROGRAMS_DATA_SYNC"
+        | "EVENT_PROGRAMS_DATA_SYNC"
+        | "FILE_RESOURCE_CLEANUP"
+        | "IMAGE_PROCESSING"
+        | "META_DATA_SYNC"
+        | "SMS_SEND"
+        | "SEND_SCHEDULED_MESSAGE"
+        | "PROGRAM_NOTIFICATIONS"
+        | "VALIDATION_RESULTS_NOTIFICATION"
+        | "CREDENTIALS_EXPIRY_ALERT"
+        | "MONITORING"
+        | "PUSH_ANALYSIS"
+        | "PREDICTOR"
+        | "DATA_SET_NOTIFICATION"
+        | "REMOVE_EXPIRED_RESERVED_VALUES"
+        | "MOCK"
+        | "DATAVALUE_IMPORT"
+        | "ANALYTICSTABLE_UPDATE"
+        | "METADATA_IMPORT"
+        | "GML_IMPORT"
+        | "DATAVALUE_IMPORT_INTERNAL"
+        | "EVENT_IMPORT"
+        | "ENROLLMENT_IMPORT"
+        | "TEI_IMPORT"
+        | "LEADER_ELECTION"
+        | "LEADER_RENEWAL"
+        | "COMPLETE_DATA_SET_REGISTRATION_IMPORT"
+        | "PROGRAM_DATA_SYNC";
+    lastExecuted: string;
+    lastExecutedStatus: "RUNNING" | "COMPLETED" | "STOPPED" | "SCHEDULED" | "DISABLED" | "FAILED";
+    lastRuntimeExecution: string;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    leaderOnlyJob: boolean;
+    name: string;
+    nextExecutionTime: string;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    userUid: string;
+};
+
+export type D2KeyJsonValue = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    key: string;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    namespace: string;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    value: string;
+};
+
+export type D2Legend = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    color: string;
+    created: string;
+    displayName: string;
+    endValue: number;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    image: string;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    startValue: number;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2LegendSet = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
     displayName: string;
     externalAccess: boolean;
     favorite: boolean;
@@ -2922,66 +2007,50 @@ export type D2ProgramRuleAction = {
     id: Id;
     lastUpdated: string;
     lastUpdatedBy: D2User;
-    location: string;
+    legends: D2Legend[];
     name: string;
-    option: D2Option;
-    optionGroup: D2OptionGroup;
-    programIndicator: D2ProgramIndicator;
-    programRule: D2ProgramRule;
-    programRuleActionType:
-        | "DISPLAYTEXT"
-        | "DISPLAYKEYVALUEPAIR"
-        | "HIDEFIELD"
-        | "HIDESECTION"
-        | "HIDEPROGRAMSTAGE"
-        | "ASSIGN"
-        | "SHOWWARNING"
-        | "WARNINGONCOMPLETE"
-        | "SHOWERROR"
-        | "ERRORONCOMPLETE"
-        | "CREATEEVENT"
-        | "SETMANDATORYFIELD"
-        | "SENDMESSAGE"
-        | "SCHEDULEMESSAGE"
-        | "HIDEOPTION"
-        | "SHOWOPTIONGROUP"
-        | "HIDEOPTIONGROUP";
-    programStage: D2ProgramStage;
-    programStageSection: D2ProgramStageSection;
     publicAccess: string;
-    templateUid: string;
-    trackedEntityAttribute: D2TrackedEntityAttribute;
+    symbolizer: string;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2ProgramRule = {
+export type D2Map = {
     access: D2Access;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    basemap: string;
     code: Id;
-    condition: string;
     created: string;
     description: string;
+    displayDescription: string;
+    displayFormName: string;
     displayName: string;
+    displayShortName: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
+    formName: string;
     href: string;
     id: Id;
+    interpretations: D2Interpretation[];
     lastUpdated: string;
     lastUpdatedBy: D2User;
+    latitude: number;
+    longitude: number;
+    mapViews: D2MapView[];
     name: string;
-    priority: number;
-    program: D2Program;
-    programRuleActions: D2ProgramRuleAction[];
-    programStage: D2ProgramStage;
     publicAccess: string;
+    shortName: string;
+    subscribed: boolean;
+    subscribers: string[];
+    title: string;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
+    zoom: number;
 };
 
 export type D2MapView = {
@@ -3103,10 +2172,1069 @@ export type D2MapView = {
     userOrganisationUnitGrandChildren: boolean;
 };
 
-export type D2Map = {
+export type D2MessageConversation = {
+    access: D2Access;
+    assignee: D2User;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    followUp: boolean;
+    href: string;
+    id: Id;
+    lastMessage: string;
+    lastSender: D2User;
+    lastSenderFirstname: string;
+    lastSenderSurname: string;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    messageCount: number;
+    messageType: "PRIVATE" | "SYSTEM" | "VALIDATION_RESULT" | "TICKET";
+    messages: any[];
+    name: string;
+    priority: "NONE" | "LOW" | "MEDIUM" | "HIGH";
+    publicAccess: string;
+    read: boolean;
+    status: "NONE" | "OPEN" | "PENDING" | "INVALID" | "SOLVED";
+    subject: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userFirstname: string;
+    userGroupAccesses: D2UserGroupAccess[];
+    userMessages: any[];
+    userSurname: string;
+};
+
+export type D2MetadataVersion = {
     access: D2Access;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    basemap: string;
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    hashCode: string;
+    href: string;
+    id: Id;
+    importDate: string;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    translations: D2Translation[];
+    type: "BEST_EFFORT" | "ATOMIC";
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2MinMaxDataElement = {
+    dataElement: D2DataElement;
+    generated: boolean;
+    max: number;
+    min: number;
+    optionCombo: D2CategoryOptionCombo;
+    source: D2OrganisationUnit;
+};
+
+export type D2OAuth2Client = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    cid: Id;
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    grantTypes: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    redirectUris: string[];
+    secret: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2Option = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: string;
+    created: string;
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    optionSet: D2OptionSet;
+    publicAccess: string;
+    shortName: string;
+    sortOrder: number;
+    style: D2Style;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2OptionGroup = {
+    access: D2Access;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    description: string;
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
+    name: string;
+    optionSet: D2OptionSet;
+    options: D2Option[];
+    publicAccess: string;
+    shortName: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2OptionGroupSet = {
+    access: D2Access;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    allItems: boolean;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    dataDimension: boolean;
+    dataDimensionType: "DISAGGREGATION" | "ATTRIBUTE";
+    description: string;
+    dimension: string;
+    dimensionType:
+        | "DATA_X"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "DATA_COLLAPSED"
+        | "CATEGORY_OPTION_COMBO"
+        | "ATTRIBUTE_OPTION_COMBO"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION_GROUP_SET"
+        | "DATA_ELEMENT_GROUP_SET"
+        | "ORGANISATION_UNIT_GROUP_SET"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY"
+        | "OPTION_GROUP_SET"
+        | "VALIDATION_RULE"
+        | "STATIC"
+        | "ORGANISATION_UNIT_LEVEL";
+    dimensionalKeywords: D2DimensionalKeywords;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    filter: string;
+    formName: string;
+    href: string;
+    id: Id;
+    items: any[];
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendSet: D2LegendSet;
+    name: string;
+    optionGroups: D2OptionGroup[];
+    optionSet: D2OptionSet;
+    programStage: D2ProgramStage;
+    publicAccess: string;
+    shortName: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2OptionSet = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    options: D2Option[];
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    valueType:
+        | "TEXT"
+        | "LONG_TEXT"
+        | "LETTER"
+        | "PHONE_NUMBER"
+        | "EMAIL"
+        | "BOOLEAN"
+        | "TRUE_ONLY"
+        | "DATE"
+        | "DATETIME"
+        | "TIME"
+        | "NUMBER"
+        | "UNIT_INTERVAL"
+        | "PERCENTAGE"
+        | "INTEGER"
+        | "INTEGER_POSITIVE"
+        | "INTEGER_NEGATIVE"
+        | "INTEGER_ZERO_OR_POSITIVE"
+        | "TRACKER_ASSOCIATE"
+        | "USERNAME"
+        | "COORDINATE"
+        | "ORGANISATION_UNIT"
+        | "AGE"
+        | "URL"
+        | "FILE_RESOURCE"
+        | "IMAGE";
+    version: number;
+};
+
+export type D2OrganisationUnit = {
+    access: D2Access;
+    address: string;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    ancestors: D2OrganisationUnit[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    children: D2OrganisationUnit[];
+    closedDate: string;
+    code: Id;
+    comment: string;
+    contactPerson: string;
+    created: string;
+    dataSets: D2DataSet[];
+    description: string;
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    email: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    geometry: D2Geometry;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    leaf: boolean;
+    legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
+    level: number;
+    memberCount: number;
+    name: string;
+    openingDate: string;
+    organisationUnitGroups: D2OrganisationUnitGroup[];
+    parent: D2OrganisationUnit;
+    path: string;
+    phoneNumber: string;
+    programs: D2Program[];
+    publicAccess: string;
+    shortName: string;
+    translations: D2Translation[];
+    type: string;
+    url: string;
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    users: D2User[];
+};
+
+export type D2OrganisationUnitGroup = {
+    access: D2Access;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    color: string;
+    created: string;
+    description: string;
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
+    formName: string;
+    geometry: D2Geometry;
+    groupSets: D2OrganisationUnitGroupSet[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
+    name: string;
+    organisationUnits: D2OrganisationUnit[];
+    publicAccess: string;
+    shortName: string;
+    symbol: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2OrganisationUnitGroupSet = {
+    access: D2Access;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    allItems: boolean;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    compulsory: boolean;
+    created: string;
+    dataDimension: boolean;
+    dataDimensionType: "DISAGGREGATION" | "ATTRIBUTE";
+    description: string;
+    dimension: string;
+    dimensionType:
+        | "DATA_X"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "DATA_COLLAPSED"
+        | "CATEGORY_OPTION_COMBO"
+        | "ATTRIBUTE_OPTION_COMBO"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION_GROUP_SET"
+        | "DATA_ELEMENT_GROUP_SET"
+        | "ORGANISATION_UNIT_GROUP_SET"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY"
+        | "OPTION_GROUP_SET"
+        | "VALIDATION_RULE"
+        | "STATIC"
+        | "ORGANISATION_UNIT_LEVEL";
+    dimensionalKeywords: D2DimensionalKeywords;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    filter: string;
+    formName: string;
+    href: string;
+    id: Id;
+    includeSubhierarchyInAnalytics: boolean;
+    items: any[];
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendSet: D2LegendSet;
+    name: string;
+    organisationUnitGroups: D2OrganisationUnitGroup[];
+    programStage: D2ProgramStage;
+    publicAccess: string;
+    shortName: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2OrganisationUnitGroupSetDimension = {
+    organisationUnitGroupSet: D2OrganisationUnitGroupSet;
+    organisationUnitGroups: D2OrganisationUnitGroup[];
+};
+
+export type D2OrganisationUnitLevel = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    level: number;
+    name: string;
+    offlineLevels: number;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2Predictor = {
+    access: D2Access;
+    annualSampleCount: number;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    generator: D2Expression;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    organisationUnitLevels: D2OrganisationUnitLevel[];
+    output: D2DataElement;
+    outputCombo: D2CategoryOptionCombo;
+    periodType: string;
+    predictorGroups: D2PredictorGroup[];
+    publicAccess: string;
+    sampleSkipTest: D2Expression;
+    sequentialSampleCount: number;
+    sequentialSkipCount: number;
+    shortName: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2PredictorGroup = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    description: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    predictors: D2Predictor[];
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2Program = {
+    access: D2Access;
+    accessLevel: "OPEN" | "AUDITED" | "PROTECTED" | "CLOSED";
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    categoryCombo: D2CategoryCombo;
+    code: Id;
+    completeEventsExpiryDays: number;
+    created: string;
+    dataEntryForm: D2DataEntryForm;
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayFrontPageList: boolean;
+    displayIncidentDate: boolean;
+    displayName: string;
+    displayShortName: string;
+    enrollmentDateLabel: string;
+    expiryDays: number;
+    expiryPeriodType: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
+    formName: string;
+    href: string;
+    id: Id;
+    ignoreOverdueEvents: boolean;
+    incidentDateLabel: string;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    maxTeiCountToReturn: number;
+    minAttributesRequiredToSearch: number;
+    name: string;
+    notificationTemplates: D2ProgramNotificationTemplate[];
+    onlyEnrollOnce: boolean;
+    organisationUnits: D2OrganisationUnit[];
+    programIndicators: D2ProgramIndicator[];
+    programRuleVariables: D2ProgramRuleVariable[];
+    programSections: D2ProgramSection[];
+    programStages: D2ProgramStage[];
+    programTrackedEntityAttributes: D2ProgramTrackedEntityAttribute[];
+    programType: "WITH_REGISTRATION" | "WITHOUT_REGISTRATION";
+    publicAccess: string;
+    registration: boolean;
+    relatedProgram: D2Program;
+    selectEnrollmentDatesInFuture: boolean;
+    selectIncidentDatesInFuture: boolean;
+    shortName: string;
+    skipOffline: boolean;
+    style: D2Style;
+    trackedEntityType: D2TrackedEntityType;
+    translations: D2Translation[];
+    useFirstStageDuringRegistration: boolean;
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    userRoles: D2UserAuthorityGroup[];
+    version: number;
+    withoutRegistration: boolean;
+};
+
+export type D2ProgramDataElementDimensionItem = {
+    access: D2Access;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    dataElement: D2DataElement;
+    description: string;
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
+    name: string;
+    program: D2Program;
+    publicAccess: string;
+    shortName: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    valueType:
+        | "TEXT"
+        | "LONG_TEXT"
+        | "LETTER"
+        | "PHONE_NUMBER"
+        | "EMAIL"
+        | "BOOLEAN"
+        | "TRUE_ONLY"
+        | "DATE"
+        | "DATETIME"
+        | "TIME"
+        | "NUMBER"
+        | "UNIT_INTERVAL"
+        | "PERCENTAGE"
+        | "INTEGER"
+        | "INTEGER_POSITIVE"
+        | "INTEGER_NEGATIVE"
+        | "INTEGER_ZERO_OR_POSITIVE"
+        | "TRACKER_ASSOCIATE"
+        | "USERNAME"
+        | "COORDINATE"
+        | "ORGANISATION_UNIT"
+        | "AGE"
+        | "URL"
+        | "FILE_RESOURCE"
+        | "IMAGE";
+};
+
+export type D2ProgramIndicator = {
+    access: D2Access;
+    aggregateExportAttributeOptionCombo: string;
+    aggregateExportCategoryOptionCombo: string;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    analyticsPeriodBoundaries: D2AnalyticsPeriodBoundary[];
+    analyticsType: "EVENT" | "ENROLLMENT";
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    decimals: number;
+    description: string;
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
+    displayDescription: string;
+    displayFormName: string;
+    displayInForm: boolean;
+    displayName: string;
+    displayShortName: string;
+    expression: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    filter: string;
+    formName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
+    name: string;
+    program: D2Program;
+    programIndicatorGroups: D2ProgramIndicatorGroup[];
+    publicAccess: string;
+    shortName: string;
+    style: D2Style;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramIndicatorGroup = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    description: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    programIndicators: D2ProgramIndicator[];
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramInstance = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    completedBy: string;
+    created: string;
+    createdAtClient: string;
+    deleted: boolean;
+    displayName: string;
+    endDate: string;
+    enrollmentDate: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    followup: boolean;
+    geometry: D2Geometry;
+    href: string;
+    id: Id;
+    incidentDate: string;
+    lastUpdated: string;
+    lastUpdatedAtClient: string;
+    lastUpdatedBy: D2User;
+    messageConversations: D2MessageConversation[];
+    name: string;
+    organisationUnit: D2OrganisationUnit;
+    program: D2Program;
+    programStageInstances: D2ProgramStageInstance[];
+    publicAccess: string;
+    relationshipItems: any[];
+    status: "ACTIVE" | "COMPLETED" | "CANCELLED";
+    storedBy: string;
+    trackedEntityComments: any[];
+    trackedEntityInstance: D2TrackedEntityInstance;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramNotificationTemplate = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    deliveryChannels: never[];
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    messageTemplate: string;
+    name: string;
+    notificationRecipient:
+        | "TRACKED_ENTITY_INSTANCE"
+        | "ORGANISATION_UNIT_CONTACT"
+        | "USERS_AT_ORGANISATION_UNIT"
+        | "USER_GROUP"
+        | "PROGRAM_ATTRIBUTE"
+        | "DATA_ELEMENT";
+    notificationTrigger:
+        | "ENROLLMENT"
+        | "COMPLETION"
+        | "PROGRAM_RULE"
+        | "SCHEDULED_DAYS_DUE_DATE"
+        | "SCHEDULED_DAYS_INCIDENT_DATE"
+        | "SCHEDULED_DAYS_ENROLLMENT_DATE";
+    notifyParentOrganisationUnitOnly: boolean;
+    notifyUsersInHierarchyOnly: boolean;
+    publicAccess: string;
+    recipientDataElement: D2DataElement;
+    recipientProgramAttribute: D2TrackedEntityAttribute;
+    recipientUserGroup: D2UserGroup;
+    relativeScheduledDays: number;
+    subjectTemplate: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramRule = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    condition: string;
+    created: string;
+    description: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    priority: number;
+    program: D2Program;
+    programRuleActions: D2ProgramRuleAction[];
+    programStage: D2ProgramStage;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramRuleAction = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    content: string;
+    created: string;
+    data: string;
+    dataElement: D2DataElement;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    location: string;
+    name: string;
+    option: D2Option;
+    optionGroup: D2OptionGroup;
+    programIndicator: D2ProgramIndicator;
+    programRule: D2ProgramRule;
+    programRuleActionType:
+        | "DISPLAYTEXT"
+        | "DISPLAYKEYVALUEPAIR"
+        | "HIDEFIELD"
+        | "HIDESECTION"
+        | "HIDEPROGRAMSTAGE"
+        | "ASSIGN"
+        | "SHOWWARNING"
+        | "WARNINGONCOMPLETE"
+        | "SHOWERROR"
+        | "ERRORONCOMPLETE"
+        | "CREATEEVENT"
+        | "SETMANDATORYFIELD"
+        | "SENDMESSAGE"
+        | "SCHEDULEMESSAGE"
+        | "HIDEOPTION"
+        | "SHOWOPTIONGROUP"
+        | "HIDEOPTIONGROUP";
+    programStage: D2ProgramStage;
+    programStageSection: D2ProgramStageSection;
+    publicAccess: string;
+    templateUid: string;
+    trackedEntityAttribute: D2TrackedEntityAttribute;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramRuleVariable = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    dataElement: D2DataElement;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    program: D2Program;
+    programRuleVariableSourceType:
+        | "DATAELEMENT_NEWEST_EVENT_PROGRAM_STAGE"
+        | "DATAELEMENT_NEWEST_EVENT_PROGRAM"
+        | "DATAELEMENT_CURRENT_EVENT"
+        | "DATAELEMENT_PREVIOUS_EVENT"
+        | "CALCULATED_VALUE"
+        | "TEI_ATTRIBUTE";
+    programStage: D2ProgramStage;
+    publicAccess: string;
+    trackedEntityAttribute: D2TrackedEntityAttribute;
+    translations: D2Translation[];
+    useCodeForOptionSet: boolean;
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramSection = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     description: string;
@@ -3120,23 +3248,441 @@ export type D2Map = {
     formName: string;
     href: string;
     id: Id;
-    interpretations: D2Interpretation[];
     lastUpdated: string;
     lastUpdatedBy: D2User;
-    latitude: number;
-    longitude: number;
-    mapViews: D2MapView[];
+    name: string;
+    program: D2Program;
+    publicAccess: string;
+    renderType: any;
+    shortName: string;
+    sortOrder: number;
+    style: D2Style;
+    trackedEntityAttributes: D2TrackedEntityAttribute[];
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramStage = {
+    access: D2Access;
+    allowGenerateNextVisit: boolean;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    autoGenerateEvent: boolean;
+    blockEntryForm: boolean;
+    code: Id;
+    created: string;
+    dataEntryForm: D2DataEntryForm;
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayGenerateEventBox: boolean;
+    displayName: string;
+    displayShortName: string;
+    dueDateLabel: string;
+    enableUserAssignment: boolean;
+    executionDateLabel: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
+    formName: string;
+    formType: "DEFAULT" | "CUSTOM" | "SECTION" | "SECTION_MULTIORG";
+    generatedByEnrollmentDate: boolean;
+    hideDueDate: boolean;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    minDaysFromStart: number;
+    name: string;
+    nextScheduleDate: D2DataElement;
+    notificationTemplates: D2ProgramNotificationTemplate[];
+    openAfterEnrollment: boolean;
+    periodType: string;
+    preGenerateUID: boolean;
+    program: D2Program;
+    programStageDataElements: D2ProgramStageDataElement[];
+    programStageSections: D2ProgramStageSection[];
+    publicAccess: string;
+    remindCompleted: boolean;
+    repeatable: boolean;
+    reportDateToUse: string;
+    shortName: string;
+    sortOrder: number;
+    standardInterval: number;
+    style: D2Style;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    validationStrategy: "ON_COMPLETE" | "ON_UPDATE_AND_INSERT";
+};
+
+export type D2ProgramStageDataElement = {
+    access: D2Access;
+    allowFutureDate: boolean;
+    allowProvidedElsewhere: boolean;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    compulsory: boolean;
+    created: string;
+    dataElement: D2DataElement;
+    displayInReports: boolean;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    programStage: D2ProgramStage;
+    publicAccess: string;
+    renderOptionsAsRadio: boolean;
+    renderType: any;
+    skipSynchronization: boolean;
+    sortOrder: number;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramStageInstance = {
+    access: D2Access;
+    assignedUser: D2User;
+    attributeOptionCombo: D2CategoryOptionCombo;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    comments: any[];
+    completed: boolean;
+    completedBy: string;
+    completedDate: string;
+    creatableInSearchScope: boolean;
+    created: string;
+    createdAtClient: string;
+    deleted: boolean;
+    displayName: string;
+    dueDate: string;
+    eventDataValues: any[];
+    eventDate: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    geometry: D2Geometry;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedAtClient: string;
+    lastUpdatedBy: D2User;
+    messageConversations: D2MessageConversation[];
+    name: string;
+    organisationUnit: D2OrganisationUnit;
+    programInstance: D2ProgramInstance;
+    programStage: D2ProgramStage;
+    publicAccess: string;
+    relationshipItems: any[];
+    status: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";
+    storedBy: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramStageInstanceFilter = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    description: string;
+    displayName: string;
+    eventQueryCriteria: any;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    program: Id;
+    programStage: Id;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramStageSection = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    dataElements: D2DataElement[];
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    programIndicators: D2ProgramIndicator[];
+    programStage: D2ProgramStage;
+    publicAccess: string;
+    renderType: any;
+    shortName: string;
+    sortOrder: number;
+    style: D2Style;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramTrackedEntityAttribute = {
+    access: D2Access;
+    allowFutureDate: boolean;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    displayInList: boolean;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    mandatory: boolean;
+    name: string;
+    program: D2Program;
+    programTrackedEntityAttributeGroups: D2ProgramTrackedEntityAttributeGroup[];
+    publicAccess: string;
+    renderOptionsAsRadio: boolean;
+    renderType: any;
+    searchable: boolean;
+    sortOrder: number;
+    trackedEntityAttribute: D2TrackedEntityAttribute;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    valueType:
+        | "TEXT"
+        | "LONG_TEXT"
+        | "LETTER"
+        | "PHONE_NUMBER"
+        | "EMAIL"
+        | "BOOLEAN"
+        | "TRUE_ONLY"
+        | "DATE"
+        | "DATETIME"
+        | "TIME"
+        | "NUMBER"
+        | "UNIT_INTERVAL"
+        | "PERCENTAGE"
+        | "INTEGER"
+        | "INTEGER_POSITIVE"
+        | "INTEGER_NEGATIVE"
+        | "INTEGER_ZERO_OR_POSITIVE"
+        | "TRACKER_ASSOCIATE"
+        | "USERNAME"
+        | "COORDINATE"
+        | "ORGANISATION_UNIT"
+        | "AGE"
+        | "URL"
+        | "FILE_RESOURCE"
+        | "IMAGE";
+};
+
+export type D2ProgramTrackedEntityAttributeDimensionItem = {
+    access: D2Access;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    attribute: D2TrackedEntityAttribute;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    description: string;
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
+    name: string;
+    program: D2Program;
+    publicAccess: string;
+    shortName: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramTrackedEntityAttributeGroup = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    attributes: D2ProgramTrackedEntityAttribute[];
+    code: Id;
+    created: string;
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
     name: string;
     publicAccess: string;
     shortName: string;
-    subscribed: boolean;
-    subscribers: string[];
+    translations: D2Translation[];
+    uniqunessType: "NONE" | "STRICT" | "VALIDATION";
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2PushAnalysis = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    dashboard: D2Dashboard;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    message: string;
+    name: string;
+    publicAccess: string;
+    recipientUserGroups: D2UserGroup[];
     title: string;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
-    zoom: number;
+};
+
+export type D2Relationship = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    from: any;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    relationshipType: D2RelationshipType;
+    shortName: string;
+    style: D2Style;
+    to: any;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2RelationshipType = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    bidirectional: boolean;
+    code: Id;
+    created: string;
+    description: string;
+    displayFromToName: string;
+    displayName: string;
+    displayToFromName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    fromConstraint: D2RelationshipConstraint;
+    fromToName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    toConstraint: D2RelationshipConstraint;
+    toFromName: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
 };
 
 export type D2Report = {
@@ -3273,1047 +3819,6 @@ export type D2ReportTable = {
     userOrganisationUnitGrandChildren: boolean;
 };
 
-export type D2Chart = {
-    access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "FIRST"
-        | "FIRST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    attributeDimensions: any[];
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    baseLineLabel: string;
-    baseLineValue: number;
-    category: string;
-    categoryDimensions: D2CategoryDimension[];
-    categoryOptionGroupSetDimensions: D2CategoryOptionGroupSetDimension[];
-    code: Id;
-    colorSet: D2ColorSet;
-    columns: any[];
-    completedOnly: boolean;
-    created: string;
-    cumulativeValues: boolean;
-    dataDimensionItems: any[];
-    dataElementDimensions: D2TrackedEntityDataElementDimension[];
-    dataElementGroupSetDimensions: D2DataElementGroupSetDimension[];
-    description: string;
-    digitGroupSeparator: "COMMA" | "SPACE" | "NONE";
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    domainAxisLabel: string;
-    endDate: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    filterDimensions: string[];
-    filters: any[];
-    formName: string;
-    hideEmptyRowItems: "NONE" | "BEFORE_FIRST" | "AFTER_LAST" | "BEFORE_FIRST_AFTER_LAST" | "ALL";
-    hideLegend: boolean;
-    hideSubtitle: boolean;
-    hideTitle: boolean;
-    href: string;
-    id: Id;
-    interpretations: D2Interpretation[];
-    itemOrganisationUnitGroups: D2OrganisationUnitGroup[];
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    legendDisplayStrategy: "FIXED" | "BY_DATA_ITEM";
-    legendSet: D2LegendSet;
-    name: string;
-    noSpaceBetweenColumns: boolean;
-    orgUnitField: string;
-    organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimension[];
-    organisationUnitLevels: number[];
-    organisationUnits: D2OrganisationUnit[];
-    parentGraphMap: D2Map;
-    percentStackedValues: boolean;
-    periods: any[];
-    programIndicatorDimensions: D2TrackedEntityProgramIndicatorDimension[];
-    publicAccess: string;
-    rangeAxisDecimals: number;
-    rangeAxisLabel: string;
-    rangeAxisMaxValue: number;
-    rangeAxisMinValue: number;
-    rangeAxisSteps: number;
-    regressionType: "NONE" | "LINEAR" | "POLYNOMIAL" | "LOESS";
-    relativePeriods: any;
-    rows: any[];
-    series: string;
-    seriesItems: any[];
-    shortName: string;
-    showData: boolean;
-    sortOrder: number;
-    startDate: string;
-    subscribed: boolean;
-    subscribers: string[];
-    subtitle: string;
-    targetLineLabel: string;
-    targetLineValue: number;
-    timeField: string;
-    title: string;
-    topLimit: number;
-    translations: D2Translation[];
-    type:
-        | "COLUMN"
-        | "STACKED_COLUMN"
-        | "BAR"
-        | "STACKED_BAR"
-        | "LINE"
-        | "AREA"
-        | "PIE"
-        | "RADAR"
-        | "GAUGE"
-        | "YEAR_OVER_YEAR_LINE"
-        | "YEAR_OVER_YEAR_COLUMN"
-        | "SINGLE_VALUE";
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    userOrganisationUnit: boolean;
-    userOrganisationUnitChildren: boolean;
-    userOrganisationUnitGrandChildren: boolean;
-    yearlySeries: string[];
-};
-
-export type D2ValidationResult = {
-    attributeOptionCombo: D2CategoryOptionCombo;
-    created: string;
-    dayInPeriod: number;
-    id: string;
-    leftsideValue: number;
-    notificationSent: boolean;
-    organisationUnit: D2OrganisationUnit;
-    period: any;
-    rightsideValue: number;
-    validationRule: D2ValidationRule;
-};
-
-export type D2Document = {
-    access: D2Access;
-    attachment: boolean;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    contentType: string;
-    created: string;
-    displayName: string;
-    external: boolean;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    url: string;
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2ExternalMapLayer = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    attribution: string;
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    imageFormat: "PNG" | "JPG";
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    layers: string;
-    legendSet: D2LegendSet;
-    legendSetUrl: string;
-    mapLayerPosition: "BASEMAP" | "OVERLAY";
-    mapService: "WMS" | "TMS" | "XYZ";
-    name: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    url: string;
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2Predictor = {
-    access: D2Access;
-    annualSampleCount: number;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    generator: D2Expression;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    organisationUnitLevels: D2OrganisationUnitLevel[];
-    output: D2DataElement;
-    outputCombo: D2CategoryOptionCombo;
-    periodType: string;
-    predictorGroups: D2PredictorGroup[];
-    publicAccess: string;
-    sampleSkipTest: D2Expression;
-    sequentialSampleCount: number;
-    sequentialSkipCount: number;
-    shortName: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2PredictorGroup = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    description: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    predictors: D2Predictor[];
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2DashboardItem = {
-    access: D2Access;
-    appKey: string;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    chart: D2Chart;
-    code: Id;
-    contentCount: number;
-    created: string;
-    displayName: string;
-    eventChart: D2EventChart;
-    eventReport: D2EventReport;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    height: number;
-    href: string;
-    id: Id;
-    interpretationCount: number;
-    interpretationLikeCount: number;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    map: D2Map;
-    messages: boolean;
-    name: string;
-    publicAccess: string;
-    reportTable: D2ReportTable;
-    reports: D2Report[];
-    resources: D2Document[];
-    shape: "NORMAL" | "DOUBLE_WIDTH" | "FULL_WIDTH";
-    text: string;
-    translations: D2Translation[];
-    type:
-        | "CHART"
-        | "EVENT_CHART"
-        | "MAP"
-        | "REPORT_TABLE"
-        | "EVENT_REPORT"
-        | "USERS"
-        | "REPORTS"
-        | "RESOURCES"
-        | "TEXT"
-        | "MESSAGES"
-        | "APP";
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    users: D2User[];
-    width: number;
-    x: number;
-    y: number;
-};
-
-export type D2Dashboard = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    dashboardItems: D2DashboardItem[];
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    itemCount: number;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    shortName: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2PushAnalysis = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    dashboard: D2Dashboard;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    message: string;
-    name: string;
-    publicAccess: string;
-    recipientUserGroups: D2UserGroup[];
-    title: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2KeyJsonValue = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    key: string;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    namespace: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    value: string;
-};
-
-export type D2InterpretationComment = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    mentions: any[];
-    name: string;
-    publicAccess: string;
-    text: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2TrackedEntityInstance = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    createdAtClient: string;
-    deleted: boolean;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    geometry: D2Geometry;
-    href: string;
-    id: Id;
-    inactive: boolean;
-    lastUpdated: string;
-    lastUpdatedAtClient: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    organisationUnit: D2OrganisationUnit;
-    programInstances: D2ProgramInstance[];
-    programOwners: any[];
-    publicAccess: string;
-    relationshipItems: any[];
-    trackedEntityAttributeValues: D2TrackedEntityAttributeValue[];
-    trackedEntityType: D2TrackedEntityType;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2Legend = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    color: string;
-    created: string;
-    displayName: string;
-    endValue: number;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    image: string;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    startValue: number;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2MessageConversation = {
-    access: D2Access;
-    assignee: D2User;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    followUp: boolean;
-    href: string;
-    id: Id;
-    lastMessage: string;
-    lastSender: D2User;
-    lastSenderFirstname: string;
-    lastSenderSurname: string;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    messageCount: number;
-    messageType: "PRIVATE" | "SYSTEM" | "VALIDATION_RESULT" | "TICKET";
-    messages: any[];
-    name: string;
-    priority: "NONE" | "LOW" | "MEDIUM" | "HIGH";
-    publicAccess: string;
-    read: boolean;
-    status: "NONE" | "OPEN" | "PENDING" | "INVALID" | "SOLVED";
-    subject: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userFirstname: string;
-    userGroupAccesses: D2UserGroupAccess[];
-    userMessages: any[];
-    userSurname: string;
-};
-
-export type D2UserAccess = {
-    access: string;
-    displayName: string;
-    id: string;
-    userUid: string;
-};
-
-export type D2MetadataVersion = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    hashCode: string;
-    href: string;
-    id: Id;
-    importDate: string;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    type: "BEST_EFFORT" | "ATOMIC";
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2DataElementOperand = {
-    access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "FIRST"
-        | "FIRST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    attributeOptionCombo: D2CategoryOptionCombo;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    categoryOptionCombo: D2CategoryOptionCombo;
-    code: Id;
-    created: string;
-    dataElement: D2DataElement;
-    description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
-    name: string;
-    publicAccess: string;
-    shortName: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2AnalyticsPeriodBoundary = {
-    access: D2Access;
-    analyticsPeriodBoundaryType:
-        | "BEFORE_START_OF_REPORTING_PERIOD"
-        | "BEFORE_END_OF_REPORTING_PERIOD"
-        | "AFTER_START_OF_REPORTING_PERIOD"
-        | "AFTER_END_OF_REPORTING_PERIOD";
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    boundaryTarget: string;
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    offsetPeriodType: string;
-    offsetPeriods: number;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2ProgramInstance = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    completedBy: string;
-    created: string;
-    createdAtClient: string;
-    deleted: boolean;
-    displayName: string;
-    endDate: string;
-    enrollmentDate: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    followup: boolean;
-    geometry: D2Geometry;
-    href: string;
-    id: Id;
-    incidentDate: string;
-    lastUpdated: string;
-    lastUpdatedAtClient: string;
-    lastUpdatedBy: D2User;
-    messageConversations: D2MessageConversation[];
-    name: string;
-    organisationUnit: D2OrganisationUnit;
-    program: D2Program;
-    programStageInstances: D2ProgramStageInstance[];
-    publicAccess: string;
-    relationshipItems: any[];
-    status: "ACTIVE" | "COMPLETED" | "CANCELLED";
-    storedBy: string;
-    trackedEntityComments: any[];
-    trackedEntityInstance: D2TrackedEntityInstance;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2TrackedEntityDataElementDimension = {
-    dataElement: D2DataElement;
-    filter: string;
-    legendSet: D2LegendSet;
-    programStage: D2ProgramStage;
-};
-
-export type D2ProgramStageInstanceFilter = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    description: string;
-    displayName: string;
-    eventQueryCriteria: any;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    program: Id;
-    programStage: Id;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2DataInputPeriod = {
-    closingDate: string;
-    openingDate: string;
-    period: any;
-};
-
-export type D2ProgramTrackedEntityAttributeDimensionItem = {
-    access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "FIRST"
-        | "FIRST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    attribute: D2TrackedEntityAttribute;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
-    name: string;
-    program: D2Program;
-    publicAccess: string;
-    shortName: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2DataElementGroupSetDimension = {
-    dataElementGroupSet: D2DataElementGroupSet;
-    dataElementGroups: D2DataElementGroup[];
-};
-
-export type D2Icon = {};
-
-export type D2UserGroupAccess = {
-    access: string;
-    displayName: string;
-    id: string;
-    userGroupUid: string;
-};
-
-export type D2Color = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    color: string;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2DataSetElement = {
-    categoryCombo: D2CategoryCombo;
-    dataElement: D2DataElement;
-    dataSet: D2DataSet;
-};
-
-export type D2ProgramStageDataElement = {
-    access: D2Access;
-    allowFutureDate: boolean;
-    allowProvidedElsewhere: boolean;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    compulsory: boolean;
-    created: string;
-    dataElement: D2DataElement;
-    displayInReports: boolean;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    programStage: D2ProgramStage;
-    publicAccess: string;
-    renderOptionsAsRadio: boolean;
-    renderType: any;
-    skipSynchronization: boolean;
-    sortOrder: number;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2ProgramTrackedEntityAttribute = {
-    access: D2Access;
-    allowFutureDate: boolean;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    displayInList: boolean;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    mandatory: boolean;
-    name: string;
-    program: D2Program;
-    programTrackedEntityAttributeGroups: D2ProgramTrackedEntityAttributeGroup[];
-    publicAccess: string;
-    renderOptionsAsRadio: boolean;
-    renderType: any;
-    searchable: boolean;
-    sortOrder: number;
-    trackedEntityAttribute: D2TrackedEntityAttribute;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    valueType:
-        | "TEXT"
-        | "LONG_TEXT"
-        | "LETTER"
-        | "PHONE_NUMBER"
-        | "EMAIL"
-        | "BOOLEAN"
-        | "TRUE_ONLY"
-        | "DATE"
-        | "DATETIME"
-        | "TIME"
-        | "NUMBER"
-        | "UNIT_INTERVAL"
-        | "PERCENTAGE"
-        | "INTEGER"
-        | "INTEGER_POSITIVE"
-        | "INTEGER_NEGATIVE"
-        | "INTEGER_ZERO_OR_POSITIVE"
-        | "TRACKER_ASSOCIATE"
-        | "USERNAME"
-        | "COORDINATE"
-        | "ORGANISATION_UNIT"
-        | "AGE"
-        | "URL"
-        | "FILE_RESOURCE"
-        | "IMAGE";
-};
-
-export type D2FileResource = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    contentLength: string;
-    contentMd5: string;
-    contentType: string;
-    created: string;
-    displayName: string;
-    domain: "DATA_VALUE" | "PUSH_ANALYSIS" | "DOCUMENT" | "MESSAGE_ATTACHMENT" | "USER_AVATAR";
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    hasMultipleStorageFiles: boolean;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    storageStatus: "NONE" | "PENDING" | "FAILED" | "STORED";
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2Relationship = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    from: any;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    relationshipType: D2RelationshipType;
-    shortName: string;
-    style: D2Style;
-    to: any;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2ProgramDataElementDimensionItem = {
-    access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "FIRST"
-        | "FIRST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    dataElement: D2DataElement;
-    description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
-    name: string;
-    program: D2Program;
-    publicAccess: string;
-    shortName: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    valueType:
-        | "TEXT"
-        | "LONG_TEXT"
-        | "LETTER"
-        | "PHONE_NUMBER"
-        | "EMAIL"
-        | "BOOLEAN"
-        | "TRUE_ONLY"
-        | "DATE"
-        | "DATETIME"
-        | "TIME"
-        | "NUMBER"
-        | "UNIT_INTERVAL"
-        | "PERCENTAGE"
-        | "INTEGER"
-        | "INTEGER_POSITIVE"
-        | "INTEGER_NEGATIVE"
-        | "INTEGER_ZERO_OR_POSITIVE"
-        | "TRACKER_ASSOCIATE"
-        | "USERNAME"
-        | "COORDINATE"
-        | "ORGANISATION_UNIT"
-        | "AGE"
-        | "URL"
-        | "FILE_RESOURCE"
-        | "IMAGE";
-};
-
-export type D2MinMaxDataElement = {
-    dataElement: D2DataElement;
-    generated: boolean;
-    max: number;
-    min: number;
-    optionCombo: D2CategoryOptionCombo;
-    source: D2OrganisationUnit;
-};
-
 export type D2ReportingRate = {
     access: D2Access;
     aggregationType:
@@ -4382,10 +3887,461 @@ export type D2ReportingRate = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
+export type D2SMSCommand = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    codeValueSeparator: string;
+    completenessMethod: "ALL_DATAVALUE" | "AT_LEAST_ONE_DATAVALUE" | "DO_NOT_MARK_COMPLETE";
+    created: string;
+    currentPeriodUsedForReporting: boolean;
+    dataset: D2DataSet;
+    defaultMessage: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    moreThanOneOrgUnitMessage: string;
+    name: string;
+    noUserMessage: string;
+    parserType:
+        | "KEY_VALUE_PARSER"
+        | "J2ME_PARSER"
+        | "ALERT_PARSER"
+        | "UNREGISTERED_PARSER"
+        | "TRACKED_ENTITY_REGISTRATION_PARSER"
+        | "PROGRAM_STAGE_DATAENTRY_PARSER"
+        | "EVENT_REGISTRATION_PARSER";
+    program: D2Program;
+    programStage: D2ProgramStage;
+    publicAccess: string;
+    receivedMessage: string;
+    separator: string;
+    smsCodes: any[];
+    specialCharacters: any[];
+    successMessage: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroup: D2UserGroup;
+    userGroupAccesses: D2UserGroupAccess[];
+    wrongFormatMessage: string;
+};
+
+export type D2Section = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    categoryCombos: D2CategoryCombo[];
+    code: Id;
+    created: string;
+    dataElements: D2DataElement[];
+    dataSet: D2DataSet;
+    description: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    greyedFields: D2DataElementOperand[];
+    href: string;
+    id: Id;
+    indicators: D2Indicator[];
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    showColumnTotals: boolean;
+    showRowTotals: boolean;
+    sortOrder: number;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2SqlView = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    cacheStrategy:
+        | "NO_CACHE"
+        | "CACHE_15_MINUTES"
+        | "CACHE_30_MINUTES"
+        | "CACHE_1_HOUR"
+        | "CACHE_6AM_TOMORROW"
+        | "CACHE_TWO_WEEKS"
+        | "RESPECT_SYSTEM_SETTING";
+    code: Id;
+    created: string;
+    description: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    sqlQuery: string;
+    translations: D2Translation[];
+    type: "VIEW" | "MATERIALIZED_VIEW" | "QUERY";
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2TrackedEntityAttribute = {
+    access: D2Access;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    confidential: boolean;
+    created: string;
+    description: string;
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
+    displayDescription: string;
+    displayFormName: string;
+    displayInListNoProgram: boolean;
+    displayName: string;
+    displayOnVisitSchedule: boolean;
+    displayShortName: string;
+    expression: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    fieldMask: string;
+    formName: string;
+    generated: boolean;
+    href: string;
+    id: Id;
+    inherit: boolean;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
+    name: string;
+    optionSet: D2OptionSet;
+    optionSetValue: boolean;
+    orgunitScope: boolean;
+    pattern: string;
+    publicAccess: string;
+    shortName: string;
+    skipSynchronization: boolean;
+    sortOrderInListNoProgram: number;
+    sortOrderInVisitSchedule: number;
+    style: D2Style;
+    translations: D2Translation[];
+    unique: boolean;
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    valueType:
+        | "TEXT"
+        | "LONG_TEXT"
+        | "LETTER"
+        | "PHONE_NUMBER"
+        | "EMAIL"
+        | "BOOLEAN"
+        | "TRUE_ONLY"
+        | "DATE"
+        | "DATETIME"
+        | "TIME"
+        | "NUMBER"
+        | "UNIT_INTERVAL"
+        | "PERCENTAGE"
+        | "INTEGER"
+        | "INTEGER_POSITIVE"
+        | "INTEGER_NEGATIVE"
+        | "INTEGER_ZERO_OR_POSITIVE"
+        | "TRACKER_ASSOCIATE"
+        | "USERNAME"
+        | "COORDINATE"
+        | "ORGANISATION_UNIT"
+        | "AGE"
+        | "URL"
+        | "FILE_RESOURCE"
+        | "IMAGE";
+};
+
+export type D2TrackedEntityAttributeValue = {
+    created: string;
+    lastUpdated: string;
+    storedBy: string;
+    trackedEntityAttribute: D2TrackedEntityAttribute;
+    trackedEntityInstance: D2TrackedEntityInstance;
+    value: string;
+};
+
+export type D2TrackedEntityDataElementDimension = {
+    dataElement: D2DataElement;
+    filter: string;
+    legendSet: D2LegendSet;
+    programStage: D2ProgramStage;
+};
+
+export type D2TrackedEntityInstance = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    createdAtClient: string;
+    deleted: boolean;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    geometry: D2Geometry;
+    href: string;
+    id: Id;
+    inactive: boolean;
+    lastUpdated: string;
+    lastUpdatedAtClient: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    organisationUnit: D2OrganisationUnit;
+    programInstances: D2ProgramInstance[];
+    programOwners: any[];
+    publicAccess: string;
+    relationshipItems: any[];
+    trackedEntityAttributeValues: D2TrackedEntityAttributeValue[];
+    trackedEntityType: D2TrackedEntityType;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2TrackedEntityInstanceFilter = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    description: string;
+    displayName: string;
+    enrollmentCreatedPeriod: any;
+    enrollmentStatus: "ACTIVE" | "COMPLETED" | "CANCELLED";
+    eventFilters: any[];
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    followup: boolean;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    program: D2Program;
+    publicAccess: string;
+    sortOrder: number;
+    style: D2Style;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
 export type D2TrackedEntityProgramIndicatorDimension = {
     filter: string;
     legendSet: D2LegendSet;
     programIndicator: D2ProgramIndicator;
+};
+
+export type D2TrackedEntityType = {
+    access: D2Access;
+    allowAuditLog: boolean;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
+    formName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    maxTeiCountToReturn: number;
+    minAttributesRequiredToSearch: number;
+    name: string;
+    publicAccess: string;
+    shortName: string;
+    style: D2Style;
+    trackedEntityTypeAttributes: D2TrackedEntityTypeAttribute[];
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2TrackedEntityTypeAttribute = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    displayInList: boolean;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    mandatory: boolean;
+    name: string;
+    publicAccess: string;
+    searchable: boolean;
+    trackedEntityAttribute: D2TrackedEntityAttribute;
+    trackedEntityType: D2TrackedEntityType;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    valueType:
+        | "TEXT"
+        | "LONG_TEXT"
+        | "LETTER"
+        | "PHONE_NUMBER"
+        | "EMAIL"
+        | "BOOLEAN"
+        | "TRUE_ONLY"
+        | "DATE"
+        | "DATETIME"
+        | "TIME"
+        | "NUMBER"
+        | "UNIT_INTERVAL"
+        | "PERCENTAGE"
+        | "INTEGER"
+        | "INTEGER_POSITIVE"
+        | "INTEGER_NEGATIVE"
+        | "INTEGER_ZERO_OR_POSITIVE"
+        | "TRACKER_ASSOCIATE"
+        | "USERNAME"
+        | "COORDINATE"
+        | "ORGANISATION_UNIT"
+        | "AGE"
+        | "URL"
+        | "FILE_RESOURCE"
+        | "IMAGE";
+};
+
+export type D2User = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    avatar: D2FileResource;
+    birthday: string;
+    code: Id;
+    created: string;
+    dataViewOrganisationUnits: D2OrganisationUnit[];
+    displayName: string;
+    education: string;
+    email: string;
+    employer: string;
+    externalAccess: boolean;
+    facebookMessenger: string;
+    favorite: boolean;
+    favorites: string[];
+    firstName: string;
+    gender: string;
+    href: string;
+    id: Id;
+    interests: string;
+    introduction: string;
+    jobTitle: string;
+    languages: string;
+    lastCheckedInterpretations: string;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    nationality: string;
+    organisationUnits: D2OrganisationUnit[];
+    phoneNumber: string;
+    publicAccess: string;
+    skype: string;
+    surname: string;
+    teiSearchOrganisationUnits: D2OrganisationUnit[];
+    telegram: string;
+    translations: D2Translation[];
+    twitter: string;
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userCredentials: D2UserCredentials;
+    userGroupAccesses: D2UserGroupAccess[];
+    userGroups: D2UserGroup[];
+    welcomeMessage: string;
+    whatsApp: string;
+};
+
+export type D2UserAccess = {
+    access: string;
+    displayName: string;
+    id: string;
+    userUid: string;
+};
+
+export type D2UserAuthorityGroup = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    authorities: string[];
+    code: Id;
+    created: string;
+    description: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    users: D2User[];
 };
 
 export type D2UserCredentials = {
@@ -4424,107 +4380,166 @@ export type D2UserCredentials = {
     username: string;
 };
 
-export type D2TrackedEntityAttributeValue = {
-    created: string;
-    lastUpdated: string;
-    storedBy: string;
-    trackedEntityAttribute: D2TrackedEntityAttribute;
-    trackedEntityInstance: D2TrackedEntityInstance;
-    value: string;
-};
-
-export type D2OrganisationUnitGroupSetDimension = {
-    organisationUnitGroupSet: D2OrganisationUnitGroupSet;
-    organisationUnitGroups: D2OrganisationUnitGroup[];
-};
-
-export type D2CategoryOptionGroupSetDimension = {
-    categoryOptionGroupSet: D2CategoryOptionGroupSet;
-    categoryOptionGroups: D2CategoryOptionGroup[];
-};
-
-export type D2ProgramStageInstance = {
+export type D2UserGroup = {
     access: D2Access;
-    assignedUser: D2User;
-    attributeOptionCombo: D2CategoryOptionCombo;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
-    comments: any[];
-    completed: boolean;
-    completedBy: string;
-    completedDate: string;
-    creatableInSearchScope: boolean;
     created: string;
-    createdAtClient: string;
-    deleted: boolean;
     displayName: string;
-    dueDate: string;
-    eventDataValues: any[];
-    eventDate: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
-    geometry: D2Geometry;
     href: string;
     id: Id;
     lastUpdated: string;
-    lastUpdatedAtClient: string;
     lastUpdatedBy: D2User;
-    messageConversations: D2MessageConversation[];
+    managedByGroups: D2UserGroup[];
+    managedGroups: D2UserGroup[];
     name: string;
-    organisationUnit: D2OrganisationUnit;
-    programInstance: D2ProgramInstance;
-    programStage: D2ProgramStage;
     publicAccess: string;
-    relationshipItems: any[];
-    status: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";
-    storedBy: string;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
+    users: D2User[];
 };
 
-export type D2TrackedEntityInstanceFilter = {
+export type D2UserGroupAccess = {
+    access: string;
+    displayName: string;
+    id: string;
+    userGroupUid: string;
+};
+
+export type D2ValidationNotificationTemplate = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    messageTemplate: string;
+    name: string;
+    notifyParentOrganisationUnitOnly: boolean;
+    notifyUsersInHierarchyOnly: boolean;
+    publicAccess: string;
+    recipientUserGroups: D2UserGroup[];
+    sendStrategy: "COLLECTIVE_SUMMARY" | "SINGLE_NOTIFICATION";
+    subjectTemplate: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    validationRules: D2ValidationRule[];
+};
+
+export type D2ValidationResult = {
+    attributeOptionCombo: D2CategoryOptionCombo;
+    created: string;
+    dayInPeriod: number;
+    id: string;
+    leftsideValue: number;
+    notificationSent: boolean;
+    organisationUnit: D2OrganisationUnit;
+    period: any;
+    rightsideValue: number;
+    validationRule: D2ValidationRule;
+};
+
+export type D2ValidationRule = {
+    access: D2Access;
+    aggregateExportAttributeOptionCombo: string;
+    aggregateExportCategoryOptionCombo: string;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    description: string;
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    importance: "HIGH" | "MEDIUM" | "LOW";
+    instruction: string;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    leftSide: D2Expression;
+    legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
+    name: string;
+    notificationTemplates: D2ValidationNotificationTemplate[];
+    operator:
+        | "equal_to"
+        | "not_equal_to"
+        | "greater_than"
+        | "greater_than_or_equal_to"
+        | "less_than"
+        | "less_than_or_equal_to"
+        | "compulsory_pair"
+        | "exclusive_pair";
+    organisationUnitLevels: number[];
+    periodType: string;
+    publicAccess: string;
+    rightSide: D2Expression;
+    shortName: string;
+    skipFormValidation: boolean;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    validationRuleGroups: D2ValidationRuleGroup[];
+};
+
+export type D2ValidationRuleGroup = {
     access: D2Access;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     description: string;
     displayName: string;
-    enrollmentCreatedPeriod: any;
-    enrollmentStatus: "ACTIVE" | "COMPLETED" | "CANCELLED";
-    eventFilters: any[];
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    followup: boolean;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    program: D2Program;
-    publicAccess: string;
-    sortOrder: number;
-    style: D2Style;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2Interpretation = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    chart: D2Chart;
-    code: Id;
-    comments: D2InterpretationComment[];
-    created: string;
-    dataSet: D2DataSet;
-    displayName: string;
-    eventChart: D2EventChart;
-    eventReport: D2EventReport;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
@@ -4532,27 +4547,156 @@ export type D2Interpretation = {
     id: Id;
     lastUpdated: string;
     lastUpdatedBy: D2User;
-    likedBy: D2User[];
-    likes: number;
-    map: D2Map;
-    mentions: any[];
     name: string;
-    organisationUnit: D2OrganisationUnit;
-    period: any;
     publicAccess: string;
-    reportTable: D2ReportTable;
-    text: string;
     translations: D2Translation[];
-    type: "REPORT_TABLE" | "CHART" | "MAP" | "EVENT_REPORT" | "EVENT_CHART" | "DATASET_REPORT";
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
+    validationRules: D2ValidationRule[];
 };
 
-export type D2CategoryDimension = {
-    category: D2Category;
-    categoryOptions: D2CategoryOption[];
-};
+export interface D2AnalyticsPeriodBoundarySchema {
+    name: "D2AnalyticsPeriodBoundary";
+    model: D2AnalyticsPeriodBoundary;
+    fields: {
+        access: D2Access;
+        analyticsPeriodBoundaryType:
+            | "BEFORE_START_OF_REPORTING_PERIOD"
+            | "BEFORE_END_OF_REPORTING_PERIOD"
+            | "AFTER_START_OF_REPORTING_PERIOD"
+            | "AFTER_END_OF_REPORTING_PERIOD";
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        boundaryTarget: string;
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        offsetPeriodType: string;
+        offsetPeriods: number;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2AnalyticsPeriodBoundary, keyof D2AnalyticsPeriodBoundary>;
+        $identifiable: Preset<D2AnalyticsPeriodBoundary, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2AnalyticsPeriodBoundary, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2AnalyticsPeriodBoundary,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "lastUpdated"
+            | "offsetPeriodType"
+            | "id"
+            | "analyticsPeriodBoundaryType"
+            | "boundaryTarget"
+            | "offsetPeriods"
+        >;
+        $owner: Preset<
+            D2AnalyticsPeriodBoundary,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "lastUpdated"
+            | "offsetPeriodType"
+            | "id"
+            | "analyticsPeriodBoundaryType"
+            | "boundaryTarget"
+            | "offsetPeriods"
+        >;
+    };
+}
+
+export interface D2AnalyticsTableHookSchema {
+    name: "D2AnalyticsTableHook";
+    model: D2AnalyticsTableHook;
+    fields: {
+        access: D2Access;
+        analyticsTableType:
+            | "DATA_VALUE"
+            | "COMPLETENESS"
+            | "COMPLETENESS_TARGET"
+            | "ORG_UNIT_TARGET"
+            | "EVENT"
+            | "ENROLLMENT"
+            | "VALIDATION_RESULT";
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        phase: "RESOURCE_TABLE_POPULATED" | "ANALYTICS_TABLE_POPULATED";
+        publicAccess: string;
+        resourceTableType:
+            | "ORG_UNIT_STRUCTURE"
+            | "DATA_SET_ORG_UNIT_CATEGORY"
+            | "CATEGORY_OPTION_COMBO_NAME"
+            | "DATA_ELEMENT_GROUP_SET_STRUCTURE"
+            | "INDICATOR_GROUP_SET_STRUCTURE"
+            | "ORG_UNIT_GROUP_SET_STRUCTURE"
+            | "CATEGORY_STRUCTURE"
+            | "DATA_ELEMENT_STRUCTURE"
+            | "PERIOD_STRUCTURE"
+            | "DATE_PERIOD_STRUCTURE"
+            | "DATA_ELEMENT_CATEGORY_OPTION_COMBO"
+            | "DATA_APPROVAL_REMAP_LEVEL"
+            | "DATA_APPROVAL_MIN_LEVEL";
+        sql: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2AnalyticsTableHook, keyof D2AnalyticsTableHook>;
+        $identifiable: Preset<D2AnalyticsTableHook, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2AnalyticsTableHook, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2AnalyticsTableHook,
+            | "phase"
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "analyticsTableType"
+            | "sql"
+            | "lastUpdated"
+            | "name"
+            | "resourceTableType"
+            | "id"
+        >;
+        $owner: Preset<
+            D2AnalyticsTableHook,
+            | "phase"
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "analyticsTableType"
+            | "sql"
+            | "lastUpdated"
+            | "name"
+            | "resourceTableType"
+            | "id"
+        >;
+    };
+}
 
 export interface D2AttributeSchema {
     name: "D2Attribute";
@@ -4752,827 +4896,9 @@ export interface D2AttributeSchema {
     };
 }
 
-export interface D2UserAuthorityGroupSchema {
-    name: "D2UserAuthorityGroup";
-    model: D2UserAuthorityGroup;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        authorities: string[];
-        code: Id;
-        created: string;
-        description: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        users: D2UserSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2UserAuthorityGroup, keyof D2UserAuthorityGroup>;
-        $identifiable: Preset<D2UserAuthorityGroup, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2UserAuthorityGroup, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2UserAuthorityGroup,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "description"
-            | "authorities"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2UserAuthorityGroup,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "description"
-            | "authorities"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
-export interface D2UserSchema {
-    name: "D2User";
-    model: D2User;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        avatar: D2FileResourceSchema;
-        birthday: string;
-        code: Id;
-        created: string;
-        dataViewOrganisationUnits: D2OrganisationUnitSchema[];
-        displayName: string;
-        education: string;
-        email: string;
-        employer: string;
-        externalAccess: boolean;
-        facebookMessenger: string;
-        favorite: boolean;
-        favorites: string[];
-        firstName: string;
-        gender: string;
-        href: string;
-        id: Id;
-        interests: string;
-        introduction: string;
-        jobTitle: string;
-        languages: string;
-        lastCheckedInterpretations: string;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        nationality: string;
-        organisationUnits: D2OrganisationUnitSchema[];
-        phoneNumber: string;
-        publicAccess: string;
-        skype: string;
-        surname: string;
-        teiSearchOrganisationUnits: D2OrganisationUnitSchema[];
-        telegram: string;
-        translations: D2Translation[];
-        twitter: string;
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userCredentials: D2UserCredentialsSchema;
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        userGroups: D2UserGroupSchema[];
-        welcomeMessage: string;
-        whatsApp: string;
-    };
-    fieldPresets: {
-        $all: Preset<D2User, keyof D2User>;
-        $identifiable: Preset<D2User, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2User, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2User,
-            | "birthday"
-            | "code"
-            | "education"
-            | "gender"
-            | "jobTitle"
-            | "skype"
-            | "lastUpdated"
-            | "teiSearchOrganisationUnits"
-            | "twitter"
-            | "surname"
-            | "employer"
-            | "id"
-            | "organisationUnits"
-            | "facebookMessenger"
-            | "introduction"
-            | "email"
-            | "dataViewOrganisationUnits"
-            | "whatsApp"
-            | "languages"
-            | "created"
-            | "welcomeMessage"
-            | "userCredentials"
-            | "attributeValues"
-            | "telegram"
-            | "avatar"
-            | "lastCheckedInterpretations"
-            | "userGroups"
-            | "firstName"
-            | "phoneNumber"
-            | "nationality"
-            | "interests"
-        >;
-        $owner: Preset<
-            D2User,
-            | "birthday"
-            | "code"
-            | "education"
-            | "gender"
-            | "jobTitle"
-            | "skype"
-            | "lastUpdated"
-            | "teiSearchOrganisationUnits"
-            | "twitter"
-            | "surname"
-            | "employer"
-            | "id"
-            | "organisationUnits"
-            | "facebookMessenger"
-            | "introduction"
-            | "email"
-            | "dataViewOrganisationUnits"
-            | "whatsApp"
-            | "languages"
-            | "created"
-            | "welcomeMessage"
-            | "userCredentials"
-            | "attributeValues"
-            | "telegram"
-            | "avatar"
-            | "lastCheckedInterpretations"
-            | "firstName"
-            | "phoneNumber"
-            | "nationality"
-            | "interests"
-        >;
-    };
-}
-
-export interface D2UserGroupSchema {
-    name: "D2UserGroup";
-    model: D2UserGroup;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        managedByGroups: D2UserGroupSchema[];
-        managedGroups: D2UserGroupSchema[];
-        name: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        users: D2UserSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2UserGroup, keyof D2UserGroup>;
-        $identifiable: Preset<D2UserGroup, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2UserGroup, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2UserGroup,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "managedByGroups"
-            | "attributeValues"
-            | "users"
-            | "managedGroups"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2UserGroup,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "users"
-            | "managedGroups"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
-export interface D2ExpressionSchema {
-    name: "D2Expression";
-    model: D2Expression;
-    fields: {
-        description: string;
-        expression: string;
-        missingValueStrategy:
-            | "SKIP_IF_ANY_VALUE_MISSING"
-            | "SKIP_IF_ALL_VALUES_MISSING"
-            | "NEVER_SKIP";
-        slidingWindow: boolean;
-    };
-    fieldPresets: {
-        $all: Preset<D2Expression, keyof D2Expression>;
-        $identifiable: Preset<D2Expression, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Expression, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Expression,
-            "description" | "expression" | "missingValueStrategy" | "slidingWindow"
-        >;
-        $owner: Preset<
-            D2Expression,
-            "description" | "expression" | "missingValueStrategy" | "slidingWindow"
-        >;
-    };
-}
-
-export interface D2ExternalFileResourceSchema {
-    name: "D2ExternalFileResource";
-    model: D2ExternalFileResource;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ExternalFileResource, keyof D2ExternalFileResource>;
-        $identifiable: Preset<D2ExternalFileResource, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ExternalFileResource, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ExternalFileResource,
-            "lastUpdatedBy" | "code" | "created" | "lastUpdated" | "id"
-        >;
-        $owner: Preset<
-            D2ExternalFileResource,
-            "lastUpdatedBy" | "code" | "created" | "lastUpdated" | "id"
-        >;
-    };
-}
-
-export interface D2SqlViewSchema {
-    name: "D2SqlView";
-    model: D2SqlView;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        cacheStrategy:
-            | "NO_CACHE"
-            | "CACHE_15_MINUTES"
-            | "CACHE_30_MINUTES"
-            | "CACHE_1_HOUR"
-            | "CACHE_6AM_TOMORROW"
-            | "CACHE_TWO_WEEKS"
-            | "RESPECT_SYSTEM_SETTING";
-        code: Id;
-        created: string;
-        description: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        sqlQuery: string;
-        translations: D2Translation[];
-        type: "VIEW" | "MATERIALIZED_VIEW" | "QUERY";
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2SqlView, keyof D2SqlView>;
-        $identifiable: Preset<D2SqlView, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2SqlView, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2SqlView,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "sqlQuery"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "description"
-            | "type"
-            | "externalAccess"
-            | "lastUpdated"
-            | "userAccesses"
-            | "name"
-            | "cacheStrategy"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2SqlView,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "sqlQuery"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "description"
-            | "type"
-            | "externalAccess"
-            | "lastUpdated"
-            | "userAccesses"
-            | "name"
-            | "cacheStrategy"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
-export interface D2OAuth2ClientSchema {
-    name: "D2OAuth2Client";
-    model: D2OAuth2Client;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        cid: Id;
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        grantTypes: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        redirectUris: string[];
-        secret: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2OAuth2Client, keyof D2OAuth2Client>;
-        $identifiable: Preset<D2OAuth2Client, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OAuth2Client, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2OAuth2Client,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "secret"
-            | "redirectUris"
-            | "lastUpdated"
-            | "grantTypes"
-            | "name"
-            | "id"
-            | "cid"
-        >;
-        $owner: Preset<
-            D2OAuth2Client,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "secret"
-            | "redirectUris"
-            | "lastUpdated"
-            | "grantTypes"
-            | "name"
-            | "id"
-            | "cid"
-        >;
-    };
-}
-
-export interface D2ConstantSchema {
-    name: "D2Constant";
-    model: D2Constant;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        shortName: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        value: number;
-    };
-    fieldPresets: {
-        $all: Preset<D2Constant, keyof D2Constant>;
-        $identifiable: Preset<D2Constant, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Constant, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Constant,
-            | "code"
-            | "publicAccess"
-            | "description"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "value"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "userAccesses"
-            | "name"
-            | "shortName"
-            | "user"
-        >;
-        $owner: Preset<
-            D2Constant,
-            | "code"
-            | "publicAccess"
-            | "description"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "value"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "userAccesses"
-            | "name"
-            | "shortName"
-            | "user"
-        >;
-    };
-}
-
-export interface D2OptionSchema {
-    name: "D2Option";
-    model: D2Option;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: string;
-        created: string;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        optionSet: D2OptionSetSchema;
-        publicAccess: string;
-        shortName: string;
-        sortOrder: number;
-        style: D2Style;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Option, keyof D2Option>;
-        $identifiable: Preset<D2Option, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Option, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Option,
-            | "code"
-            | "description"
-            | "lastUpdated"
-            | "optionSet"
-            | "translations"
-            | "formName"
-            | "id"
-            | "created"
-            | "attributeValues"
-            | "sortOrder"
-            | "name"
-            | "style"
-        >;
-        $owner: Preset<
-            D2Option,
-            | "code"
-            | "description"
-            | "lastUpdated"
-            | "optionSet"
-            | "translations"
-            | "formName"
-            | "id"
-            | "created"
-            | "attributeValues"
-            | "sortOrder"
-            | "name"
-            | "style"
-        >;
-    };
-}
-
-export interface D2JobConfigurationSchema {
-    name: "D2JobConfiguration";
-    model: D2JobConfiguration;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        configurable: boolean;
-        continuousExecution: boolean;
-        created: string;
-        cronExpression: string;
-        displayName: string;
-        enabled: boolean;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        jobParameters: string;
-        jobStatus: "RUNNING" | "COMPLETED" | "STOPPED" | "SCHEDULED" | "DISABLED" | "FAILED";
-        jobType:
-            | "DATA_STATISTICS"
-            | "DATA_INTEGRITY"
-            | "RESOURCE_TABLE"
-            | "ANALYTICS_TABLE"
-            | "DATA_SYNC"
-            | "TRACKER_PROGRAMS_DATA_SYNC"
-            | "EVENT_PROGRAMS_DATA_SYNC"
-            | "FILE_RESOURCE_CLEANUP"
-            | "IMAGE_PROCESSING"
-            | "META_DATA_SYNC"
-            | "SMS_SEND"
-            | "SEND_SCHEDULED_MESSAGE"
-            | "PROGRAM_NOTIFICATIONS"
-            | "VALIDATION_RESULTS_NOTIFICATION"
-            | "CREDENTIALS_EXPIRY_ALERT"
-            | "MONITORING"
-            | "PUSH_ANALYSIS"
-            | "PREDICTOR"
-            | "DATA_SET_NOTIFICATION"
-            | "REMOVE_EXPIRED_RESERVED_VALUES"
-            | "MOCK"
-            | "DATAVALUE_IMPORT"
-            | "ANALYTICSTABLE_UPDATE"
-            | "METADATA_IMPORT"
-            | "GML_IMPORT"
-            | "DATAVALUE_IMPORT_INTERNAL"
-            | "EVENT_IMPORT"
-            | "ENROLLMENT_IMPORT"
-            | "TEI_IMPORT"
-            | "LEADER_ELECTION"
-            | "LEADER_RENEWAL"
-            | "COMPLETE_DATA_SET_REGISTRATION_IMPORT"
-            | "PROGRAM_DATA_SYNC";
-        lastExecuted: string;
-        lastExecutedStatus:
-            | "RUNNING"
-            | "COMPLETED"
-            | "STOPPED"
-            | "SCHEDULED"
-            | "DISABLED"
-            | "FAILED";
-        lastRuntimeExecution: string;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        leaderOnlyJob: boolean;
-        name: string;
-        nextExecutionTime: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        userUid: string;
-    };
-    fieldPresets: {
-        $all: Preset<D2JobConfiguration, keyof D2JobConfiguration>;
-        $identifiable: Preset<D2JobConfiguration, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2JobConfiguration, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2JobConfiguration,
-            | "jobStatus"
-            | "code"
-            | "enabled"
-            | "leaderOnlyJob"
-            | "lastUpdated"
-            | "continuousExecution"
-            | "id"
-            | "jobType"
-            | "lastUpdatedBy"
-            | "nextExecutionTime"
-            | "created"
-            | "cronExpression"
-            | "lastRuntimeExecution"
-            | "lastExecutedStatus"
-            | "name"
-            | "jobParameters"
-            | "lastExecuted"
-        >;
-        $owner: Preset<
-            D2JobConfiguration,
-            | "jobStatus"
-            | "code"
-            | "enabled"
-            | "leaderOnlyJob"
-            | "lastUpdated"
-            | "continuousExecution"
-            | "id"
-            | "jobType"
-            | "lastUpdatedBy"
-            | "nextExecutionTime"
-            | "created"
-            | "cronExpression"
-            | "lastRuntimeExecution"
-            | "lastExecutedStatus"
-            | "name"
-            | "jobParameters"
-            | "lastExecuted"
-        >;
-    };
-}
-
-export interface D2OptionSetSchema {
-    name: "D2OptionSet";
-    model: D2OptionSet;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        options: D2OptionSchema[];
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        valueType:
-            | "TEXT"
-            | "LONG_TEXT"
-            | "LETTER"
-            | "PHONE_NUMBER"
-            | "EMAIL"
-            | "BOOLEAN"
-            | "TRUE_ONLY"
-            | "DATE"
-            | "DATETIME"
-            | "TIME"
-            | "NUMBER"
-            | "UNIT_INTERVAL"
-            | "PERCENTAGE"
-            | "INTEGER"
-            | "INTEGER_POSITIVE"
-            | "INTEGER_NEGATIVE"
-            | "INTEGER_ZERO_OR_POSITIVE"
-            | "TRACKER_ASSOCIATE"
-            | "USERNAME"
-            | "COORDINATE"
-            | "ORGANISATION_UNIT"
-            | "AGE"
-            | "URL"
-            | "FILE_RESOURCE"
-            | "IMAGE";
-        version: number;
-    };
-    fieldPresets: {
-        $all: Preset<D2OptionSet, keyof D2OptionSet>;
-        $identifiable: Preset<D2OptionSet, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OptionSet, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2OptionSet,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "version"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "valueType"
-            | "name"
-            | "options"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2OptionSet,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "version"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "valueType"
-            | "name"
-            | "options"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
-export interface D2OptionGroupSetSchema {
-    name: "D2OptionGroupSet";
-    model: D2OptionGroupSet;
+export interface D2CategorySchema {
+    name: "D2Category";
+    model: D2Category;
     fields: {
         access: D2Access;
         aggregationType:
@@ -5593,6 +4919,8 @@ export interface D2OptionGroupSetSchema {
             | "DEFAULT";
         allItems: boolean;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        categoryCombos: D2CategoryComboSchema[];
+        categoryOptions: D2CategoryOptionSchema[];
         code: Id;
         created: string;
         dataDimension: boolean;
@@ -5635,8 +4963,6 @@ export interface D2OptionGroupSetSchema {
         lastUpdatedBy: D2UserSchema;
         legendSet: D2LegendSetSchema;
         name: string;
-        optionGroups: D2OptionGroupSchema[];
-        optionSet: D2OptionSetSchema;
         programStage: D2ProgramStageSchema;
         publicAccess: string;
         shortName: string;
@@ -5646,40 +4972,41 @@ export interface D2OptionGroupSetSchema {
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2OptionGroupSet, keyof D2OptionGroupSet>;
-        $identifiable: Preset<D2OptionGroupSet, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OptionGroupSet, FieldPresets["nameable"]>;
+        $all: Preset<D2Category, keyof D2Category>;
+        $identifiable: Preset<D2Category, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Category, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2OptionGroupSet,
+            D2Category,
+            | "dataDimensionType"
             | "code"
             | "publicAccess"
-            | "description"
-            | "optionGroups"
             | "lastUpdated"
-            | "optionSet"
             | "translations"
+            | "categoryCombos"
             | "id"
+            | "categoryOptions"
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "created"
+            | "attributeValues"
             | "userAccesses"
             | "name"
             | "dataDimension"
             | "user"
         >;
         $owner: Preset<
-            D2OptionGroupSet,
+            D2Category,
+            | "dataDimensionType"
             | "code"
             | "publicAccess"
-            | "description"
-            | "optionGroups"
             | "lastUpdated"
-            | "optionSet"
             | "translations"
             | "id"
+            | "categoryOptions"
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "created"
+            | "attributeValues"
             | "userAccesses"
             | "name"
             | "dataDimension"
@@ -5688,672 +5015,86 @@ export interface D2OptionGroupSetSchema {
     };
 }
 
-export interface D2OptionGroupSchema {
-    name: "D2OptionGroup";
-    model: D2OptionGroup;
-    fields: {
-        access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "FIRST"
-            | "FIRST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        description: string;
-        dimensionItem: string;
-        dimensionItemType:
-            | "DATA_ELEMENT"
-            | "DATA_ELEMENT_OPERAND"
-            | "INDICATOR"
-            | "REPORTING_RATE"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION"
-            | "OPTION_GROUP"
-            | "DATA_ELEMENT_GROUP"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY_OPTION_GROUP";
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        legendSet: D2LegendSetSchema;
-        legendSets: D2LegendSetSchema[];
-        name: string;
-        optionSet: D2OptionSetSchema;
-        options: D2OptionSchema[];
-        publicAccess: string;
-        shortName: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2OptionGroup, keyof D2OptionGroup>;
-        $identifiable: Preset<D2OptionGroup, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OptionGroup, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2OptionGroup,
-            | "code"
-            | "publicAccess"
-            | "lastUpdated"
-            | "optionSet"
-            | "translations"
-            | "options"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "userAccesses"
-            | "name"
-            | "shortName"
-            | "user"
-        >;
-        $owner: Preset<
-            D2OptionGroup,
-            | "code"
-            | "publicAccess"
-            | "lastUpdated"
-            | "optionSet"
-            | "translations"
-            | "options"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "userAccesses"
-            | "name"
-            | "shortName"
-            | "user"
-        >;
-    };
-}
-
-export interface D2LegendSetSchema {
-    name: "D2LegendSet";
-    model: D2LegendSet;
+export interface D2CategoryComboSchema {
+    name: "D2CategoryCombo";
+    model: D2CategoryCombo;
     fields: {
         access: D2Access;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        categories: D2CategorySchema[];
+        categoryOptionCombos: D2CategoryOptionComboSchema[];
         code: Id;
         created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        legends: D2LegendSchema[];
-        name: string;
-        publicAccess: string;
-        symbolizer: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2LegendSet, keyof D2LegendSet>;
-        $identifiable: Preset<D2LegendSet, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2LegendSet, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2LegendSet,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "symbolizer"
-            | "lastUpdated"
-            | "legends"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2LegendSet,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "symbolizer"
-            | "lastUpdated"
-            | "legends"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
-export interface D2ColorSetSchema {
-    name: "D2ColorSet";
-    model: D2ColorSet;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        colors: D2ColorSchema[];
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ColorSet, keyof D2ColorSet>;
-        $identifiable: Preset<D2ColorSet, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ColorSet, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ColorSet,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "colors"
-            | "lastUpdated"
-            | "translations"
-            | "name"
-            | "id"
-        >;
-        $owner: Preset<
-            D2ColorSet,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "colors"
-            | "lastUpdated"
-            | "translations"
-            | "name"
-            | "id"
-        >;
-    };
-}
-
-export interface D2OrganisationUnitSchema {
-    name: "D2OrganisationUnit";
-    model: D2OrganisationUnit;
-    fields: {
-        access: D2Access;
-        address: string;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "FIRST"
-            | "FIRST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
-        ancestors: D2OrganisationUnitSchema[];
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        children: D2OrganisationUnitSchema[];
-        closedDate: string;
-        code: Id;
-        comment: string;
-        contactPerson: string;
-        created: string;
-        dataSets: D2DataSetSchema[];
-        description: string;
-        dimensionItem: string;
-        dimensionItemType:
-            | "DATA_ELEMENT"
-            | "DATA_ELEMENT_OPERAND"
-            | "INDICATOR"
-            | "REPORTING_RATE"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION"
-            | "OPTION_GROUP"
-            | "DATA_ELEMENT_GROUP"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY_OPTION_GROUP";
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        email: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        geometry: D2Geometry;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        leaf: boolean;
-        legendSet: D2LegendSetSchema;
-        legendSets: D2LegendSetSchema[];
-        level: number;
-        memberCount: number;
-        name: string;
-        openingDate: string;
-        organisationUnitGroups: D2OrganisationUnitGroupSchema[];
-        parent: D2OrganisationUnitSchema;
-        path: string;
-        phoneNumber: string;
-        programs: D2ProgramSchema[];
-        publicAccess: string;
-        shortName: string;
-        translations: D2Translation[];
-        type: string;
-        url: string;
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        users: D2UserSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2OrganisationUnit, keyof D2OrganisationUnit>;
-        $identifiable: Preset<D2OrganisationUnit, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OrganisationUnit, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2OrganisationUnit,
-            | "parent"
-            | "path"
-            | "lastUpdated"
-            | "children"
-            | "translations"
-            | "id"
-            | "organisationUnitGroups"
-            | "lastUpdatedBy"
-            | "level"
-            | "created"
-            | "attributeValues"
-            | "users"
-            | "phoneNumber"
-            | "name"
-            | "dataSets"
-            | "programs"
-            | "shortName"
-            | "code"
-            | "description"
-            | "contactPerson"
-            | "openingDate"
-            | "email"
-            | "address"
-            | "url"
-            | "closedDate"
-            | "geometry"
-            | "comment"
-            | "user"
-        >;
-        $owner: Preset<
-            D2OrganisationUnit,
-            | "parent"
-            | "path"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "level"
-            | "created"
-            | "attributeValues"
-            | "phoneNumber"
-            | "name"
-            | "shortName"
-            | "code"
-            | "description"
-            | "contactPerson"
-            | "openingDate"
-            | "email"
-            | "address"
-            | "url"
-            | "closedDate"
-            | "geometry"
-            | "comment"
-            | "user"
-        >;
-    };
-}
-
-export interface D2OrganisationUnitLevelSchema {
-    name: "D2OrganisationUnitLevel";
-    model: D2OrganisationUnitLevel;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        level: number;
-        name: string;
-        offlineLevels: number;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2OrganisationUnitLevel, keyof D2OrganisationUnitLevel>;
-        $identifiable: Preset<D2OrganisationUnitLevel, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OrganisationUnitLevel, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2OrganisationUnitLevel,
-            | "lastUpdatedBy"
-            | "offlineLevels"
-            | "code"
-            | "level"
-            | "created"
-            | "lastUpdated"
-            | "translations"
-            | "name"
-            | "id"
-        >;
-        $owner: Preset<
-            D2OrganisationUnitLevel,
-            | "lastUpdatedBy"
-            | "offlineLevels"
-            | "code"
-            | "level"
-            | "created"
-            | "lastUpdated"
-            | "translations"
-            | "name"
-            | "id"
-        >;
-    };
-}
-
-export interface D2OrganisationUnitGroupSchema {
-    name: "D2OrganisationUnitGroup";
-    model: D2OrganisationUnitGroup;
-    fields: {
-        access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "FIRST"
-            | "FIRST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        color: string;
-        created: string;
-        description: string;
-        dimensionItem: string;
-        dimensionItemType:
-            | "DATA_ELEMENT"
-            | "DATA_ELEMENT_OPERAND"
-            | "INDICATOR"
-            | "REPORTING_RATE"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION"
-            | "OPTION_GROUP"
-            | "DATA_ELEMENT_GROUP"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY_OPTION_GROUP";
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
-        formName: string;
-        geometry: D2Geometry;
-        groupSets: D2OrganisationUnitGroupSetSchema[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        legendSet: D2LegendSetSchema;
-        legendSets: D2LegendSetSchema[];
-        name: string;
-        organisationUnits: D2OrganisationUnitSchema[];
-        publicAccess: string;
-        shortName: string;
-        symbol: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2OrganisationUnitGroup, keyof D2OrganisationUnitGroup>;
-        $identifiable: Preset<D2OrganisationUnitGroup, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OrganisationUnitGroup, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2OrganisationUnitGroup,
-            | "symbol"
-            | "code"
-            | "color"
-            | "publicAccess"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "organisationUnits"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "groupSets"
-            | "userAccesses"
-            | "name"
-            | "geometry"
-            | "shortName"
-            | "user"
-        >;
-        $owner: Preset<
-            D2OrganisationUnitGroup,
-            | "symbol"
-            | "code"
-            | "color"
-            | "publicAccess"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "organisationUnits"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "userAccesses"
-            | "name"
-            | "geometry"
-            | "shortName"
-            | "user"
-        >;
-    };
-}
-
-export interface D2OrganisationUnitGroupSetSchema {
-    name: "D2OrganisationUnitGroupSet";
-    model: D2OrganisationUnitGroupSet;
-    fields: {
-        access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "FIRST"
-            | "FIRST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
-        allItems: boolean;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        compulsory: boolean;
-        created: string;
-        dataDimension: boolean;
         dataDimensionType: "DISAGGREGATION" | "ATTRIBUTE";
-        description: string;
-        dimension: string;
-        dimensionType:
-            | "DATA_X"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "DATA_COLLAPSED"
-            | "CATEGORY_OPTION_COMBO"
-            | "ATTRIBUTE_OPTION_COMBO"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION_GROUP_SET"
-            | "DATA_ELEMENT_GROUP_SET"
-            | "ORGANISATION_UNIT_GROUP_SET"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY"
-            | "OPTION_GROUP_SET"
-            | "VALIDATION_RULE"
-            | "STATIC"
-            | "ORGANISATION_UNIT_LEVEL";
-        dimensionalKeywords: D2DimensionalKeywords;
-        displayDescription: string;
-        displayFormName: string;
         displayName: string;
-        displayShortName: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
-        filter: string;
-        formName: string;
         href: string;
         id: Id;
-        includeSubhierarchyInAnalytics: boolean;
-        items: any[];
+        isDefault: boolean;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
-        legendSet: D2LegendSetSchema;
         name: string;
-        organisationUnitGroups: D2OrganisationUnitGroupSchema[];
-        programStage: D2ProgramStageSchema;
         publicAccess: string;
-        shortName: string;
+        skipTotal: boolean;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2OrganisationUnitGroupSet, keyof D2OrganisationUnitGroupSet>;
-        $identifiable: Preset<D2OrganisationUnitGroupSet, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OrganisationUnitGroupSet, FieldPresets["nameable"]>;
+        $all: Preset<D2CategoryCombo, keyof D2CategoryCombo>;
+        $identifiable: Preset<D2CategoryCombo, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2CategoryCombo, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2OrganisationUnitGroupSet,
+            D2CategoryCombo,
+            | "dataDimensionType"
             | "code"
             | "publicAccess"
-            | "description"
             | "lastUpdated"
             | "translations"
             | "id"
-            | "organisationUnitGroups"
+            | "categories"
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "created"
-            | "attributeValues"
-            | "compulsory"
-            | "includeSubhierarchyInAnalytics"
+            | "categoryOptionCombos"
             | "userAccesses"
             | "name"
-            | "dataDimension"
+            | "skipTotal"
             | "user"
         >;
         $owner: Preset<
-            D2OrganisationUnitGroupSet,
+            D2CategoryCombo,
+            | "dataDimensionType"
             | "code"
             | "publicAccess"
-            | "description"
             | "lastUpdated"
             | "translations"
             | "id"
-            | "organisationUnitGroups"
+            | "categories"
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "created"
-            | "attributeValues"
-            | "compulsory"
-            | "includeSubhierarchyInAnalytics"
             | "userAccesses"
             | "name"
-            | "dataDimension"
+            | "skipTotal"
             | "user"
         >;
+    };
+}
+
+export interface D2CategoryDimensionSchema {
+    name: "D2CategoryDimension";
+    model: D2CategoryDimension;
+    fields: { category: D2CategorySchema; categoryOptions: D2CategoryOptionSchema[] };
+    fieldPresets: {
+        $all: Preset<D2CategoryDimension, keyof D2CategoryDimension>;
+        $identifiable: Preset<D2CategoryDimension, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2CategoryDimension, FieldPresets["nameable"]>;
+        $persisted: Preset<D2CategoryDimension, "categoryOptions" | "category">;
+        $owner: Preset<D2CategoryDimension, "categoryOptions" | "category">;
     };
 }
 
@@ -6476,6 +5217,107 @@ export interface D2CategoryOptionSchema {
             | "shortName"
             | "user"
             | "startDate"
+        >;
+    };
+}
+
+export interface D2CategoryOptionComboSchema {
+    name: "D2CategoryOptionCombo";
+    model: D2CategoryOptionCombo;
+    fields: {
+        access: D2Access;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        categoryCombo: D2CategoryComboSchema;
+        categoryOptions: D2CategoryOptionSchema[];
+        code: Id;
+        created: string;
+        description: string;
+        dimensionItem: string;
+        dimensionItemType:
+            | "DATA_ELEMENT"
+            | "DATA_ELEMENT_OPERAND"
+            | "INDICATOR"
+            | "REPORTING_RATE"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION"
+            | "OPTION_GROUP"
+            | "DATA_ELEMENT_GROUP"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY_OPTION_GROUP";
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        ignoreApproval: boolean;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendSet: D2LegendSetSchema;
+        legendSets: D2LegendSetSchema[];
+        name: string;
+        publicAccess: string;
+        shortName: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2CategoryOptionCombo, keyof D2CategoryOptionCombo>;
+        $identifiable: Preset<D2CategoryOptionCombo, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2CategoryOptionCombo, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2CategoryOptionCombo,
+            | "code"
+            | "lastUpdated"
+            | "ignoreApproval"
+            | "categoryCombo"
+            | "translations"
+            | "id"
+            | "categoryOptions"
+            | "lastUpdatedBy"
+            | "created"
+            | "attributeValues"
+            | "name"
+        >;
+        $owner: Preset<
+            D2CategoryOptionCombo,
+            | "code"
+            | "lastUpdated"
+            | "ignoreApproval"
+            | "categoryCombo"
+            | "translations"
+            | "id"
+            | "categoryOptions"
+            | "lastUpdatedBy"
+            | "created"
+            | "attributeValues"
+            | "name"
         >;
     };
 }
@@ -6709,9 +5551,31 @@ export interface D2CategoryOptionGroupSetSchema {
     };
 }
 
-export interface D2CategorySchema {
-    name: "D2Category";
-    model: D2Category;
+export interface D2CategoryOptionGroupSetDimensionSchema {
+    name: "D2CategoryOptionGroupSetDimension";
+    model: D2CategoryOptionGroupSetDimension;
+    fields: {
+        categoryOptionGroupSet: D2CategoryOptionGroupSetSchema;
+        categoryOptionGroups: D2CategoryOptionGroupSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2CategoryOptionGroupSetDimension, keyof D2CategoryOptionGroupSetDimension>;
+        $identifiable: Preset<D2CategoryOptionGroupSetDimension, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2CategoryOptionGroupSetDimension, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2CategoryOptionGroupSetDimension,
+            "categoryOptionGroups" | "categoryOptionGroupSet"
+        >;
+        $owner: Preset<
+            D2CategoryOptionGroupSetDimension,
+            "categoryOptionGroups" | "categoryOptionGroupSet"
+        >;
+    };
+}
+
+export interface D2ChartSchema {
+    name: "D2Chart";
+    model: D2Chart;
     fields: {
         access: D2Access;
         aggregationType:
@@ -6730,36 +5594,363 @@ export interface D2CategorySchema {
             | "NONE"
             | "CUSTOM"
             | "DEFAULT";
-        allItems: boolean;
+        attributeDimensions: any[];
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        categoryCombos: D2CategoryComboSchema[];
-        categoryOptions: D2CategoryOptionSchema[];
+        baseLineLabel: string;
+        baseLineValue: number;
+        category: string;
+        categoryDimensions: D2CategoryDimensionSchema[];
+        categoryOptionGroupSetDimensions: D2CategoryOptionGroupSetDimensionSchema[];
+        code: Id;
+        colorSet: D2ColorSetSchema;
+        columns: any[];
+        completedOnly: boolean;
+        created: string;
+        cumulativeValues: boolean;
+        dataDimensionItems: any[];
+        dataElementDimensions: D2TrackedEntityDataElementDimensionSchema[];
+        dataElementGroupSetDimensions: D2DataElementGroupSetDimensionSchema[];
+        description: string;
+        digitGroupSeparator: "COMMA" | "SPACE" | "NONE";
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        domainAxisLabel: string;
+        endDate: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        filterDimensions: string[];
+        filters: any[];
+        formName: string;
+        hideEmptyRowItems:
+            | "NONE"
+            | "BEFORE_FIRST"
+            | "AFTER_LAST"
+            | "BEFORE_FIRST_AFTER_LAST"
+            | "ALL";
+        hideLegend: boolean;
+        hideSubtitle: boolean;
+        hideTitle: boolean;
+        href: string;
+        id: Id;
+        interpretations: D2InterpretationSchema[];
+        itemOrganisationUnitGroups: D2OrganisationUnitGroupSchema[];
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendDisplayStrategy: "FIXED" | "BY_DATA_ITEM";
+        legendSet: D2LegendSetSchema;
+        name: string;
+        noSpaceBetweenColumns: boolean;
+        orgUnitField: string;
+        organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimensionSchema[];
+        organisationUnitLevels: number[];
+        organisationUnits: D2OrganisationUnitSchema[];
+        parentGraphMap: D2MapSchema;
+        percentStackedValues: boolean;
+        periods: any[];
+        programIndicatorDimensions: D2TrackedEntityProgramIndicatorDimensionSchema[];
+        publicAccess: string;
+        rangeAxisDecimals: number;
+        rangeAxisLabel: string;
+        rangeAxisMaxValue: number;
+        rangeAxisMinValue: number;
+        rangeAxisSteps: number;
+        regressionType: "NONE" | "LINEAR" | "POLYNOMIAL" | "LOESS";
+        relativePeriods: any;
+        rows: any[];
+        series: string;
+        seriesItems: any[];
+        shortName: string;
+        showData: boolean;
+        sortOrder: number;
+        startDate: string;
+        subscribed: boolean;
+        subscribers: string[];
+        subtitle: string;
+        targetLineLabel: string;
+        targetLineValue: number;
+        timeField: string;
+        title: string;
+        topLimit: number;
+        translations: D2Translation[];
+        type:
+            | "COLUMN"
+            | "STACKED_COLUMN"
+            | "BAR"
+            | "STACKED_BAR"
+            | "LINE"
+            | "AREA"
+            | "PIE"
+            | "RADAR"
+            | "GAUGE"
+            | "YEAR_OVER_YEAR_LINE"
+            | "YEAR_OVER_YEAR_COLUMN"
+            | "SINGLE_VALUE";
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        userOrganisationUnit: boolean;
+        userOrganisationUnitChildren: boolean;
+        userOrganisationUnitGrandChildren: boolean;
+        yearlySeries: string[];
+    };
+    fieldPresets: {
+        $all: Preset<D2Chart, keyof D2Chart>;
+        $identifiable: Preset<D2Chart, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Chart, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Chart,
+            | "dataElementGroupSetDimensions"
+            | "showData"
+            | "endDate"
+            | "baseLineValue"
+            | "publicAccess"
+            | "userOrganisationUnitChildren"
+            | "type"
+            | "lastUpdated"
+            | "translations"
+            | "yearlySeries"
+            | "userOrganisationUnit"
+            | "filterDimensions"
+            | "id"
+            | "interpretations"
+            | "itemOrganisationUnitGroups"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "domainAxisLabel"
+            | "created"
+            | "subscribers"
+            | "rangeAxisLabel"
+            | "regressionType"
+            | "completedOnly"
+            | "cumulativeValues"
+            | "subtitle"
+            | "sortOrder"
+            | "userAccesses"
+            | "name"
+            | "rangeAxisDecimals"
+            | "startDate"
+            | "hideEmptyRowItems"
+            | "favorites"
+            | "dataDimensionItems"
+            | "aggregationType"
+            | "code"
+            | "categoryOptionGroupSetDimensions"
+            | "userOrganisationUnitGrandChildren"
+            | "hideSubtitle"
+            | "description"
+            | "organisationUnitGroupSetDimensions"
+            | "title"
+            | "hideLegend"
+            | "organisationUnitLevels"
+            | "externalAccess"
+            | "rangeAxisMinValue"
+            | "percentStackedValues"
+            | "seriesItems"
+            | "legendDisplayStrategy"
+            | "noSpaceBetweenColumns"
+            | "relativePeriods"
+            | "rangeAxisSteps"
+            | "targetLineLabel"
+            | "periods"
+            | "organisationUnits"
+            | "categoryDimensions"
+            | "targetLineValue"
+            | "baseLineLabel"
+            | "hideTitle"
+            | "series"
+            | "legendSet"
+            | "rangeAxisMaxValue"
+            | "colorSet"
+            | "category"
+            | "user"
+        >;
+        $owner: Preset<
+            D2Chart,
+            | "dataElementGroupSetDimensions"
+            | "showData"
+            | "endDate"
+            | "baseLineValue"
+            | "publicAccess"
+            | "userOrganisationUnitChildren"
+            | "type"
+            | "lastUpdated"
+            | "translations"
+            | "yearlySeries"
+            | "userOrganisationUnit"
+            | "filterDimensions"
+            | "id"
+            | "itemOrganisationUnitGroups"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "domainAxisLabel"
+            | "created"
+            | "subscribers"
+            | "rangeAxisLabel"
+            | "regressionType"
+            | "completedOnly"
+            | "cumulativeValues"
+            | "subtitle"
+            | "sortOrder"
+            | "userAccesses"
+            | "name"
+            | "rangeAxisDecimals"
+            | "startDate"
+            | "hideEmptyRowItems"
+            | "favorites"
+            | "dataDimensionItems"
+            | "aggregationType"
+            | "code"
+            | "categoryOptionGroupSetDimensions"
+            | "userOrganisationUnitGrandChildren"
+            | "hideSubtitle"
+            | "description"
+            | "organisationUnitGroupSetDimensions"
+            | "title"
+            | "hideLegend"
+            | "organisationUnitLevels"
+            | "externalAccess"
+            | "rangeAxisMinValue"
+            | "percentStackedValues"
+            | "seriesItems"
+            | "legendDisplayStrategy"
+            | "noSpaceBetweenColumns"
+            | "relativePeriods"
+            | "rangeAxisSteps"
+            | "targetLineLabel"
+            | "periods"
+            | "organisationUnits"
+            | "categoryDimensions"
+            | "targetLineValue"
+            | "baseLineLabel"
+            | "hideTitle"
+            | "series"
+            | "legendSet"
+            | "rangeAxisMaxValue"
+            | "colorSet"
+            | "category"
+            | "user"
+        >;
+    };
+}
+
+export interface D2ColorSchema {
+    name: "D2Color";
+    model: D2Color;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        color: string;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2Color, keyof D2Color>;
+        $identifiable: Preset<D2Color, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Color, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Color,
+            | "lastUpdatedBy"
+            | "code"
+            | "color"
+            | "created"
+            | "lastUpdated"
+            | "translations"
+            | "name"
+            | "id"
+        >;
+        $owner: Preset<
+            D2Color,
+            | "lastUpdatedBy"
+            | "code"
+            | "color"
+            | "created"
+            | "lastUpdated"
+            | "translations"
+            | "name"
+            | "id"
+        >;
+    };
+}
+
+export interface D2ColorSetSchema {
+    name: "D2ColorSet";
+    model: D2ColorSet;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        colors: D2ColorSchema[];
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ColorSet, keyof D2ColorSet>;
+        $identifiable: Preset<D2ColorSet, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ColorSet, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ColorSet,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "colors"
+            | "lastUpdated"
+            | "translations"
+            | "name"
+            | "id"
+        >;
+        $owner: Preset<
+            D2ColorSet,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "colors"
+            | "lastUpdated"
+            | "translations"
+            | "name"
+            | "id"
+        >;
+    };
+}
+
+export interface D2ConstantSchema {
+    name: "D2Constant";
+    model: D2Constant;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
-        dataDimension: boolean;
-        dataDimensionType: "DISAGGREGATION" | "ATTRIBUTE";
         description: string;
-        dimension: string;
-        dimensionType:
-            | "DATA_X"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "DATA_COLLAPSED"
-            | "CATEGORY_OPTION_COMBO"
-            | "ATTRIBUTE_OPTION_COMBO"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION_GROUP_SET"
-            | "DATA_ELEMENT_GROUP_SET"
-            | "ORGANISATION_UNIT_GROUP_SET"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY"
-            | "OPTION_GROUP_SET"
-            | "VALIDATION_RULE"
-            | "STATIC"
-            | "ORGANISATION_UNIT_LEVEL";
-        dimensionalKeywords: D2DimensionalKeywords;
         displayDescription: string;
         displayFormName: string;
         displayName: string;
@@ -6767,16 +5958,87 @@ export interface D2CategorySchema {
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
-        filter: string;
         formName: string;
         href: string;
         id: Id;
-        items: any[];
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
-        legendSet: D2LegendSetSchema;
         name: string;
-        programStage: D2ProgramStageSchema;
+        publicAccess: string;
+        shortName: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        value: number;
+    };
+    fieldPresets: {
+        $all: Preset<D2Constant, keyof D2Constant>;
+        $identifiable: Preset<D2Constant, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Constant, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Constant,
+            | "code"
+            | "publicAccess"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "value"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "userAccesses"
+            | "name"
+            | "shortName"
+            | "user"
+        >;
+        $owner: Preset<
+            D2Constant,
+            | "code"
+            | "publicAccess"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "value"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "userAccesses"
+            | "name"
+            | "shortName"
+            | "user"
+        >;
+    };
+}
+
+export interface D2DashboardSchema {
+    name: "D2Dashboard";
+    model: D2Dashboard;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        dashboardItems: D2DashboardItemSchema[];
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        itemCount: number;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
         publicAccess: string;
         shortName: string;
         translations: D2Translation[];
@@ -6785,216 +6047,292 @@ export interface D2CategorySchema {
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2Category, keyof D2Category>;
-        $identifiable: Preset<D2Category, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Category, FieldPresets["nameable"]>;
+        $all: Preset<D2Dashboard, keyof D2Dashboard>;
+        $identifiable: Preset<D2Dashboard, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Dashboard, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2Category,
-            | "dataDimensionType"
+            D2Dashboard,
+            | "favorites"
             | "code"
             | "publicAccess"
+            | "description"
+            | "externalAccess"
             | "lastUpdated"
             | "translations"
-            | "categoryCombos"
             | "id"
-            | "categoryOptions"
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "created"
-            | "attributeValues"
+            | "dashboardItems"
             | "userAccesses"
             | "name"
-            | "dataDimension"
             | "user"
         >;
         $owner: Preset<
-            D2Category,
-            | "dataDimensionType"
+            D2Dashboard,
+            | "favorites"
             | "code"
             | "publicAccess"
+            | "description"
+            | "externalAccess"
             | "lastUpdated"
             | "translations"
             | "id"
-            | "categoryOptions"
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "created"
-            | "attributeValues"
+            | "dashboardItems"
             | "userAccesses"
             | "name"
-            | "dataDimension"
             | "user"
         >;
     };
 }
 
-export interface D2CategoryComboSchema {
-    name: "D2CategoryCombo";
-    model: D2CategoryCombo;
+export interface D2DashboardItemSchema {
+    name: "D2DashboardItem";
+    model: D2DashboardItem;
+    fields: {
+        access: D2Access;
+        appKey: string;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        chart: D2ChartSchema;
+        code: Id;
+        contentCount: number;
+        created: string;
+        displayName: string;
+        eventChart: D2EventChartSchema;
+        eventReport: D2EventReportSchema;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        height: number;
+        href: string;
+        id: Id;
+        interpretationCount: number;
+        interpretationLikeCount: number;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        map: D2MapSchema;
+        messages: boolean;
+        name: string;
+        publicAccess: string;
+        reportTable: D2ReportTableSchema;
+        reports: D2ReportSchema[];
+        resources: D2DocumentSchema[];
+        shape: "NORMAL" | "DOUBLE_WIDTH" | "FULL_WIDTH";
+        text: string;
+        translations: D2Translation[];
+        type:
+            | "CHART"
+            | "EVENT_CHART"
+            | "MAP"
+            | "REPORT_TABLE"
+            | "EVENT_REPORT"
+            | "USERS"
+            | "REPORTS"
+            | "RESOURCES"
+            | "TEXT"
+            | "MESSAGES"
+            | "APP";
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        users: D2UserSchema[];
+        width: number;
+        x: number;
+        y: number;
+    };
+    fieldPresets: {
+        $all: Preset<D2DashboardItem, keyof D2DashboardItem>;
+        $identifiable: Preset<D2DashboardItem, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2DashboardItem, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2DashboardItem,
+            | "reports"
+            | "code"
+            | "reportTable"
+            | "lastUpdated"
+            | "translations"
+            | "appKey"
+            | "id"
+            | "text"
+            | "map"
+            | "height"
+            | "lastUpdatedBy"
+            | "shape"
+            | "created"
+            | "resources"
+            | "users"
+            | "eventReport"
+            | "eventChart"
+            | "width"
+            | "x"
+            | "messages"
+            | "y"
+            | "chart"
+        >;
+        $owner: Preset<
+            D2DashboardItem,
+            | "reports"
+            | "code"
+            | "reportTable"
+            | "lastUpdated"
+            | "translations"
+            | "appKey"
+            | "id"
+            | "text"
+            | "map"
+            | "height"
+            | "lastUpdatedBy"
+            | "shape"
+            | "created"
+            | "resources"
+            | "users"
+            | "eventReport"
+            | "eventChart"
+            | "width"
+            | "x"
+            | "messages"
+            | "y"
+            | "chart"
+        >;
+    };
+}
+
+export interface D2DataApprovalLevelSchema {
+    name: "D2DataApprovalLevel";
+    model: D2DataApprovalLevel;
     fields: {
         access: D2Access;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        categories: D2CategorySchema[];
-        categoryOptionCombos: D2CategoryOptionComboSchema[];
+        categoryOptionGroupSet: D2CategoryOptionGroupSetSchema;
         code: Id;
         created: string;
-        dataDimensionType: "DISAGGREGATION" | "ATTRIBUTE";
         displayName: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
         href: string;
         id: Id;
-        isDefault: boolean;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
+        level: number;
         name: string;
+        orgUnitLevel: number;
+        orgUnitLevelName: string;
         publicAccess: string;
-        skipTotal: boolean;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2CategoryCombo, keyof D2CategoryCombo>;
-        $identifiable: Preset<D2CategoryCombo, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2CategoryCombo, FieldPresets["nameable"]>;
+        $all: Preset<D2DataApprovalLevel, keyof D2DataApprovalLevel>;
+        $identifiable: Preset<D2DataApprovalLevel, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2DataApprovalLevel, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2CategoryCombo,
-            | "dataDimensionType"
+            D2DataApprovalLevel,
+            | "lastUpdatedBy"
+            | "categoryOptionGroupSet"
+            | "userGroupAccesses"
             | "code"
+            | "level"
+            | "created"
             | "publicAccess"
             | "lastUpdated"
             | "translations"
-            | "id"
-            | "categories"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "categoryOptionCombos"
             | "userAccesses"
             | "name"
-            | "skipTotal"
+            | "orgUnitLevel"
+            | "id"
             | "user"
         >;
         $owner: Preset<
-            D2CategoryCombo,
-            | "dataDimensionType"
+            D2DataApprovalLevel,
+            | "lastUpdatedBy"
+            | "categoryOptionGroupSet"
+            | "userGroupAccesses"
             | "code"
+            | "level"
+            | "created"
             | "publicAccess"
             | "lastUpdated"
             | "translations"
-            | "id"
-            | "categories"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
             | "userAccesses"
             | "name"
-            | "skipTotal"
+            | "orgUnitLevel"
+            | "id"
             | "user"
         >;
     };
 }
 
-export interface D2CategoryOptionComboSchema {
-    name: "D2CategoryOptionCombo";
-    model: D2CategoryOptionCombo;
+export interface D2DataApprovalWorkflowSchema {
+    name: "D2DataApprovalWorkflow";
+    model: D2DataApprovalWorkflow;
     fields: {
         access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "FIRST"
-            | "FIRST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         categoryCombo: D2CategoryComboSchema;
-        categoryOptions: D2CategoryOptionSchema[];
         code: Id;
         created: string;
-        description: string;
-        dimensionItem: string;
-        dimensionItemType:
-            | "DATA_ELEMENT"
-            | "DATA_ELEMENT_OPERAND"
-            | "INDICATOR"
-            | "REPORTING_RATE"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION"
-            | "OPTION_GROUP"
-            | "DATA_ELEMENT_GROUP"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY_OPTION_GROUP";
-        displayDescription: string;
-        displayFormName: string;
+        dataApprovalLevels: D2DataApprovalLevelSchema[];
+        dataSets: D2DataSetSchema[];
         displayName: string;
-        displayShortName: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
-        formName: string;
         href: string;
         id: Id;
-        ignoreApproval: boolean;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
-        legendSet: D2LegendSetSchema;
-        legendSets: D2LegendSetSchema[];
         name: string;
+        periodType: string;
         publicAccess: string;
-        shortName: string;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2CategoryOptionCombo, keyof D2CategoryOptionCombo>;
-        $identifiable: Preset<D2CategoryOptionCombo, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2CategoryOptionCombo, FieldPresets["nameable"]>;
+        $all: Preset<D2DataApprovalWorkflow, keyof D2DataApprovalWorkflow>;
+        $identifiable: Preset<D2DataApprovalWorkflow, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2DataApprovalWorkflow, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2CategoryOptionCombo,
+            D2DataApprovalWorkflow,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
             | "code"
+            | "created"
+            | "publicAccess"
+            | "dataApprovalLevels"
             | "lastUpdated"
-            | "ignoreApproval"
+            | "periodType"
             | "categoryCombo"
             | "translations"
-            | "id"
-            | "categoryOptions"
-            | "lastUpdatedBy"
-            | "created"
-            | "attributeValues"
+            | "userAccesses"
             | "name"
+            | "dataSets"
+            | "id"
+            | "user"
         >;
         $owner: Preset<
-            D2CategoryOptionCombo,
+            D2DataApprovalWorkflow,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
             | "code"
+            | "created"
+            | "publicAccess"
+            | "dataApprovalLevels"
             | "lastUpdated"
-            | "ignoreApproval"
+            | "periodType"
             | "categoryCombo"
             | "translations"
-            | "id"
-            | "categoryOptions"
-            | "lastUpdatedBy"
-            | "created"
-            | "attributeValues"
+            | "userAccesses"
             | "name"
+            | "id"
+            | "user"
         >;
     };
 }
@@ -7396,149 +6734,30 @@ export interface D2DataElementGroupSetSchema {
     };
 }
 
-export interface D2IndicatorTypeSchema {
-    name: "D2IndicatorType";
-    model: D2IndicatorType;
+export interface D2DataElementGroupSetDimensionSchema {
+    name: "D2DataElementGroupSetDimension";
+    model: D2DataElementGroupSetDimension;
     fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        factor: number;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        number: boolean;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
+        dataElementGroupSet: D2DataElementGroupSetSchema;
+        dataElementGroups: D2DataElementGroupSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2IndicatorType, keyof D2IndicatorType>;
-        $identifiable: Preset<D2IndicatorType, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2IndicatorType, FieldPresets["nameable"]>;
+        $all: Preset<D2DataElementGroupSetDimension, keyof D2DataElementGroupSetDimension>;
+        $identifiable: Preset<D2DataElementGroupSetDimension, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2DataElementGroupSetDimension, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2IndicatorType,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "lastUpdated"
-            | "number"
-            | "translations"
-            | "name"
-            | "id"
-            | "factor"
+            D2DataElementGroupSetDimension,
+            "dataElementGroups" | "dataElementGroupSet"
         >;
-        $owner: Preset<
-            D2IndicatorType,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "lastUpdated"
-            | "number"
-            | "translations"
-            | "name"
-            | "id"
-            | "factor"
-        >;
+        $owner: Preset<D2DataElementGroupSetDimension, "dataElementGroups" | "dataElementGroupSet">;
     };
 }
 
-export interface D2AnalyticsTableHookSchema {
-    name: "D2AnalyticsTableHook";
-    model: D2AnalyticsTableHook;
+export interface D2DataElementOperandSchema {
+    name: "D2DataElementOperand";
+    model: D2DataElementOperand;
     fields: {
         access: D2Access;
-        analyticsTableType:
-            | "DATA_VALUE"
-            | "COMPLETENESS"
-            | "COMPLETENESS_TARGET"
-            | "ORG_UNIT_TARGET"
-            | "EVENT"
-            | "ENROLLMENT"
-            | "VALIDATION_RESULT";
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        phase: "RESOURCE_TABLE_POPULATED" | "ANALYTICS_TABLE_POPULATED";
-        publicAccess: string;
-        resourceTableType:
-            | "ORG_UNIT_STRUCTURE"
-            | "DATA_SET_ORG_UNIT_CATEGORY"
-            | "CATEGORY_OPTION_COMBO_NAME"
-            | "DATA_ELEMENT_GROUP_SET_STRUCTURE"
-            | "INDICATOR_GROUP_SET_STRUCTURE"
-            | "ORG_UNIT_GROUP_SET_STRUCTURE"
-            | "CATEGORY_STRUCTURE"
-            | "DATA_ELEMENT_STRUCTURE"
-            | "PERIOD_STRUCTURE"
-            | "DATE_PERIOD_STRUCTURE"
-            | "DATA_ELEMENT_CATEGORY_OPTION_COMBO"
-            | "DATA_APPROVAL_REMAP_LEVEL"
-            | "DATA_APPROVAL_MIN_LEVEL";
-        sql: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2AnalyticsTableHook, keyof D2AnalyticsTableHook>;
-        $identifiable: Preset<D2AnalyticsTableHook, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2AnalyticsTableHook, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2AnalyticsTableHook,
-            | "phase"
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "analyticsTableType"
-            | "sql"
-            | "lastUpdated"
-            | "name"
-            | "resourceTableType"
-            | "id"
-        >;
-        $owner: Preset<
-            D2AnalyticsTableHook,
-            | "phase"
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "analyticsTableType"
-            | "sql"
-            | "lastUpdated"
-            | "name"
-            | "resourceTableType"
-            | "id"
-        >;
-    };
-}
-
-export interface D2IndicatorSchema {
-    name: "D2Indicator";
-    model: D2Indicator;
-    fields: {
-        access: D2Access;
-        aggregateExportAttributeOptionCombo: string;
-        aggregateExportCategoryOptionCombo: string;
         aggregationType:
             | "SUM"
             | "AVERAGE"
@@ -7555,14 +6774,12 @@ export interface D2IndicatorSchema {
             | "NONE"
             | "CUSTOM"
             | "DEFAULT";
-        annualized: boolean;
+        attributeOptionCombo: D2CategoryOptionComboSchema;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        categoryOptionCombo: D2CategoryOptionComboSchema;
         code: Id;
         created: string;
-        dataSets: D2DataSetSchema[];
-        decimals: number;
-        denominator: string;
-        denominatorDescription: string;
+        dataElement: D2DataElementSchema;
         description: string;
         dimensionItem: string;
         dimensionItemType:
@@ -7580,11 +6797,9 @@ export interface D2IndicatorSchema {
             | "DATA_ELEMENT_GROUP"
             | "ORGANISATION_UNIT_GROUP"
             | "CATEGORY_OPTION_GROUP";
-        displayDenominatorDescription: string;
         displayDescription: string;
         displayFormName: string;
         displayName: string;
-        displayNumeratorDescription: string;
         displayShortName: string;
         externalAccess: boolean;
         favorite: boolean;
@@ -7592,223 +6807,24 @@ export interface D2IndicatorSchema {
         formName: string;
         href: string;
         id: Id;
-        indicatorGroups: D2IndicatorGroupSchema[];
-        indicatorType: D2IndicatorTypeSchema;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
         legendSet: D2LegendSetSchema;
         legendSets: D2LegendSetSchema[];
         name: string;
-        numerator: string;
-        numeratorDescription: string;
         publicAccess: string;
         shortName: string;
-        style: D2Style;
-        translations: D2Translation[];
-        url: string;
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Indicator, keyof D2Indicator>;
-        $identifiable: Preset<D2Indicator, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Indicator, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Indicator,
-            | "code"
-            | "publicAccess"
-            | "aggregateExportCategoryOptionCombo"
-            | "description"
-            | "lastUpdated"
-            | "denominatorDescription"
-            | "indicatorType"
-            | "translations"
-            | "formName"
-            | "id"
-            | "numeratorDescription"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "indicatorGroups"
-            | "url"
-            | "numerator"
-            | "denominator"
-            | "annualized"
-            | "userAccesses"
-            | "decimals"
-            | "name"
-            | "dataSets"
-            | "legendSets"
-            | "style"
-            | "shortName"
-            | "user"
-            | "aggregateExportAttributeOptionCombo"
-        >;
-        $owner: Preset<
-            D2Indicator,
-            | "code"
-            | "publicAccess"
-            | "aggregateExportCategoryOptionCombo"
-            | "description"
-            | "lastUpdated"
-            | "denominatorDescription"
-            | "indicatorType"
-            | "translations"
-            | "formName"
-            | "id"
-            | "numeratorDescription"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "url"
-            | "numerator"
-            | "denominator"
-            | "annualized"
-            | "userAccesses"
-            | "decimals"
-            | "name"
-            | "legendSets"
-            | "style"
-            | "shortName"
-            | "user"
-            | "aggregateExportAttributeOptionCombo"
-        >;
-    };
-}
-
-export interface D2IndicatorGroupSchema {
-    name: "D2IndicatorGroup";
-    model: D2IndicatorGroup;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        indicatorGroupSet: D2IndicatorGroupSetSchema;
-        indicators: D2IndicatorSchema[];
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2IndicatorGroup, keyof D2IndicatorGroup>;
-        $identifiable: Preset<D2IndicatorGroup, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2IndicatorGroup, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2IndicatorGroup,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "indicators"
-            | "indicatorGroupSet"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2IndicatorGroup,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "indicators"
-            | "indicatorGroupSet"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
-export interface D2IndicatorGroupSetSchema {
-    name: "D2IndicatorGroupSet";
-    model: D2IndicatorGroupSet;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        compulsory: boolean;
-        created: string;
-        description: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        indicatorGroups: D2IndicatorGroupSchema[];
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2IndicatorGroupSet, keyof D2IndicatorGroupSet>;
-        $identifiable: Preset<D2IndicatorGroupSet, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2IndicatorGroupSet, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2IndicatorGroupSet,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "description"
-            | "indicatorGroups"
-            | "lastUpdated"
-            | "compulsory"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2IndicatorGroupSet,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "description"
-            | "indicatorGroups"
-            | "lastUpdated"
-            | "compulsory"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
+        $all: Preset<D2DataElementOperand, keyof D2DataElementOperand>;
+        $identifiable: Preset<D2DataElementOperand, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2DataElementOperand, FieldPresets["nameable"]>;
+        $persisted: Preset<D2DataElementOperand, "categoryOptionCombo" | "dataElement">;
+        $owner: Preset<D2DataElementOperand, "categoryOptionCombo" | "dataElement">;
     };
 }
 
@@ -7868,6 +6884,19 @@ export interface D2DataEntryFormSchema {
             | "style"
             | "id"
         >;
+    };
+}
+
+export interface D2DataInputPeriodSchema {
+    name: "D2DataInputPeriod";
+    model: D2DataInputPeriod;
+    fields: { closingDate: string; openingDate: string; period: any };
+    fieldPresets: {
+        $all: Preset<D2DataInputPeriod, keyof D2DataInputPeriod>;
+        $identifiable: Preset<D2DataInputPeriod, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2DataInputPeriod, FieldPresets["nameable"]>;
+        $persisted: Preset<D2DataInputPeriod, "period" | "closingDate" | "openingDate">;
+        $owner: Preset<D2DataInputPeriod, "period" | "closingDate" | "openingDate">;
     };
 }
 
@@ -8062,6 +7091,23 @@ export interface D2DataSetSchema {
     };
 }
 
+export interface D2DataSetElementSchema {
+    name: "D2DataSetElement";
+    model: D2DataSetElement;
+    fields: {
+        categoryCombo: D2CategoryComboSchema;
+        dataElement: D2DataElementSchema;
+        dataSet: D2DataSetSchema;
+    };
+    fieldPresets: {
+        $all: Preset<D2DataSetElement, keyof D2DataSetElement>;
+        $identifiable: Preset<D2DataSetElement, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2DataSetElement, FieldPresets["nameable"]>;
+        $persisted: Preset<D2DataSetElement, "dataElement" | "categoryCombo" | "dataSet">;
+        $owner: Preset<D2DataSetElement, "dataElement" | "categoryCombo" | "dataSet">;
+    };
+}
+
 export interface D2DataSetNotificationTemplateSchema {
     name: "D2DataSetNotificationTemplate";
     model: D2DataSetNotificationTemplate;
@@ -8143,370 +7189,18 @@ export interface D2DataSetNotificationTemplateSchema {
     };
 }
 
-export interface D2SectionSchema {
-    name: "D2Section";
-    model: D2Section;
+export interface D2DocumentSchema {
+    name: "D2Document";
+    model: D2Document;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        categoryCombos: D2CategoryComboSchema[];
-        code: Id;
-        created: string;
-        dataElements: D2DataElementSchema[];
-        dataSet: D2DataSetSchema;
-        description: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        greyedFields: D2DataElementOperandSchema[];
-        href: string;
-        id: Id;
-        indicators: D2IndicatorSchema[];
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        showColumnTotals: boolean;
-        showRowTotals: boolean;
-        sortOrder: number;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Section, keyof D2Section>;
-        $identifiable: Preset<D2Section, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Section, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Section,
-            | "code"
-            | "greyedFields"
-            | "description"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "dataSet"
-            | "dataElements"
-            | "showColumnTotals"
-            | "lastUpdatedBy"
-            | "created"
-            | "attributeValues"
-            | "indicators"
-            | "sortOrder"
-            | "name"
-            | "showRowTotals"
-        >;
-        $owner: Preset<
-            D2Section,
-            | "code"
-            | "greyedFields"
-            | "description"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "dataSet"
-            | "dataElements"
-            | "showColumnTotals"
-            | "lastUpdatedBy"
-            | "created"
-            | "attributeValues"
-            | "indicators"
-            | "sortOrder"
-            | "name"
-            | "showRowTotals"
-        >;
-    };
-}
-
-export interface D2DataApprovalLevelSchema {
-    name: "D2DataApprovalLevel";
-    model: D2DataApprovalLevel;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        categoryOptionGroupSet: D2CategoryOptionGroupSetSchema;
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        level: number;
-        name: string;
-        orgUnitLevel: number;
-        orgUnitLevelName: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2DataApprovalLevel, keyof D2DataApprovalLevel>;
-        $identifiable: Preset<D2DataApprovalLevel, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2DataApprovalLevel, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2DataApprovalLevel,
-            | "lastUpdatedBy"
-            | "categoryOptionGroupSet"
-            | "userGroupAccesses"
-            | "code"
-            | "level"
-            | "created"
-            | "publicAccess"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "orgUnitLevel"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2DataApprovalLevel,
-            | "lastUpdatedBy"
-            | "categoryOptionGroupSet"
-            | "userGroupAccesses"
-            | "code"
-            | "level"
-            | "created"
-            | "publicAccess"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "orgUnitLevel"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
-export interface D2DataApprovalWorkflowSchema {
-    name: "D2DataApprovalWorkflow";
-    model: D2DataApprovalWorkflow;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        categoryCombo: D2CategoryComboSchema;
-        code: Id;
-        created: string;
-        dataApprovalLevels: D2DataApprovalLevelSchema[];
-        dataSets: D2DataSetSchema[];
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        periodType: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2DataApprovalWorkflow, keyof D2DataApprovalWorkflow>;
-        $identifiable: Preset<D2DataApprovalWorkflow, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2DataApprovalWorkflow, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2DataApprovalWorkflow,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "dataApprovalLevels"
-            | "lastUpdated"
-            | "periodType"
-            | "categoryCombo"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "dataSets"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2DataApprovalWorkflow,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "dataApprovalLevels"
-            | "lastUpdated"
-            | "periodType"
-            | "categoryCombo"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
-export interface D2ValidationRuleSchema {
-    name: "D2ValidationRule";
-    model: D2ValidationRule;
-    fields: {
-        access: D2Access;
-        aggregateExportAttributeOptionCombo: string;
-        aggregateExportCategoryOptionCombo: string;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "FIRST"
-            | "FIRST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
+        attachment: boolean;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
+        contentType: string;
         created: string;
-        description: string;
-        dimensionItem: string;
-        dimensionItemType:
-            | "DATA_ELEMENT"
-            | "DATA_ELEMENT_OPERAND"
-            | "INDICATOR"
-            | "REPORTING_RATE"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION"
-            | "OPTION_GROUP"
-            | "DATA_ELEMENT_GROUP"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY_OPTION_GROUP";
-        displayDescription: string;
-        displayFormName: string;
         displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        importance: "HIGH" | "MEDIUM" | "LOW";
-        instruction: string;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        leftSide: D2ExpressionSchema;
-        legendSet: D2LegendSetSchema;
-        legendSets: D2LegendSetSchema[];
-        name: string;
-        notificationTemplates: D2ValidationNotificationTemplateSchema[];
-        operator:
-            | "equal_to"
-            | "not_equal_to"
-            | "greater_than"
-            | "greater_than_or_equal_to"
-            | "less_than"
-            | "less_than_or_equal_to"
-            | "compulsory_pair"
-            | "exclusive_pair";
-        organisationUnitLevels: number[];
-        periodType: string;
-        publicAccess: string;
-        rightSide: D2ExpressionSchema;
-        shortName: string;
-        skipFormValidation: boolean;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        validationRuleGroups: D2ValidationRuleGroupSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ValidationRule, keyof D2ValidationRule>;
-        $identifiable: Preset<D2ValidationRule, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ValidationRule, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ValidationRule,
-            | "validationRuleGroups"
-            | "code"
-            | "importance"
-            | "publicAccess"
-            | "description"
-            | "operator"
-            | "organisationUnitLevels"
-            | "lastUpdated"
-            | "leftSide"
-            | "notificationTemplates"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "rightSide"
-            | "periodType"
-            | "instruction"
-            | "userAccesses"
-            | "name"
-            | "skipFormValidation"
-            | "user"
-        >;
-        $owner: Preset<
-            D2ValidationRule,
-            | "code"
-            | "importance"
-            | "publicAccess"
-            | "description"
-            | "operator"
-            | "organisationUnitLevels"
-            | "lastUpdated"
-            | "leftSide"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "rightSide"
-            | "periodType"
-            | "instruction"
-            | "userAccesses"
-            | "name"
-            | "skipFormValidation"
-            | "user"
-        >;
-    };
-}
-
-export interface D2ValidationRuleGroupSchema {
-    name: "D2ValidationRuleGroup";
-    model: D2ValidationRuleGroup;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        description: string;
-        displayName: string;
+        external: boolean;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
@@ -8517,1380 +7211,54 @@ export interface D2ValidationRuleGroupSchema {
         name: string;
         publicAccess: string;
         translations: D2Translation[];
+        url: string;
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
-        validationRules: D2ValidationRuleSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2ValidationRuleGroup, keyof D2ValidationRuleGroup>;
-        $identifiable: Preset<D2ValidationRuleGroup, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ValidationRuleGroup, FieldPresets["nameable"]>;
+        $all: Preset<D2Document, keyof D2Document>;
+        $identifiable: Preset<D2Document, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Document, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2ValidationRuleGroup,
+            D2Document,
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "code"
-            | "validationRules"
             | "created"
             | "publicAccess"
             | "attributeValues"
-            | "description"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2ValidationRuleGroup,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "validationRules"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "description"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
-export interface D2ValidationNotificationTemplateSchema {
-    name: "D2ValidationNotificationTemplate";
-    model: D2ValidationNotificationTemplate;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        messageTemplate: string;
-        name: string;
-        notifyParentOrganisationUnitOnly: boolean;
-        notifyUsersInHierarchyOnly: boolean;
-        publicAccess: string;
-        recipientUserGroups: D2UserGroupSchema[];
-        sendStrategy: "COLLECTIVE_SUMMARY" | "SINGLE_NOTIFICATION";
-        subjectTemplate: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        validationRules: D2ValidationRuleSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ValidationNotificationTemplate, keyof D2ValidationNotificationTemplate>;
-        $identifiable: Preset<D2ValidationNotificationTemplate, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ValidationNotificationTemplate, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ValidationNotificationTemplate,
-            | "code"
-            | "recipientUserGroups"
-            | "lastUpdated"
-            | "subjectTemplate"
-            | "id"
-            | "sendStrategy"
-            | "lastUpdatedBy"
-            | "validationRules"
-            | "created"
-            | "notifyUsersInHierarchyOnly"
-            | "name"
-            | "messageTemplate"
-        >;
-        $owner: Preset<
-            D2ValidationNotificationTemplate,
-            | "code"
-            | "recipientUserGroups"
-            | "lastUpdated"
-            | "subjectTemplate"
-            | "id"
-            | "sendStrategy"
-            | "lastUpdatedBy"
-            | "validationRules"
-            | "created"
-            | "notifyUsersInHierarchyOnly"
-            | "name"
-            | "messageTemplate"
-        >;
-    };
-}
-
-export interface D2TrackedEntityAttributeSchema {
-    name: "D2TrackedEntityAttribute";
-    model: D2TrackedEntityAttribute;
-    fields: {
-        access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "FIRST"
-            | "FIRST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        confidential: boolean;
-        created: string;
-        description: string;
-        dimensionItem: string;
-        dimensionItemType:
-            | "DATA_ELEMENT"
-            | "DATA_ELEMENT_OPERAND"
-            | "INDICATOR"
-            | "REPORTING_RATE"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION"
-            | "OPTION_GROUP"
-            | "DATA_ELEMENT_GROUP"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY_OPTION_GROUP";
-        displayDescription: string;
-        displayFormName: string;
-        displayInListNoProgram: boolean;
-        displayName: string;
-        displayOnVisitSchedule: boolean;
-        displayShortName: string;
-        expression: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        fieldMask: string;
-        formName: string;
-        generated: boolean;
-        href: string;
-        id: Id;
-        inherit: boolean;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        legendSet: D2LegendSetSchema;
-        legendSets: D2LegendSetSchema[];
-        name: string;
-        optionSet: D2OptionSetSchema;
-        optionSetValue: boolean;
-        orgunitScope: boolean;
-        pattern: string;
-        publicAccess: string;
-        shortName: string;
-        skipSynchronization: boolean;
-        sortOrderInListNoProgram: number;
-        sortOrderInVisitSchedule: number;
-        style: D2Style;
-        translations: D2Translation[];
-        unique: boolean;
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        valueType:
-            | "TEXT"
-            | "LONG_TEXT"
-            | "LETTER"
-            | "PHONE_NUMBER"
-            | "EMAIL"
-            | "BOOLEAN"
-            | "TRUE_ONLY"
-            | "DATE"
-            | "DATETIME"
-            | "TIME"
-            | "NUMBER"
-            | "UNIT_INTERVAL"
-            | "PERCENTAGE"
-            | "INTEGER"
-            | "INTEGER_POSITIVE"
-            | "INTEGER_NEGATIVE"
-            | "INTEGER_ZERO_OR_POSITIVE"
-            | "TRACKER_ASSOCIATE"
-            | "USERNAME"
-            | "COORDINATE"
-            | "ORGANISATION_UNIT"
-            | "AGE"
-            | "URL"
-            | "FILE_RESOURCE"
-            | "IMAGE";
-    };
-    fieldPresets: {
-        $all: Preset<D2TrackedEntityAttribute, keyof D2TrackedEntityAttribute>;
-        $identifiable: Preset<D2TrackedEntityAttribute, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2TrackedEntityAttribute, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2TrackedEntityAttribute,
-            | "aggregationType"
-            | "code"
-            | "displayInListNoProgram"
-            | "publicAccess"
-            | "pattern"
-            | "description"
-            | "skipSynchronization"
-            | "sortOrderInListNoProgram"
-            | "lastUpdated"
-            | "optionSet"
-            | "generated"
-            | "displayOnVisitSchedule"
-            | "translations"
-            | "valueType"
-            | "formName"
-            | "sortOrderInVisitSchedule"
-            | "id"
-            | "orgunitScope"
-            | "confidential"
-            | "fieldMask"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "expression"
-            | "created"
-            | "attributeValues"
-            | "unique"
-            | "userAccesses"
-            | "inherit"
-            | "name"
-            | "legendSets"
-            | "style"
-            | "shortName"
-            | "user"
-        >;
-        $owner: Preset<
-            D2TrackedEntityAttribute,
-            | "aggregationType"
-            | "code"
-            | "displayInListNoProgram"
-            | "publicAccess"
-            | "pattern"
-            | "description"
-            | "skipSynchronization"
-            | "sortOrderInListNoProgram"
-            | "lastUpdated"
-            | "optionSet"
-            | "generated"
-            | "displayOnVisitSchedule"
-            | "translations"
-            | "valueType"
-            | "formName"
-            | "sortOrderInVisitSchedule"
-            | "id"
-            | "orgunitScope"
-            | "confidential"
-            | "fieldMask"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "expression"
-            | "created"
-            | "attributeValues"
-            | "unique"
-            | "userAccesses"
-            | "inherit"
-            | "name"
-            | "legendSets"
-            | "style"
-            | "shortName"
-            | "user"
-        >;
-    };
-}
-
-export interface D2TrackedEntityTypeSchema {
-    name: "D2TrackedEntityType";
-    model: D2TrackedEntityType;
-    fields: {
-        access: D2Access;
-        allowAuditLog: boolean;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        maxTeiCountToReturn: number;
-        minAttributesRequiredToSearch: number;
-        name: string;
-        publicAccess: string;
-        shortName: string;
-        style: D2Style;
-        trackedEntityTypeAttributes: D2TrackedEntityTypeAttributeSchema[];
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2TrackedEntityType, keyof D2TrackedEntityType>;
-        $identifiable: Preset<D2TrackedEntityType, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2TrackedEntityType, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2TrackedEntityType,
-            | "code"
-            | "publicAccess"
-            | "trackedEntityTypeAttributes"
-            | "description"
-            | "lastUpdated"
-            | "allowAuditLog"
-            | "translations"
-            | "formName"
-            | "featureType"
-            | "minAttributesRequiredToSearch"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "maxTeiCountToReturn"
-            | "userAccesses"
-            | "name"
-            | "style"
-            | "user"
-        >;
-        $owner: Preset<
-            D2TrackedEntityType,
-            | "code"
-            | "publicAccess"
-            | "trackedEntityTypeAttributes"
-            | "description"
-            | "lastUpdated"
-            | "allowAuditLog"
-            | "translations"
-            | "formName"
-            | "featureType"
-            | "minAttributesRequiredToSearch"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "maxTeiCountToReturn"
-            | "userAccesses"
-            | "name"
-            | "style"
-            | "user"
-        >;
-    };
-}
-
-export interface D2ProgramTrackedEntityAttributeGroupSchema {
-    name: "D2ProgramTrackedEntityAttributeGroup";
-    model: D2ProgramTrackedEntityAttributeGroup;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        attributes: D2ProgramTrackedEntityAttributeSchema[];
-        code: Id;
-        created: string;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        shortName: string;
-        translations: D2Translation[];
-        uniqunessType: "NONE" | "STRICT" | "VALIDATION";
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<
-            D2ProgramTrackedEntityAttributeGroup,
-            keyof D2ProgramTrackedEntityAttributeGroup
-        >;
-        $identifiable: Preset<D2ProgramTrackedEntityAttributeGroup, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramTrackedEntityAttributeGroup, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramTrackedEntityAttributeGroup,
-            | "code"
-            | "uniqunessType"
-            | "description"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "created"
-            | "name"
-            | "attributes"
-            | "shortName"
-        >;
-        $owner: Preset<
-            D2ProgramTrackedEntityAttributeGroup,
-            | "code"
-            | "uniqunessType"
-            | "description"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "created"
-            | "name"
-            | "shortName"
-        >;
-    };
-}
-
-export interface D2TrackedEntityTypeAttributeSchema {
-    name: "D2TrackedEntityTypeAttribute";
-    model: D2TrackedEntityTypeAttribute;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        displayInList: boolean;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        mandatory: boolean;
-        name: string;
-        publicAccess: string;
-        searchable: boolean;
-        trackedEntityAttribute: D2TrackedEntityAttributeSchema;
-        trackedEntityType: D2TrackedEntityTypeSchema;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        valueType:
-            | "TEXT"
-            | "LONG_TEXT"
-            | "LETTER"
-            | "PHONE_NUMBER"
-            | "EMAIL"
-            | "BOOLEAN"
-            | "TRUE_ONLY"
-            | "DATE"
-            | "DATETIME"
-            | "TIME"
-            | "NUMBER"
-            | "UNIT_INTERVAL"
-            | "PERCENTAGE"
-            | "INTEGER"
-            | "INTEGER_POSITIVE"
-            | "INTEGER_NEGATIVE"
-            | "INTEGER_ZERO_OR_POSITIVE"
-            | "TRACKER_ASSOCIATE"
-            | "USERNAME"
-            | "COORDINATE"
-            | "ORGANISATION_UNIT"
-            | "AGE"
-            | "URL"
-            | "FILE_RESOURCE"
-            | "IMAGE";
-    };
-    fieldPresets: {
-        $all: Preset<D2TrackedEntityTypeAttribute, keyof D2TrackedEntityTypeAttribute>;
-        $identifiable: Preset<D2TrackedEntityTypeAttribute, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2TrackedEntityTypeAttribute, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2TrackedEntityTypeAttribute,
-            | "code"
-            | "mandatory"
-            | "trackedEntityAttribute"
-            | "lastUpdated"
-            | "id"
-            | "lastUpdatedBy"
-            | "created"
-            | "searchable"
-            | "displayInList"
-            | "trackedEntityType"
-        >;
-        $owner: Preset<
-            D2TrackedEntityTypeAttribute,
-            | "code"
-            | "mandatory"
-            | "trackedEntityAttribute"
-            | "lastUpdated"
-            | "id"
-            | "lastUpdatedBy"
-            | "created"
-            | "searchable"
-            | "displayInList"
-            | "trackedEntityType"
-        >;
-    };
-}
-
-export interface D2ProgramNotificationTemplateSchema {
-    name: "D2ProgramNotificationTemplate";
-    model: D2ProgramNotificationTemplate;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        deliveryChannels: never[];
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        messageTemplate: string;
-        name: string;
-        notificationRecipient:
-            | "TRACKED_ENTITY_INSTANCE"
-            | "ORGANISATION_UNIT_CONTACT"
-            | "USERS_AT_ORGANISATION_UNIT"
-            | "USER_GROUP"
-            | "PROGRAM_ATTRIBUTE"
-            | "DATA_ELEMENT";
-        notificationTrigger:
-            | "ENROLLMENT"
-            | "COMPLETION"
-            | "PROGRAM_RULE"
-            | "SCHEDULED_DAYS_DUE_DATE"
-            | "SCHEDULED_DAYS_INCIDENT_DATE"
-            | "SCHEDULED_DAYS_ENROLLMENT_DATE";
-        notifyParentOrganisationUnitOnly: boolean;
-        notifyUsersInHierarchyOnly: boolean;
-        publicAccess: string;
-        recipientDataElement: D2DataElementSchema;
-        recipientProgramAttribute: D2TrackedEntityAttributeSchema;
-        recipientUserGroup: D2UserGroupSchema;
-        relativeScheduledDays: number;
-        subjectTemplate: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramNotificationTemplate, keyof D2ProgramNotificationTemplate>;
-        $identifiable: Preset<D2ProgramNotificationTemplate, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramNotificationTemplate, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramNotificationTemplate,
-            | "code"
-            | "notificationTrigger"
-            | "lastUpdated"
-            | "relativeScheduledDays"
-            | "id"
-            | "subjectTemplate"
-            | "lastUpdatedBy"
-            | "deliveryChannels"
-            | "recipientDataElement"
-            | "created"
-            | "notifyUsersInHierarchyOnly"
-            | "notificationRecipient"
-            | "recipientProgramAttribute"
-            | "notifyParentOrganisationUnitOnly"
-            | "name"
-            | "recipientUserGroup"
-            | "messageTemplate"
-        >;
-        $owner: Preset<
-            D2ProgramNotificationTemplate,
-            | "code"
-            | "notificationTrigger"
-            | "lastUpdated"
-            | "relativeScheduledDays"
-            | "id"
-            | "subjectTemplate"
-            | "lastUpdatedBy"
-            | "deliveryChannels"
-            | "recipientDataElement"
-            | "created"
-            | "notifyUsersInHierarchyOnly"
-            | "notificationRecipient"
-            | "recipientProgramAttribute"
-            | "notifyParentOrganisationUnitOnly"
-            | "name"
-            | "recipientUserGroup"
-            | "messageTemplate"
-        >;
-    };
-}
-
-export interface D2ProgramStageSectionSchema {
-    name: "D2ProgramStageSection";
-    model: D2ProgramStageSection;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        dataElements: D2DataElementSchema[];
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        programIndicators: D2ProgramIndicatorSchema[];
-        programStage: D2ProgramStageSchema;
-        publicAccess: string;
-        renderType: any;
-        shortName: string;
-        sortOrder: number;
-        style: D2Style;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramStageSection, keyof D2ProgramStageSection>;
-        $identifiable: Preset<D2ProgramStageSection, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramStageSection, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramStageSection,
-            | "code"
-            | "description"
-            | "programIndicators"
-            | "lastUpdated"
-            | "translations"
-            | "formName"
-            | "id"
-            | "renderType"
-            | "dataElements"
-            | "lastUpdatedBy"
-            | "programStage"
-            | "created"
-            | "sortOrder"
-            | "name"
-            | "style"
-        >;
-        $owner: Preset<
-            D2ProgramStageSection,
-            | "code"
-            | "description"
-            | "programIndicators"
-            | "lastUpdated"
-            | "translations"
-            | "formName"
-            | "id"
-            | "renderType"
-            | "dataElements"
-            | "lastUpdatedBy"
-            | "programStage"
-            | "created"
-            | "sortOrder"
-            | "name"
-            | "style"
-        >;
-    };
-}
-
-export interface D2SMSCommandSchema {
-    name: "D2SMSCommand";
-    model: D2SMSCommand;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        codeValueSeparator: string;
-        completenessMethod: "ALL_DATAVALUE" | "AT_LEAST_ONE_DATAVALUE" | "DO_NOT_MARK_COMPLETE";
-        created: string;
-        currentPeriodUsedForReporting: boolean;
-        dataset: D2DataSetSchema;
-        defaultMessage: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        moreThanOneOrgUnitMessage: string;
-        name: string;
-        noUserMessage: string;
-        parserType:
-            | "KEY_VALUE_PARSER"
-            | "J2ME_PARSER"
-            | "ALERT_PARSER"
-            | "UNREGISTERED_PARSER"
-            | "TRACKED_ENTITY_REGISTRATION_PARSER"
-            | "PROGRAM_STAGE_DATAENTRY_PARSER"
-            | "EVENT_REGISTRATION_PARSER";
-        program: D2ProgramSchema;
-        programStage: D2ProgramStageSchema;
-        publicAccess: string;
-        receivedMessage: string;
-        separator: string;
-        smsCodes: any[];
-        specialCharacters: any[];
-        successMessage: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroup: D2UserGroupSchema;
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        wrongFormatMessage: string;
-    };
-    fieldPresets: {
-        $all: Preset<D2SMSCommand, keyof D2SMSCommand>;
-        $identifiable: Preset<D2SMSCommand, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2SMSCommand, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2SMSCommand,
-            | "moreThanOneOrgUnitMessage"
-            | "smsCodes"
-            | "specialCharacters"
-            | "currentPeriodUsedForReporting"
-            | "program"
-            | "noUserMessage"
-            | "lastUpdated"
-            | "receivedMessage"
-            | "defaultMessage"
-            | "id"
-            | "userGroup"
-            | "programStage"
-            | "completenessMethod"
-            | "created"
-            | "wrongFormatMessage"
-            | "separator"
-            | "successMessage"
-            | "codeValueSeparator"
-            | "parserType"
-            | "name"
-            | "dataset"
-        >;
-        $owner: Preset<
-            D2SMSCommand,
-            | "moreThanOneOrgUnitMessage"
-            | "smsCodes"
-            | "specialCharacters"
-            | "currentPeriodUsedForReporting"
-            | "program"
-            | "noUserMessage"
-            | "lastUpdated"
-            | "receivedMessage"
-            | "defaultMessage"
-            | "id"
-            | "userGroup"
-            | "programStage"
-            | "completenessMethod"
-            | "created"
-            | "wrongFormatMessage"
-            | "separator"
-            | "successMessage"
-            | "codeValueSeparator"
-            | "parserType"
-            | "name"
-            | "dataset"
-        >;
-    };
-}
-
-export interface D2ProgramStageSchema {
-    name: "D2ProgramStage";
-    model: D2ProgramStage;
-    fields: {
-        access: D2Access;
-        allowGenerateNextVisit: boolean;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        autoGenerateEvent: boolean;
-        blockEntryForm: boolean;
-        code: Id;
-        created: string;
-        dataEntryForm: D2DataEntryFormSchema;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayGenerateEventBox: boolean;
-        displayName: string;
-        displayShortName: string;
-        dueDateLabel: string;
-        enableUserAssignment: boolean;
-        executionDateLabel: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
-        formName: string;
-        formType: "DEFAULT" | "CUSTOM" | "SECTION" | "SECTION_MULTIORG";
-        generatedByEnrollmentDate: boolean;
-        hideDueDate: boolean;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        minDaysFromStart: number;
-        name: string;
-        nextScheduleDate: D2DataElementSchema;
-        notificationTemplates: D2ProgramNotificationTemplateSchema[];
-        openAfterEnrollment: boolean;
-        periodType: string;
-        preGenerateUID: boolean;
-        program: D2ProgramSchema;
-        programStageDataElements: D2ProgramStageDataElementSchema[];
-        programStageSections: D2ProgramStageSectionSchema[];
-        publicAccess: string;
-        remindCompleted: boolean;
-        repeatable: boolean;
-        reportDateToUse: string;
-        shortName: string;
-        sortOrder: number;
-        standardInterval: number;
-        style: D2Style;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        validationStrategy: "ON_COMPLETE" | "ON_UPDATE_AND_INSERT";
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramStage, keyof D2ProgramStage>;
-        $identifiable: Preset<D2ProgramStage, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramStage, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramStage,
-            | "dataEntryForm"
-            | "allowGenerateNextVisit"
-            | "publicAccess"
-            | "reportDateToUse"
-            | "program"
-            | "lastUpdated"
-            | "programStageDataElements"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "generatedByEnrollmentDate"
-            | "created"
-            | "attributeValues"
-            | "sortOrder"
-            | "userAccesses"
-            | "name"
-            | "hideDueDate"
-            | "enableUserAssignment"
-            | "style"
-            | "minDaysFromStart"
-            | "standardInterval"
-            | "dueDateLabel"
-            | "executionDateLabel"
-            | "code"
-            | "preGenerateUID"
-            | "description"
-            | "notificationTemplates"
-            | "openAfterEnrollment"
-            | "repeatable"
-            | "formName"
-            | "featureType"
-            | "remindCompleted"
-            | "displayGenerateEventBox"
-            | "nextScheduleDate"
-            | "validationStrategy"
-            | "autoGenerateEvent"
-            | "periodType"
-            | "blockEntryForm"
-            | "user"
-            | "programStageSections"
-        >;
-        $owner: Preset<
-            D2ProgramStage,
-            | "dataEntryForm"
-            | "allowGenerateNextVisit"
-            | "publicAccess"
-            | "reportDateToUse"
-            | "program"
-            | "lastUpdated"
-            | "programStageDataElements"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "generatedByEnrollmentDate"
-            | "created"
-            | "attributeValues"
-            | "sortOrder"
-            | "userAccesses"
-            | "name"
-            | "hideDueDate"
-            | "enableUserAssignment"
-            | "style"
-            | "minDaysFromStart"
-            | "standardInterval"
-            | "dueDateLabel"
-            | "executionDateLabel"
-            | "code"
-            | "preGenerateUID"
-            | "description"
-            | "notificationTemplates"
-            | "openAfterEnrollment"
-            | "repeatable"
-            | "formName"
-            | "featureType"
-            | "remindCompleted"
-            | "displayGenerateEventBox"
-            | "nextScheduleDate"
-            | "validationStrategy"
-            | "autoGenerateEvent"
-            | "periodType"
-            | "blockEntryForm"
-            | "user"
-            | "programStageSections"
-        >;
-    };
-}
-
-export interface D2ProgramSchema {
-    name: "D2Program";
-    model: D2Program;
-    fields: {
-        access: D2Access;
-        accessLevel: "OPEN" | "AUDITED" | "PROTECTED" | "CLOSED";
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        categoryCombo: D2CategoryComboSchema;
-        code: Id;
-        completeEventsExpiryDays: number;
-        created: string;
-        dataEntryForm: D2DataEntryFormSchema;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayFrontPageList: boolean;
-        displayIncidentDate: boolean;
-        displayName: string;
-        displayShortName: string;
-        enrollmentDateLabel: string;
-        expiryDays: number;
-        expiryPeriodType: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
-        formName: string;
-        href: string;
-        id: Id;
-        ignoreOverdueEvents: boolean;
-        incidentDateLabel: string;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        maxTeiCountToReturn: number;
-        minAttributesRequiredToSearch: number;
-        name: string;
-        notificationTemplates: D2ProgramNotificationTemplateSchema[];
-        onlyEnrollOnce: boolean;
-        organisationUnits: D2OrganisationUnitSchema[];
-        programIndicators: D2ProgramIndicatorSchema[];
-        programRuleVariables: D2ProgramRuleVariableSchema[];
-        programSections: D2ProgramSectionSchema[];
-        programStages: D2ProgramStageSchema[];
-        programTrackedEntityAttributes: D2ProgramTrackedEntityAttributeSchema[];
-        programType: "WITH_REGISTRATION" | "WITHOUT_REGISTRATION";
-        publicAccess: string;
-        registration: boolean;
-        relatedProgram: D2ProgramSchema;
-        selectEnrollmentDatesInFuture: boolean;
-        selectIncidentDatesInFuture: boolean;
-        shortName: string;
-        skipOffline: boolean;
-        style: D2Style;
-        trackedEntityType: D2TrackedEntityTypeSchema;
-        translations: D2Translation[];
-        useFirstStageDuringRegistration: boolean;
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        userRoles: D2UserAuthorityGroupSchema[];
-        version: number;
-        withoutRegistration: boolean;
-    };
-    fieldPresets: {
-        $all: Preset<D2Program, keyof D2Program>;
-        $identifiable: Preset<D2Program, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Program, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Program,
-            | "dataEntryForm"
-            | "publicAccess"
-            | "ignoreOverdueEvents"
-            | "skipOffline"
-            | "programIndicators"
-            | "lastUpdated"
-            | "categoryCombo"
-            | "translations"
-            | "id"
-            | "enrollmentDateLabel"
-            | "lastUpdatedBy"
-            | "onlyEnrollOnce"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "version"
-            | "maxTeiCountToReturn"
-            | "selectIncidentDatesInFuture"
-            | "incidentDateLabel"
-            | "userRoles"
-            | "expiryPeriodType"
-            | "userAccesses"
-            | "name"
-            | "selectEnrollmentDatesInFuture"
-            | "style"
-            | "shortName"
-            | "useFirstStageDuringRegistration"
-            | "code"
-            | "programRuleVariables"
-            | "programTrackedEntityAttributes"
-            | "completeEventsExpiryDays"
-            | "description"
-            | "relatedProgram"
-            | "notificationTemplates"
-            | "formName"
-            | "featureType"
-            | "minAttributesRequiredToSearch"
-            | "displayFrontPageList"
-            | "organisationUnits"
-            | "programType"
-            | "accessLevel"
-            | "programSections"
-            | "programStages"
-            | "trackedEntityType"
-            | "displayIncidentDate"
-            | "expiryDays"
-            | "user"
-        >;
-        $owner: Preset<
-            D2Program,
-            | "dataEntryForm"
-            | "publicAccess"
-            | "ignoreOverdueEvents"
-            | "skipOffline"
-            | "lastUpdated"
-            | "categoryCombo"
-            | "translations"
-            | "id"
-            | "enrollmentDateLabel"
-            | "lastUpdatedBy"
-            | "onlyEnrollOnce"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "version"
-            | "maxTeiCountToReturn"
-            | "selectIncidentDatesInFuture"
-            | "incidentDateLabel"
-            | "expiryPeriodType"
-            | "userAccesses"
-            | "name"
-            | "selectEnrollmentDatesInFuture"
-            | "style"
-            | "shortName"
-            | "useFirstStageDuringRegistration"
-            | "code"
-            | "programTrackedEntityAttributes"
-            | "completeEventsExpiryDays"
-            | "description"
-            | "relatedProgram"
-            | "notificationTemplates"
-            | "formName"
-            | "featureType"
-            | "minAttributesRequiredToSearch"
-            | "displayFrontPageList"
-            | "organisationUnits"
-            | "programType"
-            | "accessLevel"
-            | "programSections"
-            | "programStages"
-            | "trackedEntityType"
-            | "displayIncidentDate"
-            | "expiryDays"
-            | "user"
-        >;
-    };
-}
-
-export interface D2EventReportSchema {
-    name: "D2EventReport";
-    model: D2EventReport;
-    fields: {
-        access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "FIRST"
-            | "FIRST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
-        attributeDimensions: any[];
-        attributeValueDimension: D2TrackedEntityAttributeSchema;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        categoryDimensions: D2CategoryDimensionSchema[];
-        categoryOptionGroupSetDimensions: D2CategoryOptionGroupSetDimensionSchema[];
-        code: Id;
-        colSubTotals: boolean;
-        colTotals: boolean;
-        collapseDataDimensions: boolean;
-        columnDimensions: string[];
-        columns: any[];
-        completedOnly: boolean;
-        created: string;
-        dataDimensionItems: any[];
-        dataElementDimensions: D2TrackedEntityDataElementDimensionSchema[];
-        dataElementGroupSetDimensions: D2DataElementGroupSetDimensionSchema[];
-        dataElementValueDimension: D2DataElementSchema;
-        dataType: "AGGREGATED_VALUES" | "EVENTS";
-        description: string;
-        digitGroupSeparator: "COMMA" | "SPACE" | "NONE";
-        displayDensity: "COMFORTABLE" | "NORMAL" | "COMPACT" | "NONE";
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        endDate: string;
-        eventStatus: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        filterDimensions: string[];
-        filters: any[];
-        fontSize: "LARGE" | "NORMAL" | "SMALL";
-        formName: string;
-        hideEmptyRows: boolean;
-        hideNaData: boolean;
-        hideSubtitle: boolean;
-        hideTitle: boolean;
-        href: string;
-        id: Id;
-        interpretations: D2InterpretationSchema[];
-        itemOrganisationUnitGroups: D2OrganisationUnitGroupSchema[];
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        orgUnitField: string;
-        organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimensionSchema[];
-        organisationUnitLevels: number[];
-        organisationUnits: D2OrganisationUnitSchema[];
-        outputType: "EVENT" | "ENROLLMENT" | "TRACKED_ENTITY_INSTANCE";
-        parentGraphMap: D2MapSchema;
-        periods: any[];
-        program: D2ProgramSchema;
-        programIndicatorDimensions: D2TrackedEntityProgramIndicatorDimensionSchema[];
-        programStage: D2ProgramStageSchema;
-        programStatus: "ACTIVE" | "COMPLETED" | "CANCELLED";
-        publicAccess: string;
-        relativePeriods: any;
-        rowDimensions: string[];
-        rowSubTotals: boolean;
-        rowTotals: boolean;
-        rows: any[];
-        shortName: string;
-        showDimensionLabels: boolean;
-        showHierarchy: boolean;
-        sortOrder: number;
-        startDate: string;
-        subscribed: boolean;
-        subscribers: string[];
-        subtitle: string;
-        timeField: string;
-        title: string;
-        topLimit: number;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        userOrganisationUnit: boolean;
-        userOrganisationUnitChildren: boolean;
-        userOrganisationUnitGrandChildren: boolean;
-        value: any;
-    };
-    fieldPresets: {
-        $all: Preset<D2EventReport, keyof D2EventReport>;
-        $identifiable: Preset<D2EventReport, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2EventReport, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2EventReport,
-            | "orgUnitField"
-            | "endDate"
-            | "publicAccess"
-            | "userOrganisationUnitChildren"
-            | "program"
-            | "lastUpdated"
-            | "hideEmptyRows"
-            | "attributeDimensions"
-            | "translations"
-            | "userOrganisationUnit"
-            | "filterDimensions"
-            | "id"
-            | "rowSubTotals"
-            | "hideNaData"
-            | "interpretations"
-            | "itemOrganisationUnitGroups"
-            | "displayDensity"
-            | "attributeValueDimension"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "programIndicatorDimensions"
-            | "created"
-            | "subscribers"
-            | "dataType"
-            | "columnDimensions"
-            | "completedOnly"
-            | "colTotals"
-            | "showDimensionLabels"
-            | "subtitle"
-            | "sortOrder"
-            | "userAccesses"
-            | "name"
-            | "fontSize"
-            | "topLimit"
-            | "startDate"
-            | "collapseDataDimensions"
-            | "programStatus"
-            | "favorites"
-            | "aggregationType"
-            | "code"
-            | "categoryOptionGroupSetDimensions"
-            | "userOrganisationUnitGrandChildren"
-            | "hideSubtitle"
-            | "outputType"
-            | "description"
-            | "organisationUnitGroupSetDimensions"
-            | "title"
-            | "organisationUnitLevels"
+            | "url"
             | "externalAccess"
-            | "colSubTotals"
-            | "dataElementValueDimension"
-            | "relativePeriods"
-            | "dataElementDimensions"
-            | "periods"
-            | "organisationUnits"
-            | "categoryDimensions"
-            | "showHierarchy"
-            | "programStage"
-            | "rowTotals"
-            | "timeField"
-            | "digitGroupSeparator"
-            | "hideTitle"
-            | "rowDimensions"
-            | "eventStatus"
-            | "user"
-        >;
-        $owner: Preset<
-            D2EventReport,
-            | "orgUnitField"
-            | "endDate"
-            | "publicAccess"
-            | "userOrganisationUnitChildren"
-            | "program"
             | "lastUpdated"
-            | "hideEmptyRows"
-            | "attributeDimensions"
+            | "external"
+            | "attachment"
             | "translations"
-            | "userOrganisationUnit"
-            | "filterDimensions"
-            | "id"
-            | "rowSubTotals"
-            | "hideNaData"
-            | "itemOrganisationUnitGroups"
-            | "displayDensity"
-            | "attributeValueDimension"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "programIndicatorDimensions"
-            | "created"
-            | "subscribers"
-            | "dataType"
-            | "columnDimensions"
-            | "completedOnly"
-            | "colTotals"
-            | "showDimensionLabels"
-            | "subtitle"
-            | "sortOrder"
             | "userAccesses"
             | "name"
-            | "fontSize"
-            | "topLimit"
-            | "startDate"
-            | "collapseDataDimensions"
-            | "programStatus"
-            | "favorites"
-            | "aggregationType"
-            | "code"
-            | "categoryOptionGroupSetDimensions"
-            | "userOrganisationUnitGrandChildren"
-            | "hideSubtitle"
-            | "outputType"
-            | "description"
-            | "organisationUnitGroupSetDimensions"
-            | "title"
-            | "organisationUnitLevels"
-            | "externalAccess"
-            | "colSubTotals"
-            | "dataElementValueDimension"
-            | "relativePeriods"
-            | "dataElementDimensions"
-            | "periods"
-            | "organisationUnits"
-            | "categoryDimensions"
-            | "showHierarchy"
-            | "programStage"
-            | "rowTotals"
-            | "timeField"
-            | "digitGroupSeparator"
-            | "hideTitle"
-            | "rowDimensions"
-            | "eventStatus"
+            | "id"
             | "user"
+            | "contentType"
+        >;
+        $owner: Preset<
+            D2Document,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "attributeValues"
+            | "url"
+            | "externalAccess"
+            | "lastUpdated"
+            | "external"
+            | "attachment"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+            | "contentType"
         >;
     };
 }
@@ -10181,84 +7549,478 @@ export interface D2EventChartSchema {
     };
 }
 
-export interface D2ProgramSectionSchema {
-    name: "D2ProgramSection";
-    model: D2ProgramSection;
+export interface D2EventReportSchema {
+    name: "D2EventReport";
+    model: D2EventReport;
+    fields: {
+        access: D2Access;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        attributeDimensions: any[];
+        attributeValueDimension: D2TrackedEntityAttributeSchema;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        categoryDimensions: D2CategoryDimensionSchema[];
+        categoryOptionGroupSetDimensions: D2CategoryOptionGroupSetDimensionSchema[];
+        code: Id;
+        colSubTotals: boolean;
+        colTotals: boolean;
+        collapseDataDimensions: boolean;
+        columnDimensions: string[];
+        columns: any[];
+        completedOnly: boolean;
+        created: string;
+        dataDimensionItems: any[];
+        dataElementDimensions: D2TrackedEntityDataElementDimensionSchema[];
+        dataElementGroupSetDimensions: D2DataElementGroupSetDimensionSchema[];
+        dataElementValueDimension: D2DataElementSchema;
+        dataType: "AGGREGATED_VALUES" | "EVENTS";
+        description: string;
+        digitGroupSeparator: "COMMA" | "SPACE" | "NONE";
+        displayDensity: "COMFORTABLE" | "NORMAL" | "COMPACT" | "NONE";
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        endDate: string;
+        eventStatus: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        filterDimensions: string[];
+        filters: any[];
+        fontSize: "LARGE" | "NORMAL" | "SMALL";
+        formName: string;
+        hideEmptyRows: boolean;
+        hideNaData: boolean;
+        hideSubtitle: boolean;
+        hideTitle: boolean;
+        href: string;
+        id: Id;
+        interpretations: D2InterpretationSchema[];
+        itemOrganisationUnitGroups: D2OrganisationUnitGroupSchema[];
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        orgUnitField: string;
+        organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimensionSchema[];
+        organisationUnitLevels: number[];
+        organisationUnits: D2OrganisationUnitSchema[];
+        outputType: "EVENT" | "ENROLLMENT" | "TRACKED_ENTITY_INSTANCE";
+        parentGraphMap: D2MapSchema;
+        periods: any[];
+        program: D2ProgramSchema;
+        programIndicatorDimensions: D2TrackedEntityProgramIndicatorDimensionSchema[];
+        programStage: D2ProgramStageSchema;
+        programStatus: "ACTIVE" | "COMPLETED" | "CANCELLED";
+        publicAccess: string;
+        relativePeriods: any;
+        rowDimensions: string[];
+        rowSubTotals: boolean;
+        rowTotals: boolean;
+        rows: any[];
+        shortName: string;
+        showDimensionLabels: boolean;
+        showHierarchy: boolean;
+        sortOrder: number;
+        startDate: string;
+        subscribed: boolean;
+        subscribers: string[];
+        subtitle: string;
+        timeField: string;
+        title: string;
+        topLimit: number;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        userOrganisationUnit: boolean;
+        userOrganisationUnitChildren: boolean;
+        userOrganisationUnitGrandChildren: boolean;
+        value: any;
+    };
+    fieldPresets: {
+        $all: Preset<D2EventReport, keyof D2EventReport>;
+        $identifiable: Preset<D2EventReport, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2EventReport, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2EventReport,
+            | "orgUnitField"
+            | "endDate"
+            | "publicAccess"
+            | "userOrganisationUnitChildren"
+            | "program"
+            | "lastUpdated"
+            | "hideEmptyRows"
+            | "attributeDimensions"
+            | "translations"
+            | "userOrganisationUnit"
+            | "filterDimensions"
+            | "id"
+            | "rowSubTotals"
+            | "hideNaData"
+            | "interpretations"
+            | "itemOrganisationUnitGroups"
+            | "displayDensity"
+            | "attributeValueDimension"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "programIndicatorDimensions"
+            | "created"
+            | "subscribers"
+            | "dataType"
+            | "columnDimensions"
+            | "completedOnly"
+            | "colTotals"
+            | "showDimensionLabels"
+            | "subtitle"
+            | "sortOrder"
+            | "userAccesses"
+            | "name"
+            | "fontSize"
+            | "topLimit"
+            | "startDate"
+            | "collapseDataDimensions"
+            | "programStatus"
+            | "favorites"
+            | "aggregationType"
+            | "code"
+            | "categoryOptionGroupSetDimensions"
+            | "userOrganisationUnitGrandChildren"
+            | "hideSubtitle"
+            | "outputType"
+            | "description"
+            | "organisationUnitGroupSetDimensions"
+            | "title"
+            | "organisationUnitLevels"
+            | "externalAccess"
+            | "colSubTotals"
+            | "dataElementValueDimension"
+            | "relativePeriods"
+            | "dataElementDimensions"
+            | "periods"
+            | "organisationUnits"
+            | "categoryDimensions"
+            | "showHierarchy"
+            | "programStage"
+            | "rowTotals"
+            | "timeField"
+            | "digitGroupSeparator"
+            | "hideTitle"
+            | "rowDimensions"
+            | "eventStatus"
+            | "user"
+        >;
+        $owner: Preset<
+            D2EventReport,
+            | "orgUnitField"
+            | "endDate"
+            | "publicAccess"
+            | "userOrganisationUnitChildren"
+            | "program"
+            | "lastUpdated"
+            | "hideEmptyRows"
+            | "attributeDimensions"
+            | "translations"
+            | "userOrganisationUnit"
+            | "filterDimensions"
+            | "id"
+            | "rowSubTotals"
+            | "hideNaData"
+            | "itemOrganisationUnitGroups"
+            | "displayDensity"
+            | "attributeValueDimension"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "programIndicatorDimensions"
+            | "created"
+            | "subscribers"
+            | "dataType"
+            | "columnDimensions"
+            | "completedOnly"
+            | "colTotals"
+            | "showDimensionLabels"
+            | "subtitle"
+            | "sortOrder"
+            | "userAccesses"
+            | "name"
+            | "fontSize"
+            | "topLimit"
+            | "startDate"
+            | "collapseDataDimensions"
+            | "programStatus"
+            | "favorites"
+            | "aggregationType"
+            | "code"
+            | "categoryOptionGroupSetDimensions"
+            | "userOrganisationUnitGrandChildren"
+            | "hideSubtitle"
+            | "outputType"
+            | "description"
+            | "organisationUnitGroupSetDimensions"
+            | "title"
+            | "organisationUnitLevels"
+            | "externalAccess"
+            | "colSubTotals"
+            | "dataElementValueDimension"
+            | "relativePeriods"
+            | "dataElementDimensions"
+            | "periods"
+            | "organisationUnits"
+            | "categoryDimensions"
+            | "showHierarchy"
+            | "programStage"
+            | "rowTotals"
+            | "timeField"
+            | "digitGroupSeparator"
+            | "hideTitle"
+            | "rowDimensions"
+            | "eventStatus"
+            | "user"
+        >;
+    };
+}
+
+export interface D2ExpressionSchema {
+    name: "D2Expression";
+    model: D2Expression;
+    fields: {
+        description: string;
+        expression: string;
+        missingValueStrategy:
+            | "SKIP_IF_ANY_VALUE_MISSING"
+            | "SKIP_IF_ALL_VALUES_MISSING"
+            | "NEVER_SKIP";
+        slidingWindow: boolean;
+    };
+    fieldPresets: {
+        $all: Preset<D2Expression, keyof D2Expression>;
+        $identifiable: Preset<D2Expression, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Expression, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Expression,
+            "description" | "expression" | "missingValueStrategy" | "slidingWindow"
+        >;
+        $owner: Preset<
+            D2Expression,
+            "description" | "expression" | "missingValueStrategy" | "slidingWindow"
+        >;
+    };
+}
+
+export interface D2ExternalFileResourceSchema {
+    name: "D2ExternalFileResource";
+    model: D2ExternalFileResource;
     fields: {
         access: D2Access;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
         displayName: string;
-        displayShortName: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
-        formName: string;
         href: string;
         id: Id;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
         name: string;
-        program: D2ProgramSchema;
         publicAccess: string;
-        renderType: any;
-        shortName: string;
-        sortOrder: number;
-        style: D2Style;
-        trackedEntityAttributes: D2TrackedEntityAttributeSchema[];
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2ProgramSection, keyof D2ProgramSection>;
-        $identifiable: Preset<D2ProgramSection, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramSection, FieldPresets["nameable"]>;
+        $all: Preset<D2ExternalFileResource, keyof D2ExternalFileResource>;
+        $identifiable: Preset<D2ExternalFileResource, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ExternalFileResource, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2ProgramSection,
-            | "code"
-            | "description"
-            | "program"
-            | "lastUpdated"
-            | "translations"
-            | "formName"
-            | "id"
-            | "renderType"
-            | "lastUpdatedBy"
-            | "created"
-            | "sortOrder"
-            | "name"
-            | "trackedEntityAttributes"
-            | "style"
+            D2ExternalFileResource,
+            "lastUpdatedBy" | "code" | "created" | "lastUpdated" | "id"
         >;
         $owner: Preset<
-            D2ProgramSection,
-            | "code"
-            | "description"
-            | "program"
-            | "lastUpdated"
-            | "translations"
-            | "formName"
-            | "id"
-            | "renderType"
-            | "lastUpdatedBy"
-            | "created"
-            | "sortOrder"
-            | "name"
-            | "trackedEntityAttributes"
-            | "style"
+            D2ExternalFileResource,
+            "lastUpdatedBy" | "code" | "created" | "lastUpdated" | "id"
         >;
     };
 }
 
-export interface D2ProgramIndicatorSchema {
-    name: "D2ProgramIndicator";
-    model: D2ProgramIndicator;
+export interface D2ExternalMapLayerSchema {
+    name: "D2ExternalMapLayer";
+    model: D2ExternalMapLayer;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        attribution: string;
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        imageFormat: "PNG" | "JPG";
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        layers: string;
+        legendSet: D2LegendSetSchema;
+        legendSetUrl: string;
+        mapLayerPosition: "BASEMAP" | "OVERLAY";
+        mapService: "WMS" | "TMS" | "XYZ";
+        name: string;
+        publicAccess: string;
+        translations: D2Translation[];
+        url: string;
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ExternalMapLayer, keyof D2ExternalMapLayer>;
+        $identifiable: Preset<D2ExternalMapLayer, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ExternalMapLayer, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ExternalMapLayer,
+            | "imageFormat"
+            | "code"
+            | "publicAccess"
+            | "legendSetUrl"
+            | "mapService"
+            | "lastUpdated"
+            | "layers"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "mapLayerPosition"
+            | "url"
+            | "userAccesses"
+            | "name"
+            | "legendSet"
+            | "attribution"
+            | "user"
+        >;
+        $owner: Preset<
+            D2ExternalMapLayer,
+            | "imageFormat"
+            | "code"
+            | "publicAccess"
+            | "legendSetUrl"
+            | "mapService"
+            | "lastUpdated"
+            | "layers"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "mapLayerPosition"
+            | "url"
+            | "userAccesses"
+            | "name"
+            | "legendSet"
+            | "attribution"
+            | "user"
+        >;
+    };
+}
+
+export interface D2FileResourceSchema {
+    name: "D2FileResource";
+    model: D2FileResource;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        contentLength: string;
+        contentMd5: string;
+        contentType: string;
+        created: string;
+        displayName: string;
+        domain: "DATA_VALUE" | "PUSH_ANALYSIS" | "DOCUMENT" | "MESSAGE_ATTACHMENT" | "USER_AVATAR";
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        hasMultipleStorageFiles: boolean;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        storageStatus: "NONE" | "PENDING" | "FAILED" | "STORED";
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2FileResource, keyof D2FileResource>;
+        $identifiable: Preset<D2FileResource, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2FileResource, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2FileResource,
+            | "contentMd5"
+            | "code"
+            | "lastUpdated"
+            | "id"
+            | "contentType"
+            | "lastUpdatedBy"
+            | "created"
+            | "domain"
+            | "hasMultipleStorageFiles"
+            | "name"
+            | "contentLength"
+            | "user"
+        >;
+        $owner: Preset<
+            D2FileResource,
+            | "contentMd5"
+            | "code"
+            | "lastUpdated"
+            | "id"
+            | "contentType"
+            | "lastUpdatedBy"
+            | "created"
+            | "domain"
+            | "hasMultipleStorageFiles"
+            | "name"
+            | "contentLength"
+            | "user"
+        >;
+    };
+}
+
+export interface D2IconSchema {
+    name: "D2Icon";
+    model: D2Icon;
+    fields: {};
+    fieldPresets: {
+        $all: Preset<D2Icon, keyof D2Icon>;
+        $identifiable: Preset<D2Icon, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Icon, FieldPresets["nameable"]>;
+        $persisted: Preset<D2Icon, never>;
+        $owner: Preset<D2Icon, never>;
+    };
+}
+
+export interface D2IndicatorSchema {
+    name: "D2Indicator";
+    model: D2Indicator;
     fields: {
         access: D2Access;
         aggregateExportAttributeOptionCombo: string;
@@ -10279,12 +8041,14 @@ export interface D2ProgramIndicatorSchema {
             | "NONE"
             | "CUSTOM"
             | "DEFAULT";
-        analyticsPeriodBoundaries: D2AnalyticsPeriodBoundarySchema[];
-        analyticsType: "EVENT" | "ENROLLMENT";
+        annualized: boolean;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
+        dataSets: D2DataSetSchema[];
         decimals: number;
+        denominator: string;
+        denominatorDescription: string;
         description: string;
         dimensionItem: string;
         dimensionItemType:
@@ -10302,63 +8066,66 @@ export interface D2ProgramIndicatorSchema {
             | "DATA_ELEMENT_GROUP"
             | "ORGANISATION_UNIT_GROUP"
             | "CATEGORY_OPTION_GROUP";
+        displayDenominatorDescription: string;
         displayDescription: string;
         displayFormName: string;
-        displayInForm: boolean;
         displayName: string;
+        displayNumeratorDescription: string;
         displayShortName: string;
-        expression: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
-        filter: string;
         formName: string;
         href: string;
         id: Id;
+        indicatorGroups: D2IndicatorGroupSchema[];
+        indicatorType: D2IndicatorTypeSchema;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
         legendSet: D2LegendSetSchema;
         legendSets: D2LegendSetSchema[];
         name: string;
-        program: D2ProgramSchema;
-        programIndicatorGroups: D2ProgramIndicatorGroupSchema[];
+        numerator: string;
+        numeratorDescription: string;
         publicAccess: string;
         shortName: string;
         style: D2Style;
         translations: D2Translation[];
+        url: string;
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2ProgramIndicator, keyof D2ProgramIndicator>;
-        $identifiable: Preset<D2ProgramIndicator, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramIndicator, FieldPresets["nameable"]>;
+        $all: Preset<D2Indicator, keyof D2Indicator>;
+        $identifiable: Preset<D2Indicator, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Indicator, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2ProgramIndicator,
-            | "aggregationType"
+            D2Indicator,
             | "code"
-            | "displayInForm"
             | "publicAccess"
             | "aggregateExportCategoryOptionCombo"
             | "description"
-            | "program"
             | "lastUpdated"
+            | "denominatorDescription"
+            | "indicatorType"
             | "translations"
             | "formName"
             | "id"
-            | "programIndicatorGroups"
-            | "analyticsPeriodBoundaries"
+            | "numeratorDescription"
             | "lastUpdatedBy"
             | "userGroupAccesses"
-            | "expression"
             | "created"
             | "attributeValues"
-            | "filter"
+            | "indicatorGroups"
+            | "url"
+            | "numerator"
+            | "denominator"
+            | "annualized"
             | "userAccesses"
             | "decimals"
             | "name"
-            | "analyticsType"
+            | "dataSets"
             | "legendSets"
             | "style"
             | "shortName"
@@ -10366,29 +8133,29 @@ export interface D2ProgramIndicatorSchema {
             | "aggregateExportAttributeOptionCombo"
         >;
         $owner: Preset<
-            D2ProgramIndicator,
-            | "aggregationType"
+            D2Indicator,
             | "code"
-            | "displayInForm"
             | "publicAccess"
             | "aggregateExportCategoryOptionCombo"
             | "description"
-            | "program"
             | "lastUpdated"
+            | "denominatorDescription"
+            | "indicatorType"
             | "translations"
             | "formName"
             | "id"
-            | "analyticsPeriodBoundaries"
+            | "numeratorDescription"
             | "lastUpdatedBy"
             | "userGroupAccesses"
-            | "expression"
             | "created"
             | "attributeValues"
-            | "filter"
+            | "url"
+            | "numerator"
+            | "denominator"
+            | "annualized"
             | "userAccesses"
             | "decimals"
             | "name"
-            | "analyticsType"
             | "legendSets"
             | "style"
             | "shortName"
@@ -10398,91 +8165,80 @@ export interface D2ProgramIndicatorSchema {
     };
 }
 
-export interface D2RelationshipTypeSchema {
-    name: "D2RelationshipType";
-    model: D2RelationshipType;
+export interface D2IndicatorGroupSchema {
+    name: "D2IndicatorGroup";
+    model: D2IndicatorGroup;
     fields: {
         access: D2Access;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        bidirectional: boolean;
         code: Id;
         created: string;
-        description: string;
-        displayFromToName: string;
         displayName: string;
-        displayToFromName: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
-        fromConstraint: D2RelationshipConstraint;
-        fromToName: string;
         href: string;
         id: Id;
+        indicatorGroupSet: D2IndicatorGroupSetSchema;
+        indicators: D2IndicatorSchema[];
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
         name: string;
         publicAccess: string;
-        toConstraint: D2RelationshipConstraint;
-        toFromName: string;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2RelationshipType, keyof D2RelationshipType>;
-        $identifiable: Preset<D2RelationshipType, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2RelationshipType, FieldPresets["nameable"]>;
+        $all: Preset<D2IndicatorGroup, keyof D2IndicatorGroup>;
+        $identifiable: Preset<D2IndicatorGroup, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2IndicatorGroup, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2RelationshipType,
-            | "bidirectional"
-            | "code"
-            | "publicAccess"
-            | "description"
-            | "fromToName"
-            | "lastUpdated"
-            | "translations"
-            | "toConstraint"
-            | "id"
+            D2IndicatorGroup,
             | "lastUpdatedBy"
             | "userGroupAccesses"
+            | "code"
             | "created"
-            | "toFromName"
-            | "fromConstraint"
+            | "publicAccess"
+            | "attributeValues"
+            | "indicators"
+            | "indicatorGroupSet"
+            | "lastUpdated"
+            | "translations"
             | "userAccesses"
             | "name"
+            | "id"
             | "user"
         >;
         $owner: Preset<
-            D2RelationshipType,
-            | "bidirectional"
-            | "code"
-            | "publicAccess"
-            | "description"
-            | "fromToName"
-            | "lastUpdated"
-            | "translations"
-            | "toConstraint"
-            | "id"
+            D2IndicatorGroup,
             | "lastUpdatedBy"
             | "userGroupAccesses"
+            | "code"
             | "created"
-            | "toFromName"
-            | "fromConstraint"
+            | "publicAccess"
+            | "attributeValues"
+            | "indicators"
+            | "indicatorGroupSet"
+            | "lastUpdated"
+            | "translations"
             | "userAccesses"
             | "name"
+            | "id"
             | "user"
         >;
     };
 }
 
-export interface D2ProgramIndicatorGroupSchema {
-    name: "D2ProgramIndicatorGroup";
-    model: D2ProgramIndicatorGroup;
+export interface D2IndicatorGroupSetSchema {
+    name: "D2IndicatorGroupSet";
+    model: D2IndicatorGroupSet;
     fields: {
         access: D2Access;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
+        compulsory: boolean;
         created: string;
         description: string;
         displayName: string;
@@ -10491,10 +8247,10 @@ export interface D2ProgramIndicatorGroupSchema {
         favorites: string[];
         href: string;
         id: Id;
+        indicatorGroups: D2IndicatorGroupSchema[];
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
         name: string;
-        programIndicators: D2ProgramIndicatorSchema[];
         publicAccess: string;
         translations: D2Translation[];
         user: D2UserSchema;
@@ -10502,19 +8258,20 @@ export interface D2ProgramIndicatorGroupSchema {
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2ProgramIndicatorGroup, keyof D2ProgramIndicatorGroup>;
-        $identifiable: Preset<D2ProgramIndicatorGroup, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramIndicatorGroup, FieldPresets["nameable"]>;
+        $all: Preset<D2IndicatorGroupSet, keyof D2IndicatorGroupSet>;
+        $identifiable: Preset<D2IndicatorGroupSet, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2IndicatorGroupSet, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2ProgramIndicatorGroup,
+            D2IndicatorGroupSet,
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "code"
             | "created"
             | "publicAccess"
             | "description"
-            | "programIndicators"
+            | "indicatorGroups"
             | "lastUpdated"
+            | "compulsory"
             | "translations"
             | "userAccesses"
             | "name"
@@ -10522,15 +8279,16 @@ export interface D2ProgramIndicatorGroupSchema {
             | "user"
         >;
         $owner: Preset<
-            D2ProgramIndicatorGroup,
+            D2IndicatorGroupSet,
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "code"
             | "created"
             | "publicAccess"
             | "description"
-            | "programIndicators"
+            | "indicatorGroups"
             | "lastUpdated"
+            | "compulsory"
             | "translations"
             | "userAccesses"
             | "name"
@@ -10540,15 +8298,160 @@ export interface D2ProgramIndicatorGroupSchema {
     };
 }
 
-export interface D2ProgramRuleVariableSchema {
-    name: "D2ProgramRuleVariable";
-    model: D2ProgramRuleVariable;
+export interface D2IndicatorTypeSchema {
+    name: "D2IndicatorType";
+    model: D2IndicatorType;
     fields: {
         access: D2Access;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
-        dataElement: D2DataElementSchema;
+        displayName: string;
+        externalAccess: boolean;
+        factor: number;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        number: boolean;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2IndicatorType, keyof D2IndicatorType>;
+        $identifiable: Preset<D2IndicatorType, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2IndicatorType, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2IndicatorType,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "lastUpdated"
+            | "number"
+            | "translations"
+            | "name"
+            | "id"
+            | "factor"
+        >;
+        $owner: Preset<
+            D2IndicatorType,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "lastUpdated"
+            | "number"
+            | "translations"
+            | "name"
+            | "id"
+            | "factor"
+        >;
+    };
+}
+
+export interface D2InterpretationSchema {
+    name: "D2Interpretation";
+    model: D2Interpretation;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        chart: D2ChartSchema;
+        code: Id;
+        comments: D2InterpretationCommentSchema[];
+        created: string;
+        dataSet: D2DataSetSchema;
+        displayName: string;
+        eventChart: D2EventChartSchema;
+        eventReport: D2EventReportSchema;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        likedBy: D2UserSchema[];
+        likes: number;
+        map: D2MapSchema;
+        mentions: any[];
+        name: string;
+        organisationUnit: D2OrganisationUnitSchema;
+        period: any;
+        publicAccess: string;
+        reportTable: D2ReportTableSchema;
+        text: string;
+        translations: D2Translation[];
+        type: "REPORT_TABLE" | "CHART" | "MAP" | "EVENT_REPORT" | "EVENT_CHART" | "DATASET_REPORT";
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2Interpretation, keyof D2Interpretation>;
+        $identifiable: Preset<D2Interpretation, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Interpretation, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Interpretation,
+            | "likedBy"
+            | "organisationUnit"
+            | "publicAccess"
+            | "reportTable"
+            | "lastUpdated"
+            | "id"
+            | "text"
+            | "map"
+            | "dataSet"
+            | "likes"
+            | "period"
+            | "userGroupAccesses"
+            | "comments"
+            | "created"
+            | "eventReport"
+            | "userAccesses"
+            | "mentions"
+            | "eventChart"
+            | "user"
+            | "chart"
+        >;
+        $owner: Preset<
+            D2Interpretation,
+            | "likedBy"
+            | "organisationUnit"
+            | "publicAccess"
+            | "reportTable"
+            | "lastUpdated"
+            | "id"
+            | "text"
+            | "map"
+            | "dataSet"
+            | "likes"
+            | "period"
+            | "userGroupAccesses"
+            | "comments"
+            | "created"
+            | "eventReport"
+            | "userAccesses"
+            | "mentions"
+            | "eventChart"
+            | "user"
+            | "chart"
+        >;
+    };
+}
+
+export interface D2InterpretationCommentSchema {
+    name: "D2InterpretationComment";
+    model: D2InterpretationComment;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
         displayName: string;
         externalAccess: boolean;
         favorite: boolean;
@@ -10557,72 +8460,283 @@ export interface D2ProgramRuleVariableSchema {
         id: Id;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
+        mentions: any[];
         name: string;
-        program: D2ProgramSchema;
-        programRuleVariableSourceType:
-            | "DATAELEMENT_NEWEST_EVENT_PROGRAM_STAGE"
-            | "DATAELEMENT_NEWEST_EVENT_PROGRAM"
-            | "DATAELEMENT_CURRENT_EVENT"
-            | "DATAELEMENT_PREVIOUS_EVENT"
-            | "CALCULATED_VALUE"
-            | "TEI_ATTRIBUTE";
-        programStage: D2ProgramStageSchema;
         publicAccess: string;
-        trackedEntityAttribute: D2TrackedEntityAttributeSchema;
+        text: string;
         translations: D2Translation[];
-        useCodeForOptionSet: boolean;
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2ProgramRuleVariable, keyof D2ProgramRuleVariable>;
-        $identifiable: Preset<D2ProgramRuleVariable, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramRuleVariable, FieldPresets["nameable"]>;
+        $all: Preset<D2InterpretationComment, keyof D2InterpretationComment>;
+        $identifiable: Preset<D2InterpretationComment, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2InterpretationComment, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2ProgramRuleVariable,
-            | "code"
-            | "programRuleVariableSourceType"
-            | "program"
-            | "trackedEntityAttribute"
-            | "lastUpdated"
-            | "id"
-            | "lastUpdatedBy"
-            | "programStage"
-            | "created"
-            | "useCodeForOptionSet"
-            | "dataElement"
-            | "name"
+            D2InterpretationComment,
+            "created" | "lastUpdated" | "mentions" | "text" | "id" | "user"
         >;
         $owner: Preset<
-            D2ProgramRuleVariable,
-            | "code"
-            | "programRuleVariableSourceType"
-            | "program"
-            | "trackedEntityAttribute"
-            | "lastUpdated"
-            | "id"
-            | "lastUpdatedBy"
-            | "programStage"
-            | "created"
-            | "useCodeForOptionSet"
-            | "dataElement"
-            | "name"
+            D2InterpretationComment,
+            "created" | "lastUpdated" | "mentions" | "text" | "id" | "user"
         >;
     };
 }
 
-export interface D2ProgramRuleActionSchema {
-    name: "D2ProgramRuleAction";
-    model: D2ProgramRuleAction;
+export interface D2JobConfigurationSchema {
+    name: "D2JobConfiguration";
+    model: D2JobConfiguration;
     fields: {
         access: D2Access;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
-        content: string;
+        configurable: boolean;
+        continuousExecution: boolean;
         created: string;
-        data: string;
-        dataElement: D2DataElementSchema;
+        cronExpression: string;
+        displayName: string;
+        enabled: boolean;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        jobParameters: string;
+        jobStatus: "RUNNING" | "COMPLETED" | "STOPPED" | "SCHEDULED" | "DISABLED" | "FAILED";
+        jobType:
+            | "DATA_STATISTICS"
+            | "DATA_INTEGRITY"
+            | "RESOURCE_TABLE"
+            | "ANALYTICS_TABLE"
+            | "DATA_SYNC"
+            | "TRACKER_PROGRAMS_DATA_SYNC"
+            | "EVENT_PROGRAMS_DATA_SYNC"
+            | "FILE_RESOURCE_CLEANUP"
+            | "IMAGE_PROCESSING"
+            | "META_DATA_SYNC"
+            | "SMS_SEND"
+            | "SEND_SCHEDULED_MESSAGE"
+            | "PROGRAM_NOTIFICATIONS"
+            | "VALIDATION_RESULTS_NOTIFICATION"
+            | "CREDENTIALS_EXPIRY_ALERT"
+            | "MONITORING"
+            | "PUSH_ANALYSIS"
+            | "PREDICTOR"
+            | "DATA_SET_NOTIFICATION"
+            | "REMOVE_EXPIRED_RESERVED_VALUES"
+            | "MOCK"
+            | "DATAVALUE_IMPORT"
+            | "ANALYTICSTABLE_UPDATE"
+            | "METADATA_IMPORT"
+            | "GML_IMPORT"
+            | "DATAVALUE_IMPORT_INTERNAL"
+            | "EVENT_IMPORT"
+            | "ENROLLMENT_IMPORT"
+            | "TEI_IMPORT"
+            | "LEADER_ELECTION"
+            | "LEADER_RENEWAL"
+            | "COMPLETE_DATA_SET_REGISTRATION_IMPORT"
+            | "PROGRAM_DATA_SYNC";
+        lastExecuted: string;
+        lastExecutedStatus:
+            | "RUNNING"
+            | "COMPLETED"
+            | "STOPPED"
+            | "SCHEDULED"
+            | "DISABLED"
+            | "FAILED";
+        lastRuntimeExecution: string;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        leaderOnlyJob: boolean;
+        name: string;
+        nextExecutionTime: string;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        userUid: string;
+    };
+    fieldPresets: {
+        $all: Preset<D2JobConfiguration, keyof D2JobConfiguration>;
+        $identifiable: Preset<D2JobConfiguration, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2JobConfiguration, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2JobConfiguration,
+            | "jobStatus"
+            | "code"
+            | "enabled"
+            | "leaderOnlyJob"
+            | "lastUpdated"
+            | "continuousExecution"
+            | "id"
+            | "jobType"
+            | "lastUpdatedBy"
+            | "nextExecutionTime"
+            | "created"
+            | "cronExpression"
+            | "lastRuntimeExecution"
+            | "lastExecutedStatus"
+            | "name"
+            | "jobParameters"
+            | "lastExecuted"
+        >;
+        $owner: Preset<
+            D2JobConfiguration,
+            | "jobStatus"
+            | "code"
+            | "enabled"
+            | "leaderOnlyJob"
+            | "lastUpdated"
+            | "continuousExecution"
+            | "id"
+            | "jobType"
+            | "lastUpdatedBy"
+            | "nextExecutionTime"
+            | "created"
+            | "cronExpression"
+            | "lastRuntimeExecution"
+            | "lastExecutedStatus"
+            | "name"
+            | "jobParameters"
+            | "lastExecuted"
+        >;
+    };
+}
+
+export interface D2KeyJsonValueSchema {
+    name: "D2KeyJsonValue";
+    model: D2KeyJsonValue;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        key: string;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        namespace: string;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        value: string;
+    };
+    fieldPresets: {
+        $all: Preset<D2KeyJsonValue, keyof D2KeyJsonValue>;
+        $identifiable: Preset<D2KeyJsonValue, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2KeyJsonValue, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2KeyJsonValue,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "lastUpdated"
+            | "userAccesses"
+            | "namespace"
+            | "id"
+            | "user"
+            | "key"
+        >;
+        $owner: Preset<
+            D2KeyJsonValue,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "lastUpdated"
+            | "userAccesses"
+            | "namespace"
+            | "id"
+            | "user"
+            | "key"
+        >;
+    };
+}
+
+export interface D2LegendSchema {
+    name: "D2Legend";
+    model: D2Legend;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        color: string;
+        created: string;
+        displayName: string;
+        endValue: number;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        image: string;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        startValue: number;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2Legend, keyof D2Legend>;
+        $identifiable: Preset<D2Legend, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Legend, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Legend,
+            | "lastUpdatedBy"
+            | "image"
+            | "code"
+            | "endValue"
+            | "color"
+            | "created"
+            | "lastUpdated"
+            | "translations"
+            | "name"
+            | "startValue"
+            | "id"
+        >;
+        $owner: Preset<
+            D2Legend,
+            | "lastUpdatedBy"
+            | "image"
+            | "code"
+            | "endValue"
+            | "color"
+            | "created"
+            | "lastUpdated"
+            | "translations"
+            | "name"
+            | "startValue"
+            | "id"
+        >;
+    };
+}
+
+export interface D2LegendSetSchema {
+    name: "D2LegendSet";
+    model: D2LegendSet;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
         displayName: string;
         externalAccess: boolean;
         favorite: boolean;
@@ -10631,153 +8745,146 @@ export interface D2ProgramRuleActionSchema {
         id: Id;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
-        location: string;
+        legends: D2LegendSchema[];
         name: string;
-        option: D2OptionSchema;
-        optionGroup: D2OptionGroupSchema;
-        programIndicator: D2ProgramIndicatorSchema;
-        programRule: D2ProgramRuleSchema;
-        programRuleActionType:
-            | "DISPLAYTEXT"
-            | "DISPLAYKEYVALUEPAIR"
-            | "HIDEFIELD"
-            | "HIDESECTION"
-            | "HIDEPROGRAMSTAGE"
-            | "ASSIGN"
-            | "SHOWWARNING"
-            | "WARNINGONCOMPLETE"
-            | "SHOWERROR"
-            | "ERRORONCOMPLETE"
-            | "CREATEEVENT"
-            | "SETMANDATORYFIELD"
-            | "SENDMESSAGE"
-            | "SCHEDULEMESSAGE"
-            | "HIDEOPTION"
-            | "SHOWOPTIONGROUP"
-            | "HIDEOPTIONGROUP";
-        programStage: D2ProgramStageSchema;
-        programStageSection: D2ProgramStageSectionSchema;
         publicAccess: string;
-        templateUid: string;
-        trackedEntityAttribute: D2TrackedEntityAttributeSchema;
+        symbolizer: string;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2ProgramRuleAction, keyof D2ProgramRuleAction>;
-        $identifiable: Preset<D2ProgramRuleAction, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramRuleAction, FieldPresets["nameable"]>;
+        $all: Preset<D2LegendSet, keyof D2LegendSet>;
+        $identifiable: Preset<D2LegendSet, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2LegendSet, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2ProgramRuleAction,
-            | "code"
-            | "data"
-            | "optionGroup"
-            | "templateUid"
-            | "content"
-            | "trackedEntityAttribute"
-            | "lastUpdated"
-            | "programIndicator"
-            | "id"
-            | "programRule"
-            | "programStageSection"
-            | "programRuleActionType"
+            D2LegendSet,
             | "lastUpdatedBy"
-            | "programStage"
+            | "userGroupAccesses"
+            | "code"
             | "created"
-            | "dataElement"
-            | "location"
-            | "option"
+            | "publicAccess"
+            | "attributeValues"
+            | "symbolizer"
+            | "lastUpdated"
+            | "legends"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
         >;
         $owner: Preset<
-            D2ProgramRuleAction,
-            | "code"
-            | "data"
-            | "optionGroup"
-            | "templateUid"
-            | "content"
-            | "trackedEntityAttribute"
-            | "lastUpdated"
-            | "programIndicator"
-            | "id"
-            | "programRule"
-            | "programStageSection"
-            | "programRuleActionType"
+            D2LegendSet,
             | "lastUpdatedBy"
-            | "programStage"
+            | "userGroupAccesses"
+            | "code"
             | "created"
-            | "dataElement"
-            | "location"
-            | "option"
+            | "publicAccess"
+            | "attributeValues"
+            | "symbolizer"
+            | "lastUpdated"
+            | "legends"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
         >;
     };
 }
 
-export interface D2ProgramRuleSchema {
-    name: "D2ProgramRule";
-    model: D2ProgramRule;
+export interface D2MapSchema {
+    name: "D2Map";
+    model: D2Map;
     fields: {
         access: D2Access;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        basemap: string;
         code: Id;
-        condition: string;
         created: string;
         description: string;
+        displayDescription: string;
+        displayFormName: string;
         displayName: string;
+        displayShortName: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
+        formName: string;
         href: string;
         id: Id;
+        interpretations: D2InterpretationSchema[];
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
+        latitude: number;
+        longitude: number;
+        mapViews: D2MapViewSchema[];
         name: string;
-        priority: number;
-        program: D2ProgramSchema;
-        programRuleActions: D2ProgramRuleActionSchema[];
-        programStage: D2ProgramStageSchema;
         publicAccess: string;
+        shortName: string;
+        subscribed: boolean;
+        subscribers: string[];
+        title: string;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
+        zoom: number;
     };
     fieldPresets: {
-        $all: Preset<D2ProgramRule, keyof D2ProgramRule>;
-        $identifiable: Preset<D2ProgramRule, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramRule, FieldPresets["nameable"]>;
+        $all: Preset<D2Map, keyof D2Map>;
+        $identifiable: Preset<D2Map, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Map, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2ProgramRule,
+            D2Map,
+            | "favorites"
             | "code"
+            | "publicAccess"
+            | "basemap"
+            | "latitude"
             | "description"
-            | "program"
+            | "title"
+            | "externalAccess"
             | "lastUpdated"
             | "translations"
+            | "mapViews"
             | "id"
+            | "interpretations"
+            | "longitude"
             | "lastUpdatedBy"
-            | "programStage"
+            | "userGroupAccesses"
+            | "subscribers"
             | "created"
-            | "priority"
-            | "condition"
-            | "programRuleActions"
+            | "zoom"
+            | "userAccesses"
             | "name"
+            | "user"
         >;
         $owner: Preset<
-            D2ProgramRule,
+            D2Map,
+            | "favorites"
             | "code"
+            | "publicAccess"
+            | "basemap"
+            | "latitude"
             | "description"
-            | "program"
+            | "title"
+            | "externalAccess"
             | "lastUpdated"
             | "translations"
+            | "mapViews"
             | "id"
+            | "longitude"
             | "lastUpdatedBy"
-            | "programStage"
+            | "userGroupAccesses"
+            | "subscribers"
             | "created"
-            | "priority"
-            | "condition"
-            | "programRuleActions"
+            | "zoom"
+            | "userAccesses"
             | "name"
+            | "user"
         >;
     };
 }
@@ -11030,13 +9137,2143 @@ export interface D2MapViewSchema {
     };
 }
 
-export interface D2MapSchema {
-    name: "D2Map";
-    model: D2Map;
+export interface D2MessageConversationSchema {
+    name: "D2MessageConversation";
+    model: D2MessageConversation;
+    fields: {
+        access: D2Access;
+        assignee: D2UserSchema;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        followUp: boolean;
+        href: string;
+        id: Id;
+        lastMessage: string;
+        lastSender: D2UserSchema;
+        lastSenderFirstname: string;
+        lastSenderSurname: string;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        messageCount: number;
+        messageType: "PRIVATE" | "SYSTEM" | "VALIDATION_RESULT" | "TICKET";
+        messages: any[];
+        name: string;
+        priority: "NONE" | "LOW" | "MEDIUM" | "HIGH";
+        publicAccess: string;
+        read: boolean;
+        status: "NONE" | "OPEN" | "PENDING" | "INVALID" | "SOLVED";
+        subject: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userFirstname: string;
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        userMessages: any[];
+        userSurname: string;
+    };
+    fieldPresets: {
+        $all: Preset<D2MessageConversation, keyof D2MessageConversation>;
+        $identifiable: Preset<D2MessageConversation, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2MessageConversation, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2MessageConversation,
+            | "messageCount"
+            | "subject"
+            | "lastUpdated"
+            | "messageType"
+            | "userMessages"
+            | "id"
+            | "lastSender"
+            | "created"
+            | "lastMessage"
+            | "priority"
+            | "messages"
+            | "assignee"
+            | "user"
+            | "status"
+        >;
+        $owner: Preset<
+            D2MessageConversation,
+            | "messageCount"
+            | "subject"
+            | "lastUpdated"
+            | "messageType"
+            | "userMessages"
+            | "id"
+            | "lastSender"
+            | "created"
+            | "lastMessage"
+            | "priority"
+            | "messages"
+            | "assignee"
+            | "user"
+            | "status"
+        >;
+    };
+}
+
+export interface D2MetadataVersionSchema {
+    name: "D2MetadataVersion";
+    model: D2MetadataVersion;
     fields: {
         access: D2Access;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        basemap: string;
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        hashCode: string;
+        href: string;
+        id: Id;
+        importDate: string;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        translations: D2Translation[];
+        type: "BEST_EFFORT" | "ATOMIC";
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2MetadataVersion, keyof D2MetadataVersion>;
+        $identifiable: Preset<D2MetadataVersion, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2MetadataVersion, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2MetadataVersion,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "type"
+            | "lastUpdated"
+            | "importDate"
+            | "hashCode"
+            | "name"
+            | "id"
+        >;
+        $owner: Preset<
+            D2MetadataVersion,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "type"
+            | "lastUpdated"
+            | "importDate"
+            | "hashCode"
+            | "name"
+            | "id"
+        >;
+    };
+}
+
+export interface D2MinMaxDataElementSchema {
+    name: "D2MinMaxDataElement";
+    model: D2MinMaxDataElement;
+    fields: {
+        dataElement: D2DataElementSchema;
+        generated: boolean;
+        max: number;
+        min: number;
+        optionCombo: D2CategoryOptionComboSchema;
+        source: D2OrganisationUnitSchema;
+    };
+    fieldPresets: {
+        $all: Preset<D2MinMaxDataElement, keyof D2MinMaxDataElement>;
+        $identifiable: Preset<D2MinMaxDataElement, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2MinMaxDataElement, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2MinMaxDataElement,
+            "min" | "generated" | "max" | "dataElement" | "source" | "optionCombo"
+        >;
+        $owner: Preset<
+            D2MinMaxDataElement,
+            "min" | "generated" | "max" | "dataElement" | "source" | "optionCombo"
+        >;
+    };
+}
+
+export interface D2OAuth2ClientSchema {
+    name: "D2OAuth2Client";
+    model: D2OAuth2Client;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        cid: Id;
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        grantTypes: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        redirectUris: string[];
+        secret: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2OAuth2Client, keyof D2OAuth2Client>;
+        $identifiable: Preset<D2OAuth2Client, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OAuth2Client, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2OAuth2Client,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "secret"
+            | "redirectUris"
+            | "lastUpdated"
+            | "grantTypes"
+            | "name"
+            | "id"
+            | "cid"
+        >;
+        $owner: Preset<
+            D2OAuth2Client,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "secret"
+            | "redirectUris"
+            | "lastUpdated"
+            | "grantTypes"
+            | "name"
+            | "id"
+            | "cid"
+        >;
+    };
+}
+
+export interface D2OptionSchema {
+    name: "D2Option";
+    model: D2Option;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: string;
+        created: string;
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        optionSet: D2OptionSetSchema;
+        publicAccess: string;
+        shortName: string;
+        sortOrder: number;
+        style: D2Style;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2Option, keyof D2Option>;
+        $identifiable: Preset<D2Option, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Option, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Option,
+            | "code"
+            | "description"
+            | "lastUpdated"
+            | "optionSet"
+            | "translations"
+            | "formName"
+            | "id"
+            | "created"
+            | "attributeValues"
+            | "sortOrder"
+            | "name"
+            | "style"
+        >;
+        $owner: Preset<
+            D2Option,
+            | "code"
+            | "description"
+            | "lastUpdated"
+            | "optionSet"
+            | "translations"
+            | "formName"
+            | "id"
+            | "created"
+            | "attributeValues"
+            | "sortOrder"
+            | "name"
+            | "style"
+        >;
+    };
+}
+
+export interface D2OptionGroupSchema {
+    name: "D2OptionGroup";
+    model: D2OptionGroup;
+    fields: {
+        access: D2Access;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        description: string;
+        dimensionItem: string;
+        dimensionItemType:
+            | "DATA_ELEMENT"
+            | "DATA_ELEMENT_OPERAND"
+            | "INDICATOR"
+            | "REPORTING_RATE"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION"
+            | "OPTION_GROUP"
+            | "DATA_ELEMENT_GROUP"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY_OPTION_GROUP";
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendSet: D2LegendSetSchema;
+        legendSets: D2LegendSetSchema[];
+        name: string;
+        optionSet: D2OptionSetSchema;
+        options: D2OptionSchema[];
+        publicAccess: string;
+        shortName: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2OptionGroup, keyof D2OptionGroup>;
+        $identifiable: Preset<D2OptionGroup, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OptionGroup, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2OptionGroup,
+            | "code"
+            | "publicAccess"
+            | "lastUpdated"
+            | "optionSet"
+            | "translations"
+            | "options"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "userAccesses"
+            | "name"
+            | "shortName"
+            | "user"
+        >;
+        $owner: Preset<
+            D2OptionGroup,
+            | "code"
+            | "publicAccess"
+            | "lastUpdated"
+            | "optionSet"
+            | "translations"
+            | "options"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "userAccesses"
+            | "name"
+            | "shortName"
+            | "user"
+        >;
+    };
+}
+
+export interface D2OptionGroupSetSchema {
+    name: "D2OptionGroupSet";
+    model: D2OptionGroupSet;
+    fields: {
+        access: D2Access;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        allItems: boolean;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        dataDimension: boolean;
+        dataDimensionType: "DISAGGREGATION" | "ATTRIBUTE";
+        description: string;
+        dimension: string;
+        dimensionType:
+            | "DATA_X"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "DATA_COLLAPSED"
+            | "CATEGORY_OPTION_COMBO"
+            | "ATTRIBUTE_OPTION_COMBO"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION_GROUP_SET"
+            | "DATA_ELEMENT_GROUP_SET"
+            | "ORGANISATION_UNIT_GROUP_SET"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY"
+            | "OPTION_GROUP_SET"
+            | "VALIDATION_RULE"
+            | "STATIC"
+            | "ORGANISATION_UNIT_LEVEL";
+        dimensionalKeywords: D2DimensionalKeywords;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        filter: string;
+        formName: string;
+        href: string;
+        id: Id;
+        items: any[];
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendSet: D2LegendSetSchema;
+        name: string;
+        optionGroups: D2OptionGroupSchema[];
+        optionSet: D2OptionSetSchema;
+        programStage: D2ProgramStageSchema;
+        publicAccess: string;
+        shortName: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2OptionGroupSet, keyof D2OptionGroupSet>;
+        $identifiable: Preset<D2OptionGroupSet, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OptionGroupSet, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2OptionGroupSet,
+            | "code"
+            | "publicAccess"
+            | "description"
+            | "optionGroups"
+            | "lastUpdated"
+            | "optionSet"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "userAccesses"
+            | "name"
+            | "dataDimension"
+            | "user"
+        >;
+        $owner: Preset<
+            D2OptionGroupSet,
+            | "code"
+            | "publicAccess"
+            | "description"
+            | "optionGroups"
+            | "lastUpdated"
+            | "optionSet"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "userAccesses"
+            | "name"
+            | "dataDimension"
+            | "user"
+        >;
+    };
+}
+
+export interface D2OptionSetSchema {
+    name: "D2OptionSet";
+    model: D2OptionSet;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        options: D2OptionSchema[];
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        valueType:
+            | "TEXT"
+            | "LONG_TEXT"
+            | "LETTER"
+            | "PHONE_NUMBER"
+            | "EMAIL"
+            | "BOOLEAN"
+            | "TRUE_ONLY"
+            | "DATE"
+            | "DATETIME"
+            | "TIME"
+            | "NUMBER"
+            | "UNIT_INTERVAL"
+            | "PERCENTAGE"
+            | "INTEGER"
+            | "INTEGER_POSITIVE"
+            | "INTEGER_NEGATIVE"
+            | "INTEGER_ZERO_OR_POSITIVE"
+            | "TRACKER_ASSOCIATE"
+            | "USERNAME"
+            | "COORDINATE"
+            | "ORGANISATION_UNIT"
+            | "AGE"
+            | "URL"
+            | "FILE_RESOURCE"
+            | "IMAGE";
+        version: number;
+    };
+    fieldPresets: {
+        $all: Preset<D2OptionSet, keyof D2OptionSet>;
+        $identifiable: Preset<D2OptionSet, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OptionSet, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2OptionSet,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "attributeValues"
+            | "version"
+            | "lastUpdated"
+            | "translations"
+            | "userAccesses"
+            | "valueType"
+            | "name"
+            | "options"
+            | "id"
+            | "user"
+        >;
+        $owner: Preset<
+            D2OptionSet,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "attributeValues"
+            | "version"
+            | "lastUpdated"
+            | "translations"
+            | "userAccesses"
+            | "valueType"
+            | "name"
+            | "options"
+            | "id"
+            | "user"
+        >;
+    };
+}
+
+export interface D2OrganisationUnitSchema {
+    name: "D2OrganisationUnit";
+    model: D2OrganisationUnit;
+    fields: {
+        access: D2Access;
+        address: string;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        ancestors: D2OrganisationUnitSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        children: D2OrganisationUnitSchema[];
+        closedDate: string;
+        code: Id;
+        comment: string;
+        contactPerson: string;
+        created: string;
+        dataSets: D2DataSetSchema[];
+        description: string;
+        dimensionItem: string;
+        dimensionItemType:
+            | "DATA_ELEMENT"
+            | "DATA_ELEMENT_OPERAND"
+            | "INDICATOR"
+            | "REPORTING_RATE"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION"
+            | "OPTION_GROUP"
+            | "DATA_ELEMENT_GROUP"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY_OPTION_GROUP";
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        email: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        geometry: D2Geometry;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        leaf: boolean;
+        legendSet: D2LegendSetSchema;
+        legendSets: D2LegendSetSchema[];
+        level: number;
+        memberCount: number;
+        name: string;
+        openingDate: string;
+        organisationUnitGroups: D2OrganisationUnitGroupSchema[];
+        parent: D2OrganisationUnitSchema;
+        path: string;
+        phoneNumber: string;
+        programs: D2ProgramSchema[];
+        publicAccess: string;
+        shortName: string;
+        translations: D2Translation[];
+        type: string;
+        url: string;
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        users: D2UserSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2OrganisationUnit, keyof D2OrganisationUnit>;
+        $identifiable: Preset<D2OrganisationUnit, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OrganisationUnit, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2OrganisationUnit,
+            | "parent"
+            | "path"
+            | "lastUpdated"
+            | "children"
+            | "translations"
+            | "id"
+            | "organisationUnitGroups"
+            | "lastUpdatedBy"
+            | "level"
+            | "created"
+            | "attributeValues"
+            | "users"
+            | "phoneNumber"
+            | "name"
+            | "dataSets"
+            | "programs"
+            | "shortName"
+            | "code"
+            | "description"
+            | "contactPerson"
+            | "openingDate"
+            | "email"
+            | "address"
+            | "url"
+            | "closedDate"
+            | "geometry"
+            | "comment"
+            | "user"
+        >;
+        $owner: Preset<
+            D2OrganisationUnit,
+            | "parent"
+            | "path"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "level"
+            | "created"
+            | "attributeValues"
+            | "phoneNumber"
+            | "name"
+            | "shortName"
+            | "code"
+            | "description"
+            | "contactPerson"
+            | "openingDate"
+            | "email"
+            | "address"
+            | "url"
+            | "closedDate"
+            | "geometry"
+            | "comment"
+            | "user"
+        >;
+    };
+}
+
+export interface D2OrganisationUnitGroupSchema {
+    name: "D2OrganisationUnitGroup";
+    model: D2OrganisationUnitGroup;
+    fields: {
+        access: D2Access;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        color: string;
+        created: string;
+        description: string;
+        dimensionItem: string;
+        dimensionItemType:
+            | "DATA_ELEMENT"
+            | "DATA_ELEMENT_OPERAND"
+            | "INDICATOR"
+            | "REPORTING_RATE"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION"
+            | "OPTION_GROUP"
+            | "DATA_ELEMENT_GROUP"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY_OPTION_GROUP";
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
+        formName: string;
+        geometry: D2Geometry;
+        groupSets: D2OrganisationUnitGroupSetSchema[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendSet: D2LegendSetSchema;
+        legendSets: D2LegendSetSchema[];
+        name: string;
+        organisationUnits: D2OrganisationUnitSchema[];
+        publicAccess: string;
+        shortName: string;
+        symbol: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2OrganisationUnitGroup, keyof D2OrganisationUnitGroup>;
+        $identifiable: Preset<D2OrganisationUnitGroup, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OrganisationUnitGroup, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2OrganisationUnitGroup,
+            | "symbol"
+            | "code"
+            | "color"
+            | "publicAccess"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "organisationUnits"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "groupSets"
+            | "userAccesses"
+            | "name"
+            | "geometry"
+            | "shortName"
+            | "user"
+        >;
+        $owner: Preset<
+            D2OrganisationUnitGroup,
+            | "symbol"
+            | "code"
+            | "color"
+            | "publicAccess"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "organisationUnits"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "userAccesses"
+            | "name"
+            | "geometry"
+            | "shortName"
+            | "user"
+        >;
+    };
+}
+
+export interface D2OrganisationUnitGroupSetSchema {
+    name: "D2OrganisationUnitGroupSet";
+    model: D2OrganisationUnitGroupSet;
+    fields: {
+        access: D2Access;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        allItems: boolean;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        compulsory: boolean;
+        created: string;
+        dataDimension: boolean;
+        dataDimensionType: "DISAGGREGATION" | "ATTRIBUTE";
+        description: string;
+        dimension: string;
+        dimensionType:
+            | "DATA_X"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "DATA_COLLAPSED"
+            | "CATEGORY_OPTION_COMBO"
+            | "ATTRIBUTE_OPTION_COMBO"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION_GROUP_SET"
+            | "DATA_ELEMENT_GROUP_SET"
+            | "ORGANISATION_UNIT_GROUP_SET"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY"
+            | "OPTION_GROUP_SET"
+            | "VALIDATION_RULE"
+            | "STATIC"
+            | "ORGANISATION_UNIT_LEVEL";
+        dimensionalKeywords: D2DimensionalKeywords;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        filter: string;
+        formName: string;
+        href: string;
+        id: Id;
+        includeSubhierarchyInAnalytics: boolean;
+        items: any[];
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendSet: D2LegendSetSchema;
+        name: string;
+        organisationUnitGroups: D2OrganisationUnitGroupSchema[];
+        programStage: D2ProgramStageSchema;
+        publicAccess: string;
+        shortName: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2OrganisationUnitGroupSet, keyof D2OrganisationUnitGroupSet>;
+        $identifiable: Preset<D2OrganisationUnitGroupSet, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OrganisationUnitGroupSet, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2OrganisationUnitGroupSet,
+            | "code"
+            | "publicAccess"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "organisationUnitGroups"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "compulsory"
+            | "includeSubhierarchyInAnalytics"
+            | "userAccesses"
+            | "name"
+            | "dataDimension"
+            | "user"
+        >;
+        $owner: Preset<
+            D2OrganisationUnitGroupSet,
+            | "code"
+            | "publicAccess"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "organisationUnitGroups"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "compulsory"
+            | "includeSubhierarchyInAnalytics"
+            | "userAccesses"
+            | "name"
+            | "dataDimension"
+            | "user"
+        >;
+    };
+}
+
+export interface D2OrganisationUnitGroupSetDimensionSchema {
+    name: "D2OrganisationUnitGroupSetDimension";
+    model: D2OrganisationUnitGroupSetDimension;
+    fields: {
+        organisationUnitGroupSet: D2OrganisationUnitGroupSetSchema;
+        organisationUnitGroups: D2OrganisationUnitGroupSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<
+            D2OrganisationUnitGroupSetDimension,
+            keyof D2OrganisationUnitGroupSetDimension
+        >;
+        $identifiable: Preset<D2OrganisationUnitGroupSetDimension, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OrganisationUnitGroupSetDimension, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2OrganisationUnitGroupSetDimension,
+            "organisationUnitGroupSet" | "organisationUnitGroups"
+        >;
+        $owner: Preset<
+            D2OrganisationUnitGroupSetDimension,
+            "organisationUnitGroupSet" | "organisationUnitGroups"
+        >;
+    };
+}
+
+export interface D2OrganisationUnitLevelSchema {
+    name: "D2OrganisationUnitLevel";
+    model: D2OrganisationUnitLevel;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        level: number;
+        name: string;
+        offlineLevels: number;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2OrganisationUnitLevel, keyof D2OrganisationUnitLevel>;
+        $identifiable: Preset<D2OrganisationUnitLevel, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OrganisationUnitLevel, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2OrganisationUnitLevel,
+            | "lastUpdatedBy"
+            | "offlineLevels"
+            | "code"
+            | "level"
+            | "created"
+            | "lastUpdated"
+            | "translations"
+            | "name"
+            | "id"
+        >;
+        $owner: Preset<
+            D2OrganisationUnitLevel,
+            | "lastUpdatedBy"
+            | "offlineLevels"
+            | "code"
+            | "level"
+            | "created"
+            | "lastUpdated"
+            | "translations"
+            | "name"
+            | "id"
+        >;
+    };
+}
+
+export interface D2PredictorSchema {
+    name: "D2Predictor";
+    model: D2Predictor;
+    fields: {
+        access: D2Access;
+        annualSampleCount: number;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        generator: D2ExpressionSchema;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        organisationUnitLevels: D2OrganisationUnitLevelSchema[];
+        output: D2DataElementSchema;
+        outputCombo: D2CategoryOptionComboSchema;
+        periodType: string;
+        predictorGroups: D2PredictorGroupSchema[];
+        publicAccess: string;
+        sampleSkipTest: D2ExpressionSchema;
+        sequentialSampleCount: number;
+        sequentialSkipCount: number;
+        shortName: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2Predictor, keyof D2Predictor>;
+        $identifiable: Preset<D2Predictor, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Predictor, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Predictor,
+            | "outputCombo"
+            | "code"
+            | "description"
+            | "generator"
+            | "organisationUnitLevels"
+            | "output"
+            | "lastUpdated"
+            | "sampleSkipTest"
+            | "id"
+            | "sequentialSampleCount"
+            | "annualSampleCount"
+            | "lastUpdatedBy"
+            | "created"
+            | "sequentialSkipCount"
+            | "predictorGroups"
+            | "periodType"
+            | "name"
+        >;
+        $owner: Preset<
+            D2Predictor,
+            | "outputCombo"
+            | "code"
+            | "description"
+            | "generator"
+            | "organisationUnitLevels"
+            | "output"
+            | "lastUpdated"
+            | "sampleSkipTest"
+            | "id"
+            | "sequentialSampleCount"
+            | "annualSampleCount"
+            | "lastUpdatedBy"
+            | "created"
+            | "sequentialSkipCount"
+            | "periodType"
+            | "name"
+        >;
+    };
+}
+
+export interface D2PredictorGroupSchema {
+    name: "D2PredictorGroup";
+    model: D2PredictorGroup;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        description: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        predictors: D2PredictorSchema[];
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2PredictorGroup, keyof D2PredictorGroup>;
+        $identifiable: Preset<D2PredictorGroup, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2PredictorGroup, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2PredictorGroup,
+            | "predictors"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+        >;
+        $owner: Preset<
+            D2PredictorGroup,
+            | "predictors"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+        >;
+    };
+}
+
+export interface D2ProgramSchema {
+    name: "D2Program";
+    model: D2Program;
+    fields: {
+        access: D2Access;
+        accessLevel: "OPEN" | "AUDITED" | "PROTECTED" | "CLOSED";
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        categoryCombo: D2CategoryComboSchema;
+        code: Id;
+        completeEventsExpiryDays: number;
+        created: string;
+        dataEntryForm: D2DataEntryFormSchema;
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayFrontPageList: boolean;
+        displayIncidentDate: boolean;
+        displayName: string;
+        displayShortName: string;
+        enrollmentDateLabel: string;
+        expiryDays: number;
+        expiryPeriodType: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
+        formName: string;
+        href: string;
+        id: Id;
+        ignoreOverdueEvents: boolean;
+        incidentDateLabel: string;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        maxTeiCountToReturn: number;
+        minAttributesRequiredToSearch: number;
+        name: string;
+        notificationTemplates: D2ProgramNotificationTemplateSchema[];
+        onlyEnrollOnce: boolean;
+        organisationUnits: D2OrganisationUnitSchema[];
+        programIndicators: D2ProgramIndicatorSchema[];
+        programRuleVariables: D2ProgramRuleVariableSchema[];
+        programSections: D2ProgramSectionSchema[];
+        programStages: D2ProgramStageSchema[];
+        programTrackedEntityAttributes: D2ProgramTrackedEntityAttributeSchema[];
+        programType: "WITH_REGISTRATION" | "WITHOUT_REGISTRATION";
+        publicAccess: string;
+        registration: boolean;
+        relatedProgram: D2ProgramSchema;
+        selectEnrollmentDatesInFuture: boolean;
+        selectIncidentDatesInFuture: boolean;
+        shortName: string;
+        skipOffline: boolean;
+        style: D2Style;
+        trackedEntityType: D2TrackedEntityTypeSchema;
+        translations: D2Translation[];
+        useFirstStageDuringRegistration: boolean;
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        userRoles: D2UserAuthorityGroupSchema[];
+        version: number;
+        withoutRegistration: boolean;
+    };
+    fieldPresets: {
+        $all: Preset<D2Program, keyof D2Program>;
+        $identifiable: Preset<D2Program, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Program, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Program,
+            | "dataEntryForm"
+            | "publicAccess"
+            | "ignoreOverdueEvents"
+            | "skipOffline"
+            | "programIndicators"
+            | "lastUpdated"
+            | "categoryCombo"
+            | "translations"
+            | "id"
+            | "enrollmentDateLabel"
+            | "lastUpdatedBy"
+            | "onlyEnrollOnce"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "version"
+            | "maxTeiCountToReturn"
+            | "selectIncidentDatesInFuture"
+            | "incidentDateLabel"
+            | "userRoles"
+            | "expiryPeriodType"
+            | "userAccesses"
+            | "name"
+            | "selectEnrollmentDatesInFuture"
+            | "style"
+            | "shortName"
+            | "useFirstStageDuringRegistration"
+            | "code"
+            | "programRuleVariables"
+            | "programTrackedEntityAttributes"
+            | "completeEventsExpiryDays"
+            | "description"
+            | "relatedProgram"
+            | "notificationTemplates"
+            | "formName"
+            | "featureType"
+            | "minAttributesRequiredToSearch"
+            | "displayFrontPageList"
+            | "organisationUnits"
+            | "programType"
+            | "accessLevel"
+            | "programSections"
+            | "programStages"
+            | "trackedEntityType"
+            | "displayIncidentDate"
+            | "expiryDays"
+            | "user"
+        >;
+        $owner: Preset<
+            D2Program,
+            | "dataEntryForm"
+            | "publicAccess"
+            | "ignoreOverdueEvents"
+            | "skipOffline"
+            | "lastUpdated"
+            | "categoryCombo"
+            | "translations"
+            | "id"
+            | "enrollmentDateLabel"
+            | "lastUpdatedBy"
+            | "onlyEnrollOnce"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "version"
+            | "maxTeiCountToReturn"
+            | "selectIncidentDatesInFuture"
+            | "incidentDateLabel"
+            | "expiryPeriodType"
+            | "userAccesses"
+            | "name"
+            | "selectEnrollmentDatesInFuture"
+            | "style"
+            | "shortName"
+            | "useFirstStageDuringRegistration"
+            | "code"
+            | "programTrackedEntityAttributes"
+            | "completeEventsExpiryDays"
+            | "description"
+            | "relatedProgram"
+            | "notificationTemplates"
+            | "formName"
+            | "featureType"
+            | "minAttributesRequiredToSearch"
+            | "displayFrontPageList"
+            | "organisationUnits"
+            | "programType"
+            | "accessLevel"
+            | "programSections"
+            | "programStages"
+            | "trackedEntityType"
+            | "displayIncidentDate"
+            | "expiryDays"
+            | "user"
+        >;
+    };
+}
+
+export interface D2ProgramDataElementDimensionItemSchema {
+    name: "D2ProgramDataElementDimensionItem";
+    model: D2ProgramDataElementDimensionItem;
+    fields: {
+        access: D2Access;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        dataElement: D2DataElementSchema;
+        description: string;
+        dimensionItem: string;
+        dimensionItemType:
+            | "DATA_ELEMENT"
+            | "DATA_ELEMENT_OPERAND"
+            | "INDICATOR"
+            | "REPORTING_RATE"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION"
+            | "OPTION_GROUP"
+            | "DATA_ELEMENT_GROUP"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY_OPTION_GROUP";
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendSet: D2LegendSetSchema;
+        legendSets: D2LegendSetSchema[];
+        name: string;
+        program: D2ProgramSchema;
+        publicAccess: string;
+        shortName: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        valueType:
+            | "TEXT"
+            | "LONG_TEXT"
+            | "LETTER"
+            | "PHONE_NUMBER"
+            | "EMAIL"
+            | "BOOLEAN"
+            | "TRUE_ONLY"
+            | "DATE"
+            | "DATETIME"
+            | "TIME"
+            | "NUMBER"
+            | "UNIT_INTERVAL"
+            | "PERCENTAGE"
+            | "INTEGER"
+            | "INTEGER_POSITIVE"
+            | "INTEGER_NEGATIVE"
+            | "INTEGER_ZERO_OR_POSITIVE"
+            | "TRACKER_ASSOCIATE"
+            | "USERNAME"
+            | "COORDINATE"
+            | "ORGANISATION_UNIT"
+            | "AGE"
+            | "URL"
+            | "FILE_RESOURCE"
+            | "IMAGE";
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramDataElementDimensionItem, keyof D2ProgramDataElementDimensionItem>;
+        $identifiable: Preset<D2ProgramDataElementDimensionItem, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramDataElementDimensionItem, FieldPresets["nameable"]>;
+        $persisted: Preset<D2ProgramDataElementDimensionItem, never>;
+        $owner: Preset<D2ProgramDataElementDimensionItem, never>;
+    };
+}
+
+export interface D2ProgramIndicatorSchema {
+    name: "D2ProgramIndicator";
+    model: D2ProgramIndicator;
+    fields: {
+        access: D2Access;
+        aggregateExportAttributeOptionCombo: string;
+        aggregateExportCategoryOptionCombo: string;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        analyticsPeriodBoundaries: D2AnalyticsPeriodBoundarySchema[];
+        analyticsType: "EVENT" | "ENROLLMENT";
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        decimals: number;
+        description: string;
+        dimensionItem: string;
+        dimensionItemType:
+            | "DATA_ELEMENT"
+            | "DATA_ELEMENT_OPERAND"
+            | "INDICATOR"
+            | "REPORTING_RATE"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION"
+            | "OPTION_GROUP"
+            | "DATA_ELEMENT_GROUP"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY_OPTION_GROUP";
+        displayDescription: string;
+        displayFormName: string;
+        displayInForm: boolean;
+        displayName: string;
+        displayShortName: string;
+        expression: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        filter: string;
+        formName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendSet: D2LegendSetSchema;
+        legendSets: D2LegendSetSchema[];
+        name: string;
+        program: D2ProgramSchema;
+        programIndicatorGroups: D2ProgramIndicatorGroupSchema[];
+        publicAccess: string;
+        shortName: string;
+        style: D2Style;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramIndicator, keyof D2ProgramIndicator>;
+        $identifiable: Preset<D2ProgramIndicator, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramIndicator, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramIndicator,
+            | "aggregationType"
+            | "code"
+            | "displayInForm"
+            | "publicAccess"
+            | "aggregateExportCategoryOptionCombo"
+            | "description"
+            | "program"
+            | "lastUpdated"
+            | "translations"
+            | "formName"
+            | "id"
+            | "programIndicatorGroups"
+            | "analyticsPeriodBoundaries"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "expression"
+            | "created"
+            | "attributeValues"
+            | "filter"
+            | "userAccesses"
+            | "decimals"
+            | "name"
+            | "analyticsType"
+            | "legendSets"
+            | "style"
+            | "shortName"
+            | "user"
+            | "aggregateExportAttributeOptionCombo"
+        >;
+        $owner: Preset<
+            D2ProgramIndicator,
+            | "aggregationType"
+            | "code"
+            | "displayInForm"
+            | "publicAccess"
+            | "aggregateExportCategoryOptionCombo"
+            | "description"
+            | "program"
+            | "lastUpdated"
+            | "translations"
+            | "formName"
+            | "id"
+            | "analyticsPeriodBoundaries"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "expression"
+            | "created"
+            | "attributeValues"
+            | "filter"
+            | "userAccesses"
+            | "decimals"
+            | "name"
+            | "analyticsType"
+            | "legendSets"
+            | "style"
+            | "shortName"
+            | "user"
+            | "aggregateExportAttributeOptionCombo"
+        >;
+    };
+}
+
+export interface D2ProgramIndicatorGroupSchema {
+    name: "D2ProgramIndicatorGroup";
+    model: D2ProgramIndicatorGroup;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        description: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        programIndicators: D2ProgramIndicatorSchema[];
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramIndicatorGroup, keyof D2ProgramIndicatorGroup>;
+        $identifiable: Preset<D2ProgramIndicatorGroup, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramIndicatorGroup, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramIndicatorGroup,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "description"
+            | "programIndicators"
+            | "lastUpdated"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+        >;
+        $owner: Preset<
+            D2ProgramIndicatorGroup,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "description"
+            | "programIndicators"
+            | "lastUpdated"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+        >;
+    };
+}
+
+export interface D2ProgramInstanceSchema {
+    name: "D2ProgramInstance";
+    model: D2ProgramInstance;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        completedBy: string;
+        created: string;
+        createdAtClient: string;
+        deleted: boolean;
+        displayName: string;
+        endDate: string;
+        enrollmentDate: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        followup: boolean;
+        geometry: D2Geometry;
+        href: string;
+        id: Id;
+        incidentDate: string;
+        lastUpdated: string;
+        lastUpdatedAtClient: string;
+        lastUpdatedBy: D2UserSchema;
+        messageConversations: D2MessageConversationSchema[];
+        name: string;
+        organisationUnit: D2OrganisationUnitSchema;
+        program: D2ProgramSchema;
+        programStageInstances: D2ProgramStageInstanceSchema[];
+        publicAccess: string;
+        relationshipItems: any[];
+        status: "ACTIVE" | "COMPLETED" | "CANCELLED";
+        storedBy: string;
+        trackedEntityComments: any[];
+        trackedEntityInstance: D2TrackedEntityInstanceSchema;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramInstance, keyof D2ProgramInstance>;
+        $identifiable: Preset<D2ProgramInstance, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramInstance, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramInstance,
+            | "storedBy"
+            | "endDate"
+            | "organisationUnit"
+            | "enrollmentDate"
+            | "createdAtClient"
+            | "program"
+            | "messageConversations"
+            | "trackedEntityComments"
+            | "lastUpdated"
+            | "relationshipItems"
+            | "id"
+            | "created"
+            | "programStageInstances"
+            | "trackedEntityInstance"
+            | "followup"
+            | "deleted"
+            | "geometry"
+            | "incidentDate"
+            | "completedBy"
+            | "status"
+            | "lastUpdatedAtClient"
+        >;
+        $owner: Preset<
+            D2ProgramInstance,
+            | "storedBy"
+            | "endDate"
+            | "organisationUnit"
+            | "enrollmentDate"
+            | "createdAtClient"
+            | "program"
+            | "messageConversations"
+            | "trackedEntityComments"
+            | "lastUpdated"
+            | "id"
+            | "created"
+            | "programStageInstances"
+            | "trackedEntityInstance"
+            | "followup"
+            | "deleted"
+            | "geometry"
+            | "incidentDate"
+            | "completedBy"
+            | "status"
+            | "lastUpdatedAtClient"
+        >;
+    };
+}
+
+export interface D2ProgramNotificationTemplateSchema {
+    name: "D2ProgramNotificationTemplate";
+    model: D2ProgramNotificationTemplate;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        deliveryChannels: never[];
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        messageTemplate: string;
+        name: string;
+        notificationRecipient:
+            | "TRACKED_ENTITY_INSTANCE"
+            | "ORGANISATION_UNIT_CONTACT"
+            | "USERS_AT_ORGANISATION_UNIT"
+            | "USER_GROUP"
+            | "PROGRAM_ATTRIBUTE"
+            | "DATA_ELEMENT";
+        notificationTrigger:
+            | "ENROLLMENT"
+            | "COMPLETION"
+            | "PROGRAM_RULE"
+            | "SCHEDULED_DAYS_DUE_DATE"
+            | "SCHEDULED_DAYS_INCIDENT_DATE"
+            | "SCHEDULED_DAYS_ENROLLMENT_DATE";
+        notifyParentOrganisationUnitOnly: boolean;
+        notifyUsersInHierarchyOnly: boolean;
+        publicAccess: string;
+        recipientDataElement: D2DataElementSchema;
+        recipientProgramAttribute: D2TrackedEntityAttributeSchema;
+        recipientUserGroup: D2UserGroupSchema;
+        relativeScheduledDays: number;
+        subjectTemplate: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramNotificationTemplate, keyof D2ProgramNotificationTemplate>;
+        $identifiable: Preset<D2ProgramNotificationTemplate, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramNotificationTemplate, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramNotificationTemplate,
+            | "code"
+            | "notificationTrigger"
+            | "lastUpdated"
+            | "relativeScheduledDays"
+            | "id"
+            | "subjectTemplate"
+            | "lastUpdatedBy"
+            | "deliveryChannels"
+            | "recipientDataElement"
+            | "created"
+            | "notifyUsersInHierarchyOnly"
+            | "notificationRecipient"
+            | "recipientProgramAttribute"
+            | "notifyParentOrganisationUnitOnly"
+            | "name"
+            | "recipientUserGroup"
+            | "messageTemplate"
+        >;
+        $owner: Preset<
+            D2ProgramNotificationTemplate,
+            | "code"
+            | "notificationTrigger"
+            | "lastUpdated"
+            | "relativeScheduledDays"
+            | "id"
+            | "subjectTemplate"
+            | "lastUpdatedBy"
+            | "deliveryChannels"
+            | "recipientDataElement"
+            | "created"
+            | "notifyUsersInHierarchyOnly"
+            | "notificationRecipient"
+            | "recipientProgramAttribute"
+            | "notifyParentOrganisationUnitOnly"
+            | "name"
+            | "recipientUserGroup"
+            | "messageTemplate"
+        >;
+    };
+}
+
+export interface D2ProgramRuleSchema {
+    name: "D2ProgramRule";
+    model: D2ProgramRule;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        condition: string;
+        created: string;
+        description: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        priority: number;
+        program: D2ProgramSchema;
+        programRuleActions: D2ProgramRuleActionSchema[];
+        programStage: D2ProgramStageSchema;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramRule, keyof D2ProgramRule>;
+        $identifiable: Preset<D2ProgramRule, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramRule, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramRule,
+            | "code"
+            | "description"
+            | "program"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "priority"
+            | "condition"
+            | "programRuleActions"
+            | "name"
+        >;
+        $owner: Preset<
+            D2ProgramRule,
+            | "code"
+            | "description"
+            | "program"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "priority"
+            | "condition"
+            | "programRuleActions"
+            | "name"
+        >;
+    };
+}
+
+export interface D2ProgramRuleActionSchema {
+    name: "D2ProgramRuleAction";
+    model: D2ProgramRuleAction;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        content: string;
+        created: string;
+        data: string;
+        dataElement: D2DataElementSchema;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        location: string;
+        name: string;
+        option: D2OptionSchema;
+        optionGroup: D2OptionGroupSchema;
+        programIndicator: D2ProgramIndicatorSchema;
+        programRule: D2ProgramRuleSchema;
+        programRuleActionType:
+            | "DISPLAYTEXT"
+            | "DISPLAYKEYVALUEPAIR"
+            | "HIDEFIELD"
+            | "HIDESECTION"
+            | "HIDEPROGRAMSTAGE"
+            | "ASSIGN"
+            | "SHOWWARNING"
+            | "WARNINGONCOMPLETE"
+            | "SHOWERROR"
+            | "ERRORONCOMPLETE"
+            | "CREATEEVENT"
+            | "SETMANDATORYFIELD"
+            | "SENDMESSAGE"
+            | "SCHEDULEMESSAGE"
+            | "HIDEOPTION"
+            | "SHOWOPTIONGROUP"
+            | "HIDEOPTIONGROUP";
+        programStage: D2ProgramStageSchema;
+        programStageSection: D2ProgramStageSectionSchema;
+        publicAccess: string;
+        templateUid: string;
+        trackedEntityAttribute: D2TrackedEntityAttributeSchema;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramRuleAction, keyof D2ProgramRuleAction>;
+        $identifiable: Preset<D2ProgramRuleAction, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramRuleAction, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramRuleAction,
+            | "code"
+            | "data"
+            | "optionGroup"
+            | "templateUid"
+            | "content"
+            | "trackedEntityAttribute"
+            | "lastUpdated"
+            | "programIndicator"
+            | "id"
+            | "programRule"
+            | "programStageSection"
+            | "programRuleActionType"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "dataElement"
+            | "location"
+            | "option"
+        >;
+        $owner: Preset<
+            D2ProgramRuleAction,
+            | "code"
+            | "data"
+            | "optionGroup"
+            | "templateUid"
+            | "content"
+            | "trackedEntityAttribute"
+            | "lastUpdated"
+            | "programIndicator"
+            | "id"
+            | "programRule"
+            | "programStageSection"
+            | "programRuleActionType"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "dataElement"
+            | "location"
+            | "option"
+        >;
+    };
+}
+
+export interface D2ProgramRuleVariableSchema {
+    name: "D2ProgramRuleVariable";
+    model: D2ProgramRuleVariable;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        dataElement: D2DataElementSchema;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        program: D2ProgramSchema;
+        programRuleVariableSourceType:
+            | "DATAELEMENT_NEWEST_EVENT_PROGRAM_STAGE"
+            | "DATAELEMENT_NEWEST_EVENT_PROGRAM"
+            | "DATAELEMENT_CURRENT_EVENT"
+            | "DATAELEMENT_PREVIOUS_EVENT"
+            | "CALCULATED_VALUE"
+            | "TEI_ATTRIBUTE";
+        programStage: D2ProgramStageSchema;
+        publicAccess: string;
+        trackedEntityAttribute: D2TrackedEntityAttributeSchema;
+        translations: D2Translation[];
+        useCodeForOptionSet: boolean;
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramRuleVariable, keyof D2ProgramRuleVariable>;
+        $identifiable: Preset<D2ProgramRuleVariable, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramRuleVariable, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramRuleVariable,
+            | "code"
+            | "programRuleVariableSourceType"
+            | "program"
+            | "trackedEntityAttribute"
+            | "lastUpdated"
+            | "id"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "useCodeForOptionSet"
+            | "dataElement"
+            | "name"
+        >;
+        $owner: Preset<
+            D2ProgramRuleVariable,
+            | "code"
+            | "programRuleVariableSourceType"
+            | "program"
+            | "trackedEntityAttribute"
+            | "lastUpdated"
+            | "id"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "useCodeForOptionSet"
+            | "dataElement"
+            | "name"
+        >;
+    };
+}
+
+export interface D2ProgramSectionSchema {
+    name: "D2ProgramSection";
+    model: D2ProgramSection;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         description: string;
@@ -11050,73 +11287,986 @@ export interface D2MapSchema {
         formName: string;
         href: string;
         id: Id;
-        interpretations: D2InterpretationSchema[];
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
-        latitude: number;
-        longitude: number;
-        mapViews: D2MapViewSchema[];
+        name: string;
+        program: D2ProgramSchema;
+        publicAccess: string;
+        renderType: any;
+        shortName: string;
+        sortOrder: number;
+        style: D2Style;
+        trackedEntityAttributes: D2TrackedEntityAttributeSchema[];
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramSection, keyof D2ProgramSection>;
+        $identifiable: Preset<D2ProgramSection, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramSection, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramSection,
+            | "code"
+            | "description"
+            | "program"
+            | "lastUpdated"
+            | "translations"
+            | "formName"
+            | "id"
+            | "renderType"
+            | "lastUpdatedBy"
+            | "created"
+            | "sortOrder"
+            | "name"
+            | "trackedEntityAttributes"
+            | "style"
+        >;
+        $owner: Preset<
+            D2ProgramSection,
+            | "code"
+            | "description"
+            | "program"
+            | "lastUpdated"
+            | "translations"
+            | "formName"
+            | "id"
+            | "renderType"
+            | "lastUpdatedBy"
+            | "created"
+            | "sortOrder"
+            | "name"
+            | "trackedEntityAttributes"
+            | "style"
+        >;
+    };
+}
+
+export interface D2ProgramStageSchema {
+    name: "D2ProgramStage";
+    model: D2ProgramStage;
+    fields: {
+        access: D2Access;
+        allowGenerateNextVisit: boolean;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        autoGenerateEvent: boolean;
+        blockEntryForm: boolean;
+        code: Id;
+        created: string;
+        dataEntryForm: D2DataEntryFormSchema;
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayGenerateEventBox: boolean;
+        displayName: string;
+        displayShortName: string;
+        dueDateLabel: string;
+        enableUserAssignment: boolean;
+        executionDateLabel: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
+        formName: string;
+        formType: "DEFAULT" | "CUSTOM" | "SECTION" | "SECTION_MULTIORG";
+        generatedByEnrollmentDate: boolean;
+        hideDueDate: boolean;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        minDaysFromStart: number;
+        name: string;
+        nextScheduleDate: D2DataElementSchema;
+        notificationTemplates: D2ProgramNotificationTemplateSchema[];
+        openAfterEnrollment: boolean;
+        periodType: string;
+        preGenerateUID: boolean;
+        program: D2ProgramSchema;
+        programStageDataElements: D2ProgramStageDataElementSchema[];
+        programStageSections: D2ProgramStageSectionSchema[];
+        publicAccess: string;
+        remindCompleted: boolean;
+        repeatable: boolean;
+        reportDateToUse: string;
+        shortName: string;
+        sortOrder: number;
+        standardInterval: number;
+        style: D2Style;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        validationStrategy: "ON_COMPLETE" | "ON_UPDATE_AND_INSERT";
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramStage, keyof D2ProgramStage>;
+        $identifiable: Preset<D2ProgramStage, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramStage, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramStage,
+            | "dataEntryForm"
+            | "allowGenerateNextVisit"
+            | "publicAccess"
+            | "reportDateToUse"
+            | "program"
+            | "lastUpdated"
+            | "programStageDataElements"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "generatedByEnrollmentDate"
+            | "created"
+            | "attributeValues"
+            | "sortOrder"
+            | "userAccesses"
+            | "name"
+            | "hideDueDate"
+            | "enableUserAssignment"
+            | "style"
+            | "minDaysFromStart"
+            | "standardInterval"
+            | "dueDateLabel"
+            | "executionDateLabel"
+            | "code"
+            | "preGenerateUID"
+            | "description"
+            | "notificationTemplates"
+            | "openAfterEnrollment"
+            | "repeatable"
+            | "formName"
+            | "featureType"
+            | "remindCompleted"
+            | "displayGenerateEventBox"
+            | "nextScheduleDate"
+            | "validationStrategy"
+            | "autoGenerateEvent"
+            | "periodType"
+            | "blockEntryForm"
+            | "user"
+            | "programStageSections"
+        >;
+        $owner: Preset<
+            D2ProgramStage,
+            | "dataEntryForm"
+            | "allowGenerateNextVisit"
+            | "publicAccess"
+            | "reportDateToUse"
+            | "program"
+            | "lastUpdated"
+            | "programStageDataElements"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "generatedByEnrollmentDate"
+            | "created"
+            | "attributeValues"
+            | "sortOrder"
+            | "userAccesses"
+            | "name"
+            | "hideDueDate"
+            | "enableUserAssignment"
+            | "style"
+            | "minDaysFromStart"
+            | "standardInterval"
+            | "dueDateLabel"
+            | "executionDateLabel"
+            | "code"
+            | "preGenerateUID"
+            | "description"
+            | "notificationTemplates"
+            | "openAfterEnrollment"
+            | "repeatable"
+            | "formName"
+            | "featureType"
+            | "remindCompleted"
+            | "displayGenerateEventBox"
+            | "nextScheduleDate"
+            | "validationStrategy"
+            | "autoGenerateEvent"
+            | "periodType"
+            | "blockEntryForm"
+            | "user"
+            | "programStageSections"
+        >;
+    };
+}
+
+export interface D2ProgramStageDataElementSchema {
+    name: "D2ProgramStageDataElement";
+    model: D2ProgramStageDataElement;
+    fields: {
+        access: D2Access;
+        allowFutureDate: boolean;
+        allowProvidedElsewhere: boolean;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        compulsory: boolean;
+        created: string;
+        dataElement: D2DataElementSchema;
+        displayInReports: boolean;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        programStage: D2ProgramStageSchema;
+        publicAccess: string;
+        renderOptionsAsRadio: boolean;
+        renderType: any;
+        skipSynchronization: boolean;
+        sortOrder: number;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramStageDataElement, keyof D2ProgramStageDataElement>;
+        $identifiable: Preset<D2ProgramStageDataElement, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramStageDataElement, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramStageDataElement,
+            | "displayInReports"
+            | "code"
+            | "skipSynchronization"
+            | "lastUpdated"
+            | "renderOptionsAsRadio"
+            | "id"
+            | "allowFutureDate"
+            | "renderType"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "dataElement"
+            | "compulsory"
+            | "allowProvidedElsewhere"
+            | "sortOrder"
+        >;
+        $owner: Preset<
+            D2ProgramStageDataElement,
+            | "displayInReports"
+            | "code"
+            | "skipSynchronization"
+            | "lastUpdated"
+            | "renderOptionsAsRadio"
+            | "id"
+            | "allowFutureDate"
+            | "renderType"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "dataElement"
+            | "compulsory"
+            | "allowProvidedElsewhere"
+            | "sortOrder"
+        >;
+    };
+}
+
+export interface D2ProgramStageInstanceSchema {
+    name: "D2ProgramStageInstance";
+    model: D2ProgramStageInstance;
+    fields: {
+        access: D2Access;
+        assignedUser: D2UserSchema;
+        attributeOptionCombo: D2CategoryOptionComboSchema;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        comments: any[];
+        completed: boolean;
+        completedBy: string;
+        completedDate: string;
+        creatableInSearchScope: boolean;
+        created: string;
+        createdAtClient: string;
+        deleted: boolean;
+        displayName: string;
+        dueDate: string;
+        eventDataValues: any[];
+        eventDate: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        geometry: D2Geometry;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedAtClient: string;
+        lastUpdatedBy: D2UserSchema;
+        messageConversations: D2MessageConversationSchema[];
+        name: string;
+        organisationUnit: D2OrganisationUnitSchema;
+        programInstance: D2ProgramInstanceSchema;
+        programStage: D2ProgramStageSchema;
+        publicAccess: string;
+        relationshipItems: any[];
+        status: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";
+        storedBy: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramStageInstance, keyof D2ProgramStageInstance>;
+        $identifiable: Preset<D2ProgramStageInstance, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramStageInstance, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramStageInstance,
+            | "code"
+            | "storedBy"
+            | "organisationUnit"
+            | "dueDate"
+            | "createdAtClient"
+            | "messageConversations"
+            | "lastUpdated"
+            | "eventDataValues"
+            | "relationshipItems"
+            | "id"
+            | "assignedUser"
+            | "programStage"
+            | "comments"
+            | "created"
+            | "completedDate"
+            | "programInstance"
+            | "deleted"
+            | "attributeOptionCombo"
+            | "geometry"
+            | "completedBy"
+            | "status"
+            | "lastUpdatedAtClient"
+            | "eventDate"
+        >;
+        $owner: Preset<
+            D2ProgramStageInstance,
+            | "code"
+            | "storedBy"
+            | "organisationUnit"
+            | "dueDate"
+            | "createdAtClient"
+            | "messageConversations"
+            | "lastUpdated"
+            | "eventDataValues"
+            | "id"
+            | "assignedUser"
+            | "programStage"
+            | "comments"
+            | "created"
+            | "completedDate"
+            | "programInstance"
+            | "deleted"
+            | "attributeOptionCombo"
+            | "geometry"
+            | "completedBy"
+            | "status"
+            | "lastUpdatedAtClient"
+            | "eventDate"
+        >;
+    };
+}
+
+export interface D2ProgramStageInstanceFilterSchema {
+    name: "D2ProgramStageInstanceFilter";
+    model: D2ProgramStageInstanceFilter;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        description: string;
+        displayName: string;
+        eventQueryCriteria: any;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        program: Id;
+        programStage: Id;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramStageInstanceFilter, keyof D2ProgramStageInstanceFilter>;
+        $identifiable: Preset<D2ProgramStageInstanceFilter, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramStageInstanceFilter, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramStageInstanceFilter,
+            | "lastUpdatedBy"
+            | "programStage"
+            | "eventQueryCriteria"
+            | "userGroupAccesses"
+            | "created"
+            | "publicAccess"
+            | "description"
+            | "program"
+            | "lastUpdated"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+        >;
+        $owner: Preset<
+            D2ProgramStageInstanceFilter,
+            | "lastUpdatedBy"
+            | "programStage"
+            | "eventQueryCriteria"
+            | "userGroupAccesses"
+            | "created"
+            | "publicAccess"
+            | "description"
+            | "program"
+            | "lastUpdated"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+        >;
+    };
+}
+
+export interface D2ProgramStageSectionSchema {
+    name: "D2ProgramStageSection";
+    model: D2ProgramStageSection;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        dataElements: D2DataElementSchema[];
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        programIndicators: D2ProgramIndicatorSchema[];
+        programStage: D2ProgramStageSchema;
+        publicAccess: string;
+        renderType: any;
+        shortName: string;
+        sortOrder: number;
+        style: D2Style;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramStageSection, keyof D2ProgramStageSection>;
+        $identifiable: Preset<D2ProgramStageSection, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramStageSection, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramStageSection,
+            | "code"
+            | "description"
+            | "programIndicators"
+            | "lastUpdated"
+            | "translations"
+            | "formName"
+            | "id"
+            | "renderType"
+            | "dataElements"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "sortOrder"
+            | "name"
+            | "style"
+        >;
+        $owner: Preset<
+            D2ProgramStageSection,
+            | "code"
+            | "description"
+            | "programIndicators"
+            | "lastUpdated"
+            | "translations"
+            | "formName"
+            | "id"
+            | "renderType"
+            | "dataElements"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "sortOrder"
+            | "name"
+            | "style"
+        >;
+    };
+}
+
+export interface D2ProgramTrackedEntityAttributeSchema {
+    name: "D2ProgramTrackedEntityAttribute";
+    model: D2ProgramTrackedEntityAttribute;
+    fields: {
+        access: D2Access;
+        allowFutureDate: boolean;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        displayInList: boolean;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        mandatory: boolean;
+        name: string;
+        program: D2ProgramSchema;
+        programTrackedEntityAttributeGroups: D2ProgramTrackedEntityAttributeGroupSchema[];
+        publicAccess: string;
+        renderOptionsAsRadio: boolean;
+        renderType: any;
+        searchable: boolean;
+        sortOrder: number;
+        trackedEntityAttribute: D2TrackedEntityAttributeSchema;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        valueType:
+            | "TEXT"
+            | "LONG_TEXT"
+            | "LETTER"
+            | "PHONE_NUMBER"
+            | "EMAIL"
+            | "BOOLEAN"
+            | "TRUE_ONLY"
+            | "DATE"
+            | "DATETIME"
+            | "TIME"
+            | "NUMBER"
+            | "UNIT_INTERVAL"
+            | "PERCENTAGE"
+            | "INTEGER"
+            | "INTEGER_POSITIVE"
+            | "INTEGER_NEGATIVE"
+            | "INTEGER_ZERO_OR_POSITIVE"
+            | "TRACKER_ASSOCIATE"
+            | "USERNAME"
+            | "COORDINATE"
+            | "ORGANISATION_UNIT"
+            | "AGE"
+            | "URL"
+            | "FILE_RESOURCE"
+            | "IMAGE";
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramTrackedEntityAttribute, keyof D2ProgramTrackedEntityAttribute>;
+        $identifiable: Preset<D2ProgramTrackedEntityAttribute, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramTrackedEntityAttribute, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramTrackedEntityAttribute,
+            | "code"
+            | "programTrackedEntityAttributeGroups"
+            | "program"
+            | "mandatory"
+            | "trackedEntityAttribute"
+            | "lastUpdated"
+            | "renderOptionsAsRadio"
+            | "id"
+            | "allowFutureDate"
+            | "renderType"
+            | "lastUpdatedBy"
+            | "created"
+            | "searchable"
+            | "displayInList"
+            | "sortOrder"
+        >;
+        $owner: Preset<
+            D2ProgramTrackedEntityAttribute,
+            | "code"
+            | "programTrackedEntityAttributeGroups"
+            | "program"
+            | "mandatory"
+            | "trackedEntityAttribute"
+            | "lastUpdated"
+            | "renderOptionsAsRadio"
+            | "id"
+            | "allowFutureDate"
+            | "renderType"
+            | "lastUpdatedBy"
+            | "created"
+            | "searchable"
+            | "displayInList"
+            | "sortOrder"
+        >;
+    };
+}
+
+export interface D2ProgramTrackedEntityAttributeDimensionItemSchema {
+    name: "D2ProgramTrackedEntityAttributeDimensionItem";
+    model: D2ProgramTrackedEntityAttributeDimensionItem;
+    fields: {
+        access: D2Access;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        attribute: D2TrackedEntityAttributeSchema;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        description: string;
+        dimensionItem: string;
+        dimensionItemType:
+            | "DATA_ELEMENT"
+            | "DATA_ELEMENT_OPERAND"
+            | "INDICATOR"
+            | "REPORTING_RATE"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION"
+            | "OPTION_GROUP"
+            | "DATA_ELEMENT_GROUP"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY_OPTION_GROUP";
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendSet: D2LegendSetSchema;
+        legendSets: D2LegendSetSchema[];
+        name: string;
+        program: D2ProgramSchema;
+        publicAccess: string;
+        shortName: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<
+            D2ProgramTrackedEntityAttributeDimensionItem,
+            keyof D2ProgramTrackedEntityAttributeDimensionItem
+        >;
+        $identifiable: Preset<
+            D2ProgramTrackedEntityAttributeDimensionItem,
+            FieldPresets["identifiable"]
+        >;
+        $nameable: Preset<D2ProgramTrackedEntityAttributeDimensionItem, FieldPresets["nameable"]>;
+        $persisted: Preset<D2ProgramTrackedEntityAttributeDimensionItem, never>;
+        $owner: Preset<D2ProgramTrackedEntityAttributeDimensionItem, never>;
+    };
+}
+
+export interface D2ProgramTrackedEntityAttributeGroupSchema {
+    name: "D2ProgramTrackedEntityAttributeGroup";
+    model: D2ProgramTrackedEntityAttributeGroup;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        attributes: D2ProgramTrackedEntityAttributeSchema[];
+        code: Id;
+        created: string;
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
         name: string;
         publicAccess: string;
         shortName: string;
-        subscribed: boolean;
-        subscribers: string[];
+        translations: D2Translation[];
+        uniqunessType: "NONE" | "STRICT" | "VALIDATION";
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<
+            D2ProgramTrackedEntityAttributeGroup,
+            keyof D2ProgramTrackedEntityAttributeGroup
+        >;
+        $identifiable: Preset<D2ProgramTrackedEntityAttributeGroup, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramTrackedEntityAttributeGroup, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramTrackedEntityAttributeGroup,
+            | "code"
+            | "uniqunessType"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "created"
+            | "name"
+            | "attributes"
+            | "shortName"
+        >;
+        $owner: Preset<
+            D2ProgramTrackedEntityAttributeGroup,
+            | "code"
+            | "uniqunessType"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "created"
+            | "name"
+            | "shortName"
+        >;
+    };
+}
+
+export interface D2PushAnalysisSchema {
+    name: "D2PushAnalysis";
+    model: D2PushAnalysis;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        dashboard: D2DashboardSchema;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        message: string;
+        name: string;
+        publicAccess: string;
+        recipientUserGroups: D2UserGroupSchema[];
         title: string;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
-        zoom: number;
     };
     fieldPresets: {
-        $all: Preset<D2Map, keyof D2Map>;
-        $identifiable: Preset<D2Map, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Map, FieldPresets["nameable"]>;
+        $all: Preset<D2PushAnalysis, keyof D2PushAnalysis>;
+        $identifiable: Preset<D2PushAnalysis, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2PushAnalysis, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2Map,
-            | "favorites"
+            D2PushAnalysis,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "recipientUserGroups"
+            | "message"
+            | "title"
+            | "lastUpdated"
+            | "name"
+            | "id"
+            | "dashboard"
+        >;
+        $owner: Preset<
+            D2PushAnalysis,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "recipientUserGroups"
+            | "message"
+            | "title"
+            | "lastUpdated"
+            | "name"
+            | "id"
+            | "dashboard"
+        >;
+    };
+}
+
+export interface D2RelationshipSchema {
+    name: "D2Relationship";
+    model: D2Relationship;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        from: any;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        relationshipType: D2RelationshipTypeSchema;
+        shortName: string;
+        style: D2Style;
+        to: any;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2Relationship, keyof D2Relationship>;
+        $identifiable: Preset<D2Relationship, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Relationship, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Relationship,
+            | "code"
+            | "description"
+            | "lastUpdated"
+            | "formName"
+            | "from"
+            | "id"
+            | "lastUpdatedBy"
+            | "relationshipType"
+            | "created"
+            | "style"
+            | "to"
+        >;
+        $owner: Preset<
+            D2Relationship,
+            | "code"
+            | "description"
+            | "lastUpdated"
+            | "formName"
+            | "from"
+            | "id"
+            | "lastUpdatedBy"
+            | "relationshipType"
+            | "created"
+            | "style"
+            | "to"
+        >;
+    };
+}
+
+export interface D2RelationshipTypeSchema {
+    name: "D2RelationshipType";
+    model: D2RelationshipType;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        bidirectional: boolean;
+        code: Id;
+        created: string;
+        description: string;
+        displayFromToName: string;
+        displayName: string;
+        displayToFromName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        fromConstraint: D2RelationshipConstraint;
+        fromToName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        toConstraint: D2RelationshipConstraint;
+        toFromName: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2RelationshipType, keyof D2RelationshipType>;
+        $identifiable: Preset<D2RelationshipType, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2RelationshipType, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2RelationshipType,
+            | "bidirectional"
             | "code"
             | "publicAccess"
-            | "basemap"
-            | "latitude"
             | "description"
-            | "title"
-            | "externalAccess"
+            | "fromToName"
             | "lastUpdated"
             | "translations"
-            | "mapViews"
+            | "toConstraint"
             | "id"
-            | "interpretations"
-            | "longitude"
             | "lastUpdatedBy"
             | "userGroupAccesses"
-            | "subscribers"
             | "created"
-            | "zoom"
+            | "toFromName"
+            | "fromConstraint"
             | "userAccesses"
             | "name"
             | "user"
         >;
         $owner: Preset<
-            D2Map,
-            | "favorites"
+            D2RelationshipType,
+            | "bidirectional"
             | "code"
             | "publicAccess"
-            | "basemap"
-            | "latitude"
             | "description"
-            | "title"
-            | "externalAccess"
+            | "fromToName"
             | "lastUpdated"
             | "translations"
-            | "mapViews"
+            | "toConstraint"
             | "id"
-            | "longitude"
             | "lastUpdatedBy"
             | "userGroupAccesses"
-            | "subscribers"
             | "created"
-            | "zoom"
+            | "toFromName"
+            | "fromConstraint"
             | "userAccesses"
             | "name"
             | "user"
@@ -11447,2207 +12597,6 @@ export interface D2ReportTableSchema {
     };
 }
 
-export interface D2ChartSchema {
-    name: "D2Chart";
-    model: D2Chart;
-    fields: {
-        access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "FIRST"
-            | "FIRST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
-        attributeDimensions: any[];
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        baseLineLabel: string;
-        baseLineValue: number;
-        category: string;
-        categoryDimensions: D2CategoryDimensionSchema[];
-        categoryOptionGroupSetDimensions: D2CategoryOptionGroupSetDimensionSchema[];
-        code: Id;
-        colorSet: D2ColorSetSchema;
-        columns: any[];
-        completedOnly: boolean;
-        created: string;
-        cumulativeValues: boolean;
-        dataDimensionItems: any[];
-        dataElementDimensions: D2TrackedEntityDataElementDimensionSchema[];
-        dataElementGroupSetDimensions: D2DataElementGroupSetDimensionSchema[];
-        description: string;
-        digitGroupSeparator: "COMMA" | "SPACE" | "NONE";
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        domainAxisLabel: string;
-        endDate: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        filterDimensions: string[];
-        filters: any[];
-        formName: string;
-        hideEmptyRowItems:
-            | "NONE"
-            | "BEFORE_FIRST"
-            | "AFTER_LAST"
-            | "BEFORE_FIRST_AFTER_LAST"
-            | "ALL";
-        hideLegend: boolean;
-        hideSubtitle: boolean;
-        hideTitle: boolean;
-        href: string;
-        id: Id;
-        interpretations: D2InterpretationSchema[];
-        itemOrganisationUnitGroups: D2OrganisationUnitGroupSchema[];
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        legendDisplayStrategy: "FIXED" | "BY_DATA_ITEM";
-        legendSet: D2LegendSetSchema;
-        name: string;
-        noSpaceBetweenColumns: boolean;
-        orgUnitField: string;
-        organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimensionSchema[];
-        organisationUnitLevels: number[];
-        organisationUnits: D2OrganisationUnitSchema[];
-        parentGraphMap: D2MapSchema;
-        percentStackedValues: boolean;
-        periods: any[];
-        programIndicatorDimensions: D2TrackedEntityProgramIndicatorDimensionSchema[];
-        publicAccess: string;
-        rangeAxisDecimals: number;
-        rangeAxisLabel: string;
-        rangeAxisMaxValue: number;
-        rangeAxisMinValue: number;
-        rangeAxisSteps: number;
-        regressionType: "NONE" | "LINEAR" | "POLYNOMIAL" | "LOESS";
-        relativePeriods: any;
-        rows: any[];
-        series: string;
-        seriesItems: any[];
-        shortName: string;
-        showData: boolean;
-        sortOrder: number;
-        startDate: string;
-        subscribed: boolean;
-        subscribers: string[];
-        subtitle: string;
-        targetLineLabel: string;
-        targetLineValue: number;
-        timeField: string;
-        title: string;
-        topLimit: number;
-        translations: D2Translation[];
-        type:
-            | "COLUMN"
-            | "STACKED_COLUMN"
-            | "BAR"
-            | "STACKED_BAR"
-            | "LINE"
-            | "AREA"
-            | "PIE"
-            | "RADAR"
-            | "GAUGE"
-            | "YEAR_OVER_YEAR_LINE"
-            | "YEAR_OVER_YEAR_COLUMN"
-            | "SINGLE_VALUE";
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        userOrganisationUnit: boolean;
-        userOrganisationUnitChildren: boolean;
-        userOrganisationUnitGrandChildren: boolean;
-        yearlySeries: string[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Chart, keyof D2Chart>;
-        $identifiable: Preset<D2Chart, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Chart, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Chart,
-            | "dataElementGroupSetDimensions"
-            | "showData"
-            | "endDate"
-            | "baseLineValue"
-            | "publicAccess"
-            | "userOrganisationUnitChildren"
-            | "type"
-            | "lastUpdated"
-            | "translations"
-            | "yearlySeries"
-            | "userOrganisationUnit"
-            | "filterDimensions"
-            | "id"
-            | "interpretations"
-            | "itemOrganisationUnitGroups"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "domainAxisLabel"
-            | "created"
-            | "subscribers"
-            | "rangeAxisLabel"
-            | "regressionType"
-            | "completedOnly"
-            | "cumulativeValues"
-            | "subtitle"
-            | "sortOrder"
-            | "userAccesses"
-            | "name"
-            | "rangeAxisDecimals"
-            | "startDate"
-            | "hideEmptyRowItems"
-            | "favorites"
-            | "dataDimensionItems"
-            | "aggregationType"
-            | "code"
-            | "categoryOptionGroupSetDimensions"
-            | "userOrganisationUnitGrandChildren"
-            | "hideSubtitle"
-            | "description"
-            | "organisationUnitGroupSetDimensions"
-            | "title"
-            | "hideLegend"
-            | "organisationUnitLevels"
-            | "externalAccess"
-            | "rangeAxisMinValue"
-            | "percentStackedValues"
-            | "seriesItems"
-            | "legendDisplayStrategy"
-            | "noSpaceBetweenColumns"
-            | "relativePeriods"
-            | "rangeAxisSteps"
-            | "targetLineLabel"
-            | "periods"
-            | "organisationUnits"
-            | "categoryDimensions"
-            | "targetLineValue"
-            | "baseLineLabel"
-            | "hideTitle"
-            | "series"
-            | "legendSet"
-            | "rangeAxisMaxValue"
-            | "colorSet"
-            | "category"
-            | "user"
-        >;
-        $owner: Preset<
-            D2Chart,
-            | "dataElementGroupSetDimensions"
-            | "showData"
-            | "endDate"
-            | "baseLineValue"
-            | "publicAccess"
-            | "userOrganisationUnitChildren"
-            | "type"
-            | "lastUpdated"
-            | "translations"
-            | "yearlySeries"
-            | "userOrganisationUnit"
-            | "filterDimensions"
-            | "id"
-            | "itemOrganisationUnitGroups"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "domainAxisLabel"
-            | "created"
-            | "subscribers"
-            | "rangeAxisLabel"
-            | "regressionType"
-            | "completedOnly"
-            | "cumulativeValues"
-            | "subtitle"
-            | "sortOrder"
-            | "userAccesses"
-            | "name"
-            | "rangeAxisDecimals"
-            | "startDate"
-            | "hideEmptyRowItems"
-            | "favorites"
-            | "dataDimensionItems"
-            | "aggregationType"
-            | "code"
-            | "categoryOptionGroupSetDimensions"
-            | "userOrganisationUnitGrandChildren"
-            | "hideSubtitle"
-            | "description"
-            | "organisationUnitGroupSetDimensions"
-            | "title"
-            | "hideLegend"
-            | "organisationUnitLevels"
-            | "externalAccess"
-            | "rangeAxisMinValue"
-            | "percentStackedValues"
-            | "seriesItems"
-            | "legendDisplayStrategy"
-            | "noSpaceBetweenColumns"
-            | "relativePeriods"
-            | "rangeAxisSteps"
-            | "targetLineLabel"
-            | "periods"
-            | "organisationUnits"
-            | "categoryDimensions"
-            | "targetLineValue"
-            | "baseLineLabel"
-            | "hideTitle"
-            | "series"
-            | "legendSet"
-            | "rangeAxisMaxValue"
-            | "colorSet"
-            | "category"
-            | "user"
-        >;
-    };
-}
-
-export interface D2ValidationResultSchema {
-    name: "D2ValidationResult";
-    model: D2ValidationResult;
-    fields: {
-        attributeOptionCombo: D2CategoryOptionComboSchema;
-        created: string;
-        dayInPeriod: number;
-        id: string;
-        leftsideValue: number;
-        notificationSent: boolean;
-        organisationUnit: D2OrganisationUnitSchema;
-        period: any;
-        rightsideValue: number;
-        validationRule: D2ValidationRuleSchema;
-    };
-    fieldPresets: {
-        $all: Preset<D2ValidationResult, keyof D2ValidationResult>;
-        $identifiable: Preset<D2ValidationResult, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ValidationResult, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ValidationResult,
-            "created" | "rightsideValue" | "leftsideValue" | "notificationSent"
-        >;
-        $owner: Preset<
-            D2ValidationResult,
-            "created" | "rightsideValue" | "leftsideValue" | "notificationSent"
-        >;
-    };
-}
-
-export interface D2DocumentSchema {
-    name: "D2Document";
-    model: D2Document;
-    fields: {
-        access: D2Access;
-        attachment: boolean;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        contentType: string;
-        created: string;
-        displayName: string;
-        external: boolean;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        url: string;
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Document, keyof D2Document>;
-        $identifiable: Preset<D2Document, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Document, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Document,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "url"
-            | "externalAccess"
-            | "lastUpdated"
-            | "external"
-            | "attachment"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-            | "contentType"
-        >;
-        $owner: Preset<
-            D2Document,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "url"
-            | "externalAccess"
-            | "lastUpdated"
-            | "external"
-            | "attachment"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-            | "contentType"
-        >;
-    };
-}
-
-export interface D2ExternalMapLayerSchema {
-    name: "D2ExternalMapLayer";
-    model: D2ExternalMapLayer;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        attribution: string;
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        imageFormat: "PNG" | "JPG";
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        layers: string;
-        legendSet: D2LegendSetSchema;
-        legendSetUrl: string;
-        mapLayerPosition: "BASEMAP" | "OVERLAY";
-        mapService: "WMS" | "TMS" | "XYZ";
-        name: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        url: string;
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ExternalMapLayer, keyof D2ExternalMapLayer>;
-        $identifiable: Preset<D2ExternalMapLayer, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ExternalMapLayer, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ExternalMapLayer,
-            | "imageFormat"
-            | "code"
-            | "publicAccess"
-            | "legendSetUrl"
-            | "mapService"
-            | "lastUpdated"
-            | "layers"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "mapLayerPosition"
-            | "url"
-            | "userAccesses"
-            | "name"
-            | "legendSet"
-            | "attribution"
-            | "user"
-        >;
-        $owner: Preset<
-            D2ExternalMapLayer,
-            | "imageFormat"
-            | "code"
-            | "publicAccess"
-            | "legendSetUrl"
-            | "mapService"
-            | "lastUpdated"
-            | "layers"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "mapLayerPosition"
-            | "url"
-            | "userAccesses"
-            | "name"
-            | "legendSet"
-            | "attribution"
-            | "user"
-        >;
-    };
-}
-
-export interface D2PredictorSchema {
-    name: "D2Predictor";
-    model: D2Predictor;
-    fields: {
-        access: D2Access;
-        annualSampleCount: number;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        generator: D2ExpressionSchema;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        organisationUnitLevels: D2OrganisationUnitLevelSchema[];
-        output: D2DataElementSchema;
-        outputCombo: D2CategoryOptionComboSchema;
-        periodType: string;
-        predictorGroups: D2PredictorGroupSchema[];
-        publicAccess: string;
-        sampleSkipTest: D2ExpressionSchema;
-        sequentialSampleCount: number;
-        sequentialSkipCount: number;
-        shortName: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Predictor, keyof D2Predictor>;
-        $identifiable: Preset<D2Predictor, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Predictor, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Predictor,
-            | "outputCombo"
-            | "code"
-            | "description"
-            | "generator"
-            | "organisationUnitLevels"
-            | "output"
-            | "lastUpdated"
-            | "sampleSkipTest"
-            | "id"
-            | "sequentialSampleCount"
-            | "annualSampleCount"
-            | "lastUpdatedBy"
-            | "created"
-            | "sequentialSkipCount"
-            | "predictorGroups"
-            | "periodType"
-            | "name"
-        >;
-        $owner: Preset<
-            D2Predictor,
-            | "outputCombo"
-            | "code"
-            | "description"
-            | "generator"
-            | "organisationUnitLevels"
-            | "output"
-            | "lastUpdated"
-            | "sampleSkipTest"
-            | "id"
-            | "sequentialSampleCount"
-            | "annualSampleCount"
-            | "lastUpdatedBy"
-            | "created"
-            | "sequentialSkipCount"
-            | "periodType"
-            | "name"
-        >;
-    };
-}
-
-export interface D2PredictorGroupSchema {
-    name: "D2PredictorGroup";
-    model: D2PredictorGroup;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        description: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        predictors: D2PredictorSchema[];
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2PredictorGroup, keyof D2PredictorGroup>;
-        $identifiable: Preset<D2PredictorGroup, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2PredictorGroup, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2PredictorGroup,
-            | "predictors"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "description"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2PredictorGroup,
-            | "predictors"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "description"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
-export interface D2DashboardItemSchema {
-    name: "D2DashboardItem";
-    model: D2DashboardItem;
-    fields: {
-        access: D2Access;
-        appKey: string;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        chart: D2ChartSchema;
-        code: Id;
-        contentCount: number;
-        created: string;
-        displayName: string;
-        eventChart: D2EventChartSchema;
-        eventReport: D2EventReportSchema;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        height: number;
-        href: string;
-        id: Id;
-        interpretationCount: number;
-        interpretationLikeCount: number;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        map: D2MapSchema;
-        messages: boolean;
-        name: string;
-        publicAccess: string;
-        reportTable: D2ReportTableSchema;
-        reports: D2ReportSchema[];
-        resources: D2DocumentSchema[];
-        shape: "NORMAL" | "DOUBLE_WIDTH" | "FULL_WIDTH";
-        text: string;
-        translations: D2Translation[];
-        type:
-            | "CHART"
-            | "EVENT_CHART"
-            | "MAP"
-            | "REPORT_TABLE"
-            | "EVENT_REPORT"
-            | "USERS"
-            | "REPORTS"
-            | "RESOURCES"
-            | "TEXT"
-            | "MESSAGES"
-            | "APP";
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        users: D2UserSchema[];
-        width: number;
-        x: number;
-        y: number;
-    };
-    fieldPresets: {
-        $all: Preset<D2DashboardItem, keyof D2DashboardItem>;
-        $identifiable: Preset<D2DashboardItem, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2DashboardItem, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2DashboardItem,
-            | "reports"
-            | "code"
-            | "reportTable"
-            | "lastUpdated"
-            | "translations"
-            | "appKey"
-            | "id"
-            | "text"
-            | "map"
-            | "height"
-            | "lastUpdatedBy"
-            | "shape"
-            | "created"
-            | "resources"
-            | "users"
-            | "eventReport"
-            | "eventChart"
-            | "width"
-            | "x"
-            | "messages"
-            | "y"
-            | "chart"
-        >;
-        $owner: Preset<
-            D2DashboardItem,
-            | "reports"
-            | "code"
-            | "reportTable"
-            | "lastUpdated"
-            | "translations"
-            | "appKey"
-            | "id"
-            | "text"
-            | "map"
-            | "height"
-            | "lastUpdatedBy"
-            | "shape"
-            | "created"
-            | "resources"
-            | "users"
-            | "eventReport"
-            | "eventChart"
-            | "width"
-            | "x"
-            | "messages"
-            | "y"
-            | "chart"
-        >;
-    };
-}
-
-export interface D2DashboardSchema {
-    name: "D2Dashboard";
-    model: D2Dashboard;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        dashboardItems: D2DashboardItemSchema[];
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        itemCount: number;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        shortName: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Dashboard, keyof D2Dashboard>;
-        $identifiable: Preset<D2Dashboard, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Dashboard, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Dashboard,
-            | "favorites"
-            | "code"
-            | "publicAccess"
-            | "description"
-            | "externalAccess"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "dashboardItems"
-            | "userAccesses"
-            | "name"
-            | "user"
-        >;
-        $owner: Preset<
-            D2Dashboard,
-            | "favorites"
-            | "code"
-            | "publicAccess"
-            | "description"
-            | "externalAccess"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "dashboardItems"
-            | "userAccesses"
-            | "name"
-            | "user"
-        >;
-    };
-}
-
-export interface D2PushAnalysisSchema {
-    name: "D2PushAnalysis";
-    model: D2PushAnalysis;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        dashboard: D2DashboardSchema;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        message: string;
-        name: string;
-        publicAccess: string;
-        recipientUserGroups: D2UserGroupSchema[];
-        title: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2PushAnalysis, keyof D2PushAnalysis>;
-        $identifiable: Preset<D2PushAnalysis, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2PushAnalysis, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2PushAnalysis,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "recipientUserGroups"
-            | "message"
-            | "title"
-            | "lastUpdated"
-            | "name"
-            | "id"
-            | "dashboard"
-        >;
-        $owner: Preset<
-            D2PushAnalysis,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "recipientUserGroups"
-            | "message"
-            | "title"
-            | "lastUpdated"
-            | "name"
-            | "id"
-            | "dashboard"
-        >;
-    };
-}
-
-export interface D2KeyJsonValueSchema {
-    name: "D2KeyJsonValue";
-    model: D2KeyJsonValue;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        key: string;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        namespace: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        value: string;
-    };
-    fieldPresets: {
-        $all: Preset<D2KeyJsonValue, keyof D2KeyJsonValue>;
-        $identifiable: Preset<D2KeyJsonValue, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2KeyJsonValue, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2KeyJsonValue,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "lastUpdated"
-            | "userAccesses"
-            | "namespace"
-            | "id"
-            | "user"
-            | "key"
-        >;
-        $owner: Preset<
-            D2KeyJsonValue,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "lastUpdated"
-            | "userAccesses"
-            | "namespace"
-            | "id"
-            | "user"
-            | "key"
-        >;
-    };
-}
-
-export interface D2InterpretationCommentSchema {
-    name: "D2InterpretationComment";
-    model: D2InterpretationComment;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        mentions: any[];
-        name: string;
-        publicAccess: string;
-        text: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2InterpretationComment, keyof D2InterpretationComment>;
-        $identifiable: Preset<D2InterpretationComment, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2InterpretationComment, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2InterpretationComment,
-            "created" | "lastUpdated" | "mentions" | "text" | "id" | "user"
-        >;
-        $owner: Preset<
-            D2InterpretationComment,
-            "created" | "lastUpdated" | "mentions" | "text" | "id" | "user"
-        >;
-    };
-}
-
-export interface D2TrackedEntityInstanceSchema {
-    name: "D2TrackedEntityInstance";
-    model: D2TrackedEntityInstance;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        createdAtClient: string;
-        deleted: boolean;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        geometry: D2Geometry;
-        href: string;
-        id: Id;
-        inactive: boolean;
-        lastUpdated: string;
-        lastUpdatedAtClient: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        organisationUnit: D2OrganisationUnitSchema;
-        programInstances: D2ProgramInstanceSchema[];
-        programOwners: any[];
-        publicAccess: string;
-        relationshipItems: any[];
-        trackedEntityAttributeValues: D2TrackedEntityAttributeValueSchema[];
-        trackedEntityType: D2TrackedEntityTypeSchema;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2TrackedEntityInstance, keyof D2TrackedEntityInstance>;
-        $identifiable: Preset<D2TrackedEntityInstance, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2TrackedEntityInstance, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2TrackedEntityInstance,
-            | "programOwners"
-            | "code"
-            | "programInstances"
-            | "organisationUnit"
-            | "createdAtClient"
-            | "lastUpdated"
-            | "inactive"
-            | "relationshipItems"
-            | "id"
-            | "lastUpdatedBy"
-            | "created"
-            | "deleted"
-            | "trackedEntityType"
-            | "geometry"
-            | "trackedEntityAttributeValues"
-            | "lastUpdatedAtClient"
-        >;
-        $owner: Preset<
-            D2TrackedEntityInstance,
-            | "code"
-            | "organisationUnit"
-            | "createdAtClient"
-            | "lastUpdated"
-            | "inactive"
-            | "id"
-            | "lastUpdatedBy"
-            | "created"
-            | "deleted"
-            | "trackedEntityType"
-            | "geometry"
-            | "lastUpdatedAtClient"
-        >;
-    };
-}
-
-export interface D2LegendSchema {
-    name: "D2Legend";
-    model: D2Legend;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        color: string;
-        created: string;
-        displayName: string;
-        endValue: number;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        image: string;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        startValue: number;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Legend, keyof D2Legend>;
-        $identifiable: Preset<D2Legend, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Legend, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Legend,
-            | "lastUpdatedBy"
-            | "image"
-            | "code"
-            | "endValue"
-            | "color"
-            | "created"
-            | "lastUpdated"
-            | "translations"
-            | "name"
-            | "startValue"
-            | "id"
-        >;
-        $owner: Preset<
-            D2Legend,
-            | "lastUpdatedBy"
-            | "image"
-            | "code"
-            | "endValue"
-            | "color"
-            | "created"
-            | "lastUpdated"
-            | "translations"
-            | "name"
-            | "startValue"
-            | "id"
-        >;
-    };
-}
-
-export interface D2MessageConversationSchema {
-    name: "D2MessageConversation";
-    model: D2MessageConversation;
-    fields: {
-        access: D2Access;
-        assignee: D2UserSchema;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        followUp: boolean;
-        href: string;
-        id: Id;
-        lastMessage: string;
-        lastSender: D2UserSchema;
-        lastSenderFirstname: string;
-        lastSenderSurname: string;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        messageCount: number;
-        messageType: "PRIVATE" | "SYSTEM" | "VALIDATION_RESULT" | "TICKET";
-        messages: any[];
-        name: string;
-        priority: "NONE" | "LOW" | "MEDIUM" | "HIGH";
-        publicAccess: string;
-        read: boolean;
-        status: "NONE" | "OPEN" | "PENDING" | "INVALID" | "SOLVED";
-        subject: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userFirstname: string;
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        userMessages: any[];
-        userSurname: string;
-    };
-    fieldPresets: {
-        $all: Preset<D2MessageConversation, keyof D2MessageConversation>;
-        $identifiable: Preset<D2MessageConversation, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2MessageConversation, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2MessageConversation,
-            | "messageCount"
-            | "subject"
-            | "lastUpdated"
-            | "messageType"
-            | "userMessages"
-            | "id"
-            | "lastSender"
-            | "created"
-            | "lastMessage"
-            | "priority"
-            | "messages"
-            | "assignee"
-            | "user"
-            | "status"
-        >;
-        $owner: Preset<
-            D2MessageConversation,
-            | "messageCount"
-            | "subject"
-            | "lastUpdated"
-            | "messageType"
-            | "userMessages"
-            | "id"
-            | "lastSender"
-            | "created"
-            | "lastMessage"
-            | "priority"
-            | "messages"
-            | "assignee"
-            | "user"
-            | "status"
-        >;
-    };
-}
-
-export interface D2UserAccessSchema {
-    name: "D2UserAccess";
-    model: D2UserAccess;
-    fields: { access: string; displayName: string; id: string; userUid: string };
-    fieldPresets: {
-        $all: Preset<D2UserAccess, keyof D2UserAccess>;
-        $identifiable: Preset<D2UserAccess, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2UserAccess, FieldPresets["nameable"]>;
-        $persisted: Preset<D2UserAccess, "access">;
-        $owner: Preset<D2UserAccess, "access">;
-    };
-}
-
-export interface D2MetadataVersionSchema {
-    name: "D2MetadataVersion";
-    model: D2MetadataVersion;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        hashCode: string;
-        href: string;
-        id: Id;
-        importDate: string;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        type: "BEST_EFFORT" | "ATOMIC";
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2MetadataVersion, keyof D2MetadataVersion>;
-        $identifiable: Preset<D2MetadataVersion, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2MetadataVersion, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2MetadataVersion,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "type"
-            | "lastUpdated"
-            | "importDate"
-            | "hashCode"
-            | "name"
-            | "id"
-        >;
-        $owner: Preset<
-            D2MetadataVersion,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "type"
-            | "lastUpdated"
-            | "importDate"
-            | "hashCode"
-            | "name"
-            | "id"
-        >;
-    };
-}
-
-export interface D2DataElementOperandSchema {
-    name: "D2DataElementOperand";
-    model: D2DataElementOperand;
-    fields: {
-        access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "FIRST"
-            | "FIRST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
-        attributeOptionCombo: D2CategoryOptionComboSchema;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        categoryOptionCombo: D2CategoryOptionComboSchema;
-        code: Id;
-        created: string;
-        dataElement: D2DataElementSchema;
-        description: string;
-        dimensionItem: string;
-        dimensionItemType:
-            | "DATA_ELEMENT"
-            | "DATA_ELEMENT_OPERAND"
-            | "INDICATOR"
-            | "REPORTING_RATE"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION"
-            | "OPTION_GROUP"
-            | "DATA_ELEMENT_GROUP"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY_OPTION_GROUP";
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        legendSet: D2LegendSetSchema;
-        legendSets: D2LegendSetSchema[];
-        name: string;
-        publicAccess: string;
-        shortName: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2DataElementOperand, keyof D2DataElementOperand>;
-        $identifiable: Preset<D2DataElementOperand, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2DataElementOperand, FieldPresets["nameable"]>;
-        $persisted: Preset<D2DataElementOperand, "categoryOptionCombo" | "dataElement">;
-        $owner: Preset<D2DataElementOperand, "categoryOptionCombo" | "dataElement">;
-    };
-}
-
-export interface D2AnalyticsPeriodBoundarySchema {
-    name: "D2AnalyticsPeriodBoundary";
-    model: D2AnalyticsPeriodBoundary;
-    fields: {
-        access: D2Access;
-        analyticsPeriodBoundaryType:
-            | "BEFORE_START_OF_REPORTING_PERIOD"
-            | "BEFORE_END_OF_REPORTING_PERIOD"
-            | "AFTER_START_OF_REPORTING_PERIOD"
-            | "AFTER_END_OF_REPORTING_PERIOD";
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        boundaryTarget: string;
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        offsetPeriodType: string;
-        offsetPeriods: number;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2AnalyticsPeriodBoundary, keyof D2AnalyticsPeriodBoundary>;
-        $identifiable: Preset<D2AnalyticsPeriodBoundary, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2AnalyticsPeriodBoundary, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2AnalyticsPeriodBoundary,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "lastUpdated"
-            | "offsetPeriodType"
-            | "id"
-            | "analyticsPeriodBoundaryType"
-            | "boundaryTarget"
-            | "offsetPeriods"
-        >;
-        $owner: Preset<
-            D2AnalyticsPeriodBoundary,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "lastUpdated"
-            | "offsetPeriodType"
-            | "id"
-            | "analyticsPeriodBoundaryType"
-            | "boundaryTarget"
-            | "offsetPeriods"
-        >;
-    };
-}
-
-export interface D2ProgramInstanceSchema {
-    name: "D2ProgramInstance";
-    model: D2ProgramInstance;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        completedBy: string;
-        created: string;
-        createdAtClient: string;
-        deleted: boolean;
-        displayName: string;
-        endDate: string;
-        enrollmentDate: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        followup: boolean;
-        geometry: D2Geometry;
-        href: string;
-        id: Id;
-        incidentDate: string;
-        lastUpdated: string;
-        lastUpdatedAtClient: string;
-        lastUpdatedBy: D2UserSchema;
-        messageConversations: D2MessageConversationSchema[];
-        name: string;
-        organisationUnit: D2OrganisationUnitSchema;
-        program: D2ProgramSchema;
-        programStageInstances: D2ProgramStageInstanceSchema[];
-        publicAccess: string;
-        relationshipItems: any[];
-        status: "ACTIVE" | "COMPLETED" | "CANCELLED";
-        storedBy: string;
-        trackedEntityComments: any[];
-        trackedEntityInstance: D2TrackedEntityInstanceSchema;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramInstance, keyof D2ProgramInstance>;
-        $identifiable: Preset<D2ProgramInstance, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramInstance, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramInstance,
-            | "storedBy"
-            | "endDate"
-            | "organisationUnit"
-            | "enrollmentDate"
-            | "createdAtClient"
-            | "program"
-            | "messageConversations"
-            | "trackedEntityComments"
-            | "lastUpdated"
-            | "relationshipItems"
-            | "id"
-            | "created"
-            | "programStageInstances"
-            | "trackedEntityInstance"
-            | "followup"
-            | "deleted"
-            | "geometry"
-            | "incidentDate"
-            | "completedBy"
-            | "status"
-            | "lastUpdatedAtClient"
-        >;
-        $owner: Preset<
-            D2ProgramInstance,
-            | "storedBy"
-            | "endDate"
-            | "organisationUnit"
-            | "enrollmentDate"
-            | "createdAtClient"
-            | "program"
-            | "messageConversations"
-            | "trackedEntityComments"
-            | "lastUpdated"
-            | "id"
-            | "created"
-            | "programStageInstances"
-            | "trackedEntityInstance"
-            | "followup"
-            | "deleted"
-            | "geometry"
-            | "incidentDate"
-            | "completedBy"
-            | "status"
-            | "lastUpdatedAtClient"
-        >;
-    };
-}
-
-export interface D2TrackedEntityDataElementDimensionSchema {
-    name: "D2TrackedEntityDataElementDimension";
-    model: D2TrackedEntityDataElementDimension;
-    fields: {
-        dataElement: D2DataElementSchema;
-        filter: string;
-        legendSet: D2LegendSetSchema;
-        programStage: D2ProgramStageSchema;
-    };
-    fieldPresets: {
-        $all: Preset<
-            D2TrackedEntityDataElementDimension,
-            keyof D2TrackedEntityDataElementDimension
-        >;
-        $identifiable: Preset<D2TrackedEntityDataElementDimension, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2TrackedEntityDataElementDimension, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2TrackedEntityDataElementDimension,
-            "filter" | "legendSet" | "programStage" | "dataElement"
-        >;
-        $owner: Preset<
-            D2TrackedEntityDataElementDimension,
-            "filter" | "legendSet" | "programStage" | "dataElement"
-        >;
-    };
-}
-
-export interface D2ProgramStageInstanceFilterSchema {
-    name: "D2ProgramStageInstanceFilter";
-    model: D2ProgramStageInstanceFilter;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        description: string;
-        displayName: string;
-        eventQueryCriteria: any;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        program: Id;
-        programStage: Id;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramStageInstanceFilter, keyof D2ProgramStageInstanceFilter>;
-        $identifiable: Preset<D2ProgramStageInstanceFilter, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramStageInstanceFilter, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramStageInstanceFilter,
-            | "lastUpdatedBy"
-            | "programStage"
-            | "eventQueryCriteria"
-            | "userGroupAccesses"
-            | "created"
-            | "publicAccess"
-            | "description"
-            | "program"
-            | "lastUpdated"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2ProgramStageInstanceFilter,
-            | "lastUpdatedBy"
-            | "programStage"
-            | "eventQueryCriteria"
-            | "userGroupAccesses"
-            | "created"
-            | "publicAccess"
-            | "description"
-            | "program"
-            | "lastUpdated"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
-export interface D2DataInputPeriodSchema {
-    name: "D2DataInputPeriod";
-    model: D2DataInputPeriod;
-    fields: { closingDate: string; openingDate: string; period: any };
-    fieldPresets: {
-        $all: Preset<D2DataInputPeriod, keyof D2DataInputPeriod>;
-        $identifiable: Preset<D2DataInputPeriod, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2DataInputPeriod, FieldPresets["nameable"]>;
-        $persisted: Preset<D2DataInputPeriod, "period" | "closingDate" | "openingDate">;
-        $owner: Preset<D2DataInputPeriod, "period" | "closingDate" | "openingDate">;
-    };
-}
-
-export interface D2ProgramTrackedEntityAttributeDimensionItemSchema {
-    name: "D2ProgramTrackedEntityAttributeDimensionItem";
-    model: D2ProgramTrackedEntityAttributeDimensionItem;
-    fields: {
-        access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "FIRST"
-            | "FIRST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
-        attribute: D2TrackedEntityAttributeSchema;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        description: string;
-        dimensionItem: string;
-        dimensionItemType:
-            | "DATA_ELEMENT"
-            | "DATA_ELEMENT_OPERAND"
-            | "INDICATOR"
-            | "REPORTING_RATE"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION"
-            | "OPTION_GROUP"
-            | "DATA_ELEMENT_GROUP"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY_OPTION_GROUP";
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        legendSet: D2LegendSetSchema;
-        legendSets: D2LegendSetSchema[];
-        name: string;
-        program: D2ProgramSchema;
-        publicAccess: string;
-        shortName: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<
-            D2ProgramTrackedEntityAttributeDimensionItem,
-            keyof D2ProgramTrackedEntityAttributeDimensionItem
-        >;
-        $identifiable: Preset<
-            D2ProgramTrackedEntityAttributeDimensionItem,
-            FieldPresets["identifiable"]
-        >;
-        $nameable: Preset<D2ProgramTrackedEntityAttributeDimensionItem, FieldPresets["nameable"]>;
-        $persisted: Preset<D2ProgramTrackedEntityAttributeDimensionItem, never>;
-        $owner: Preset<D2ProgramTrackedEntityAttributeDimensionItem, never>;
-    };
-}
-
-export interface D2DataElementGroupSetDimensionSchema {
-    name: "D2DataElementGroupSetDimension";
-    model: D2DataElementGroupSetDimension;
-    fields: {
-        dataElementGroupSet: D2DataElementGroupSetSchema;
-        dataElementGroups: D2DataElementGroupSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2DataElementGroupSetDimension, keyof D2DataElementGroupSetDimension>;
-        $identifiable: Preset<D2DataElementGroupSetDimension, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2DataElementGroupSetDimension, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2DataElementGroupSetDimension,
-            "dataElementGroups" | "dataElementGroupSet"
-        >;
-        $owner: Preset<D2DataElementGroupSetDimension, "dataElementGroups" | "dataElementGroupSet">;
-    };
-}
-
-export interface D2IconSchema {
-    name: "D2Icon";
-    model: D2Icon;
-    fields: {};
-    fieldPresets: {
-        $all: Preset<D2Icon, keyof D2Icon>;
-        $identifiable: Preset<D2Icon, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Icon, FieldPresets["nameable"]>;
-        $persisted: Preset<D2Icon, never>;
-        $owner: Preset<D2Icon, never>;
-    };
-}
-
-export interface D2UserGroupAccessSchema {
-    name: "D2UserGroupAccess";
-    model: D2UserGroupAccess;
-    fields: { access: string; displayName: string; id: string; userGroupUid: string };
-    fieldPresets: {
-        $all: Preset<D2UserGroupAccess, keyof D2UserGroupAccess>;
-        $identifiable: Preset<D2UserGroupAccess, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2UserGroupAccess, FieldPresets["nameable"]>;
-        $persisted: Preset<D2UserGroupAccess, "access">;
-        $owner: Preset<D2UserGroupAccess, "access">;
-    };
-}
-
-export interface D2ColorSchema {
-    name: "D2Color";
-    model: D2Color;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        color: string;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Color, keyof D2Color>;
-        $identifiable: Preset<D2Color, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Color, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Color,
-            | "lastUpdatedBy"
-            | "code"
-            | "color"
-            | "created"
-            | "lastUpdated"
-            | "translations"
-            | "name"
-            | "id"
-        >;
-        $owner: Preset<
-            D2Color,
-            | "lastUpdatedBy"
-            | "code"
-            | "color"
-            | "created"
-            | "lastUpdated"
-            | "translations"
-            | "name"
-            | "id"
-        >;
-    };
-}
-
-export interface D2DataSetElementSchema {
-    name: "D2DataSetElement";
-    model: D2DataSetElement;
-    fields: {
-        categoryCombo: D2CategoryComboSchema;
-        dataElement: D2DataElementSchema;
-        dataSet: D2DataSetSchema;
-    };
-    fieldPresets: {
-        $all: Preset<D2DataSetElement, keyof D2DataSetElement>;
-        $identifiable: Preset<D2DataSetElement, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2DataSetElement, FieldPresets["nameable"]>;
-        $persisted: Preset<D2DataSetElement, "dataElement" | "categoryCombo" | "dataSet">;
-        $owner: Preset<D2DataSetElement, "dataElement" | "categoryCombo" | "dataSet">;
-    };
-}
-
-export interface D2ProgramStageDataElementSchema {
-    name: "D2ProgramStageDataElement";
-    model: D2ProgramStageDataElement;
-    fields: {
-        access: D2Access;
-        allowFutureDate: boolean;
-        allowProvidedElsewhere: boolean;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        compulsory: boolean;
-        created: string;
-        dataElement: D2DataElementSchema;
-        displayInReports: boolean;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        programStage: D2ProgramStageSchema;
-        publicAccess: string;
-        renderOptionsAsRadio: boolean;
-        renderType: any;
-        skipSynchronization: boolean;
-        sortOrder: number;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramStageDataElement, keyof D2ProgramStageDataElement>;
-        $identifiable: Preset<D2ProgramStageDataElement, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramStageDataElement, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramStageDataElement,
-            | "displayInReports"
-            | "code"
-            | "skipSynchronization"
-            | "lastUpdated"
-            | "renderOptionsAsRadio"
-            | "id"
-            | "allowFutureDate"
-            | "renderType"
-            | "lastUpdatedBy"
-            | "programStage"
-            | "created"
-            | "dataElement"
-            | "compulsory"
-            | "allowProvidedElsewhere"
-            | "sortOrder"
-        >;
-        $owner: Preset<
-            D2ProgramStageDataElement,
-            | "displayInReports"
-            | "code"
-            | "skipSynchronization"
-            | "lastUpdated"
-            | "renderOptionsAsRadio"
-            | "id"
-            | "allowFutureDate"
-            | "renderType"
-            | "lastUpdatedBy"
-            | "programStage"
-            | "created"
-            | "dataElement"
-            | "compulsory"
-            | "allowProvidedElsewhere"
-            | "sortOrder"
-        >;
-    };
-}
-
-export interface D2ProgramTrackedEntityAttributeSchema {
-    name: "D2ProgramTrackedEntityAttribute";
-    model: D2ProgramTrackedEntityAttribute;
-    fields: {
-        access: D2Access;
-        allowFutureDate: boolean;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        displayInList: boolean;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        mandatory: boolean;
-        name: string;
-        program: D2ProgramSchema;
-        programTrackedEntityAttributeGroups: D2ProgramTrackedEntityAttributeGroupSchema[];
-        publicAccess: string;
-        renderOptionsAsRadio: boolean;
-        renderType: any;
-        searchable: boolean;
-        sortOrder: number;
-        trackedEntityAttribute: D2TrackedEntityAttributeSchema;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        valueType:
-            | "TEXT"
-            | "LONG_TEXT"
-            | "LETTER"
-            | "PHONE_NUMBER"
-            | "EMAIL"
-            | "BOOLEAN"
-            | "TRUE_ONLY"
-            | "DATE"
-            | "DATETIME"
-            | "TIME"
-            | "NUMBER"
-            | "UNIT_INTERVAL"
-            | "PERCENTAGE"
-            | "INTEGER"
-            | "INTEGER_POSITIVE"
-            | "INTEGER_NEGATIVE"
-            | "INTEGER_ZERO_OR_POSITIVE"
-            | "TRACKER_ASSOCIATE"
-            | "USERNAME"
-            | "COORDINATE"
-            | "ORGANISATION_UNIT"
-            | "AGE"
-            | "URL"
-            | "FILE_RESOURCE"
-            | "IMAGE";
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramTrackedEntityAttribute, keyof D2ProgramTrackedEntityAttribute>;
-        $identifiable: Preset<D2ProgramTrackedEntityAttribute, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramTrackedEntityAttribute, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramTrackedEntityAttribute,
-            | "code"
-            | "programTrackedEntityAttributeGroups"
-            | "program"
-            | "mandatory"
-            | "trackedEntityAttribute"
-            | "lastUpdated"
-            | "renderOptionsAsRadio"
-            | "id"
-            | "allowFutureDate"
-            | "renderType"
-            | "lastUpdatedBy"
-            | "created"
-            | "searchable"
-            | "displayInList"
-            | "sortOrder"
-        >;
-        $owner: Preset<
-            D2ProgramTrackedEntityAttribute,
-            | "code"
-            | "programTrackedEntityAttributeGroups"
-            | "program"
-            | "mandatory"
-            | "trackedEntityAttribute"
-            | "lastUpdated"
-            | "renderOptionsAsRadio"
-            | "id"
-            | "allowFutureDate"
-            | "renderType"
-            | "lastUpdatedBy"
-            | "created"
-            | "searchable"
-            | "displayInList"
-            | "sortOrder"
-        >;
-    };
-}
-
-export interface D2FileResourceSchema {
-    name: "D2FileResource";
-    model: D2FileResource;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        contentLength: string;
-        contentMd5: string;
-        contentType: string;
-        created: string;
-        displayName: string;
-        domain: "DATA_VALUE" | "PUSH_ANALYSIS" | "DOCUMENT" | "MESSAGE_ATTACHMENT" | "USER_AVATAR";
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        hasMultipleStorageFiles: boolean;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        storageStatus: "NONE" | "PENDING" | "FAILED" | "STORED";
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2FileResource, keyof D2FileResource>;
-        $identifiable: Preset<D2FileResource, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2FileResource, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2FileResource,
-            | "contentMd5"
-            | "code"
-            | "lastUpdated"
-            | "id"
-            | "contentType"
-            | "lastUpdatedBy"
-            | "created"
-            | "domain"
-            | "hasMultipleStorageFiles"
-            | "name"
-            | "contentLength"
-            | "user"
-        >;
-        $owner: Preset<
-            D2FileResource,
-            | "contentMd5"
-            | "code"
-            | "lastUpdated"
-            | "id"
-            | "contentType"
-            | "lastUpdatedBy"
-            | "created"
-            | "domain"
-            | "hasMultipleStorageFiles"
-            | "name"
-            | "contentLength"
-            | "user"
-        >;
-    };
-}
-
-export interface D2RelationshipSchema {
-    name: "D2Relationship";
-    model: D2Relationship;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        from: any;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        relationshipType: D2RelationshipTypeSchema;
-        shortName: string;
-        style: D2Style;
-        to: any;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Relationship, keyof D2Relationship>;
-        $identifiable: Preset<D2Relationship, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Relationship, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Relationship,
-            | "code"
-            | "description"
-            | "lastUpdated"
-            | "formName"
-            | "from"
-            | "id"
-            | "lastUpdatedBy"
-            | "relationshipType"
-            | "created"
-            | "style"
-            | "to"
-        >;
-        $owner: Preset<
-            D2Relationship,
-            | "code"
-            | "description"
-            | "lastUpdated"
-            | "formName"
-            | "from"
-            | "id"
-            | "lastUpdatedBy"
-            | "relationshipType"
-            | "created"
-            | "style"
-            | "to"
-        >;
-    };
-}
-
-export interface D2ProgramDataElementDimensionItemSchema {
-    name: "D2ProgramDataElementDimensionItem";
-    model: D2ProgramDataElementDimensionItem;
-    fields: {
-        access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "FIRST"
-            | "FIRST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        dataElement: D2DataElementSchema;
-        description: string;
-        dimensionItem: string;
-        dimensionItemType:
-            | "DATA_ELEMENT"
-            | "DATA_ELEMENT_OPERAND"
-            | "INDICATOR"
-            | "REPORTING_RATE"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION"
-            | "OPTION_GROUP"
-            | "DATA_ELEMENT_GROUP"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY_OPTION_GROUP";
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        legendSet: D2LegendSetSchema;
-        legendSets: D2LegendSetSchema[];
-        name: string;
-        program: D2ProgramSchema;
-        publicAccess: string;
-        shortName: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        valueType:
-            | "TEXT"
-            | "LONG_TEXT"
-            | "LETTER"
-            | "PHONE_NUMBER"
-            | "EMAIL"
-            | "BOOLEAN"
-            | "TRUE_ONLY"
-            | "DATE"
-            | "DATETIME"
-            | "TIME"
-            | "NUMBER"
-            | "UNIT_INTERVAL"
-            | "PERCENTAGE"
-            | "INTEGER"
-            | "INTEGER_POSITIVE"
-            | "INTEGER_NEGATIVE"
-            | "INTEGER_ZERO_OR_POSITIVE"
-            | "TRACKER_ASSOCIATE"
-            | "USERNAME"
-            | "COORDINATE"
-            | "ORGANISATION_UNIT"
-            | "AGE"
-            | "URL"
-            | "FILE_RESOURCE"
-            | "IMAGE";
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramDataElementDimensionItem, keyof D2ProgramDataElementDimensionItem>;
-        $identifiable: Preset<D2ProgramDataElementDimensionItem, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramDataElementDimensionItem, FieldPresets["nameable"]>;
-        $persisted: Preset<D2ProgramDataElementDimensionItem, never>;
-        $owner: Preset<D2ProgramDataElementDimensionItem, never>;
-    };
-}
-
-export interface D2MinMaxDataElementSchema {
-    name: "D2MinMaxDataElement";
-    model: D2MinMaxDataElement;
-    fields: {
-        dataElement: D2DataElementSchema;
-        generated: boolean;
-        max: number;
-        min: number;
-        optionCombo: D2CategoryOptionComboSchema;
-        source: D2OrganisationUnitSchema;
-    };
-    fieldPresets: {
-        $all: Preset<D2MinMaxDataElement, keyof D2MinMaxDataElement>;
-        $identifiable: Preset<D2MinMaxDataElement, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2MinMaxDataElement, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2MinMaxDataElement,
-            "min" | "generated" | "max" | "dataElement" | "source" | "optionCombo"
-        >;
-        $owner: Preset<
-            D2MinMaxDataElement,
-            "min" | "generated" | "max" | "dataElement" | "source" | "optionCombo"
-        >;
-    };
-}
-
 export interface D2ReportingRateSchema {
     name: "D2ReportingRate";
     model: D2ReportingRate;
@@ -13727,6 +12676,642 @@ export interface D2ReportingRateSchema {
     };
 }
 
+export interface D2SMSCommandSchema {
+    name: "D2SMSCommand";
+    model: D2SMSCommand;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        codeValueSeparator: string;
+        completenessMethod: "ALL_DATAVALUE" | "AT_LEAST_ONE_DATAVALUE" | "DO_NOT_MARK_COMPLETE";
+        created: string;
+        currentPeriodUsedForReporting: boolean;
+        dataset: D2DataSetSchema;
+        defaultMessage: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        moreThanOneOrgUnitMessage: string;
+        name: string;
+        noUserMessage: string;
+        parserType:
+            | "KEY_VALUE_PARSER"
+            | "J2ME_PARSER"
+            | "ALERT_PARSER"
+            | "UNREGISTERED_PARSER"
+            | "TRACKED_ENTITY_REGISTRATION_PARSER"
+            | "PROGRAM_STAGE_DATAENTRY_PARSER"
+            | "EVENT_REGISTRATION_PARSER";
+        program: D2ProgramSchema;
+        programStage: D2ProgramStageSchema;
+        publicAccess: string;
+        receivedMessage: string;
+        separator: string;
+        smsCodes: any[];
+        specialCharacters: any[];
+        successMessage: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroup: D2UserGroupSchema;
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        wrongFormatMessage: string;
+    };
+    fieldPresets: {
+        $all: Preset<D2SMSCommand, keyof D2SMSCommand>;
+        $identifiable: Preset<D2SMSCommand, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2SMSCommand, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2SMSCommand,
+            | "moreThanOneOrgUnitMessage"
+            | "smsCodes"
+            | "specialCharacters"
+            | "currentPeriodUsedForReporting"
+            | "program"
+            | "noUserMessage"
+            | "lastUpdated"
+            | "receivedMessage"
+            | "defaultMessage"
+            | "id"
+            | "userGroup"
+            | "programStage"
+            | "completenessMethod"
+            | "created"
+            | "wrongFormatMessage"
+            | "separator"
+            | "successMessage"
+            | "codeValueSeparator"
+            | "parserType"
+            | "name"
+            | "dataset"
+        >;
+        $owner: Preset<
+            D2SMSCommand,
+            | "moreThanOneOrgUnitMessage"
+            | "smsCodes"
+            | "specialCharacters"
+            | "currentPeriodUsedForReporting"
+            | "program"
+            | "noUserMessage"
+            | "lastUpdated"
+            | "receivedMessage"
+            | "defaultMessage"
+            | "id"
+            | "userGroup"
+            | "programStage"
+            | "completenessMethod"
+            | "created"
+            | "wrongFormatMessage"
+            | "separator"
+            | "successMessage"
+            | "codeValueSeparator"
+            | "parserType"
+            | "name"
+            | "dataset"
+        >;
+    };
+}
+
+export interface D2SectionSchema {
+    name: "D2Section";
+    model: D2Section;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        categoryCombos: D2CategoryComboSchema[];
+        code: Id;
+        created: string;
+        dataElements: D2DataElementSchema[];
+        dataSet: D2DataSetSchema;
+        description: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        greyedFields: D2DataElementOperandSchema[];
+        href: string;
+        id: Id;
+        indicators: D2IndicatorSchema[];
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        showColumnTotals: boolean;
+        showRowTotals: boolean;
+        sortOrder: number;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2Section, keyof D2Section>;
+        $identifiable: Preset<D2Section, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Section, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Section,
+            | "code"
+            | "greyedFields"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "dataSet"
+            | "dataElements"
+            | "showColumnTotals"
+            | "lastUpdatedBy"
+            | "created"
+            | "attributeValues"
+            | "indicators"
+            | "sortOrder"
+            | "name"
+            | "showRowTotals"
+        >;
+        $owner: Preset<
+            D2Section,
+            | "code"
+            | "greyedFields"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "dataSet"
+            | "dataElements"
+            | "showColumnTotals"
+            | "lastUpdatedBy"
+            | "created"
+            | "attributeValues"
+            | "indicators"
+            | "sortOrder"
+            | "name"
+            | "showRowTotals"
+        >;
+    };
+}
+
+export interface D2SqlViewSchema {
+    name: "D2SqlView";
+    model: D2SqlView;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        cacheStrategy:
+            | "NO_CACHE"
+            | "CACHE_15_MINUTES"
+            | "CACHE_30_MINUTES"
+            | "CACHE_1_HOUR"
+            | "CACHE_6AM_TOMORROW"
+            | "CACHE_TWO_WEEKS"
+            | "RESPECT_SYSTEM_SETTING";
+        code: Id;
+        created: string;
+        description: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        sqlQuery: string;
+        translations: D2Translation[];
+        type: "VIEW" | "MATERIALIZED_VIEW" | "QUERY";
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2SqlView, keyof D2SqlView>;
+        $identifiable: Preset<D2SqlView, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2SqlView, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2SqlView,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "sqlQuery"
+            | "created"
+            | "publicAccess"
+            | "attributeValues"
+            | "description"
+            | "type"
+            | "externalAccess"
+            | "lastUpdated"
+            | "userAccesses"
+            | "name"
+            | "cacheStrategy"
+            | "id"
+            | "user"
+        >;
+        $owner: Preset<
+            D2SqlView,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "sqlQuery"
+            | "created"
+            | "publicAccess"
+            | "attributeValues"
+            | "description"
+            | "type"
+            | "externalAccess"
+            | "lastUpdated"
+            | "userAccesses"
+            | "name"
+            | "cacheStrategy"
+            | "id"
+            | "user"
+        >;
+    };
+}
+
+export interface D2TrackedEntityAttributeSchema {
+    name: "D2TrackedEntityAttribute";
+    model: D2TrackedEntityAttribute;
+    fields: {
+        access: D2Access;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        confidential: boolean;
+        created: string;
+        description: string;
+        dimensionItem: string;
+        dimensionItemType:
+            | "DATA_ELEMENT"
+            | "DATA_ELEMENT_OPERAND"
+            | "INDICATOR"
+            | "REPORTING_RATE"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION"
+            | "OPTION_GROUP"
+            | "DATA_ELEMENT_GROUP"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY_OPTION_GROUP";
+        displayDescription: string;
+        displayFormName: string;
+        displayInListNoProgram: boolean;
+        displayName: string;
+        displayOnVisitSchedule: boolean;
+        displayShortName: string;
+        expression: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        fieldMask: string;
+        formName: string;
+        generated: boolean;
+        href: string;
+        id: Id;
+        inherit: boolean;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendSet: D2LegendSetSchema;
+        legendSets: D2LegendSetSchema[];
+        name: string;
+        optionSet: D2OptionSetSchema;
+        optionSetValue: boolean;
+        orgunitScope: boolean;
+        pattern: string;
+        publicAccess: string;
+        shortName: string;
+        skipSynchronization: boolean;
+        sortOrderInListNoProgram: number;
+        sortOrderInVisitSchedule: number;
+        style: D2Style;
+        translations: D2Translation[];
+        unique: boolean;
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        valueType:
+            | "TEXT"
+            | "LONG_TEXT"
+            | "LETTER"
+            | "PHONE_NUMBER"
+            | "EMAIL"
+            | "BOOLEAN"
+            | "TRUE_ONLY"
+            | "DATE"
+            | "DATETIME"
+            | "TIME"
+            | "NUMBER"
+            | "UNIT_INTERVAL"
+            | "PERCENTAGE"
+            | "INTEGER"
+            | "INTEGER_POSITIVE"
+            | "INTEGER_NEGATIVE"
+            | "INTEGER_ZERO_OR_POSITIVE"
+            | "TRACKER_ASSOCIATE"
+            | "USERNAME"
+            | "COORDINATE"
+            | "ORGANISATION_UNIT"
+            | "AGE"
+            | "URL"
+            | "FILE_RESOURCE"
+            | "IMAGE";
+    };
+    fieldPresets: {
+        $all: Preset<D2TrackedEntityAttribute, keyof D2TrackedEntityAttribute>;
+        $identifiable: Preset<D2TrackedEntityAttribute, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2TrackedEntityAttribute, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2TrackedEntityAttribute,
+            | "aggregationType"
+            | "code"
+            | "displayInListNoProgram"
+            | "publicAccess"
+            | "pattern"
+            | "description"
+            | "skipSynchronization"
+            | "sortOrderInListNoProgram"
+            | "lastUpdated"
+            | "optionSet"
+            | "generated"
+            | "displayOnVisitSchedule"
+            | "translations"
+            | "valueType"
+            | "formName"
+            | "sortOrderInVisitSchedule"
+            | "id"
+            | "orgunitScope"
+            | "confidential"
+            | "fieldMask"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "expression"
+            | "created"
+            | "attributeValues"
+            | "unique"
+            | "userAccesses"
+            | "inherit"
+            | "name"
+            | "legendSets"
+            | "style"
+            | "shortName"
+            | "user"
+        >;
+        $owner: Preset<
+            D2TrackedEntityAttribute,
+            | "aggregationType"
+            | "code"
+            | "displayInListNoProgram"
+            | "publicAccess"
+            | "pattern"
+            | "description"
+            | "skipSynchronization"
+            | "sortOrderInListNoProgram"
+            | "lastUpdated"
+            | "optionSet"
+            | "generated"
+            | "displayOnVisitSchedule"
+            | "translations"
+            | "valueType"
+            | "formName"
+            | "sortOrderInVisitSchedule"
+            | "id"
+            | "orgunitScope"
+            | "confidential"
+            | "fieldMask"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "expression"
+            | "created"
+            | "attributeValues"
+            | "unique"
+            | "userAccesses"
+            | "inherit"
+            | "name"
+            | "legendSets"
+            | "style"
+            | "shortName"
+            | "user"
+        >;
+    };
+}
+
+export interface D2TrackedEntityAttributeValueSchema {
+    name: "D2TrackedEntityAttributeValue";
+    model: D2TrackedEntityAttributeValue;
+    fields: {
+        created: string;
+        lastUpdated: string;
+        storedBy: string;
+        trackedEntityAttribute: D2TrackedEntityAttributeSchema;
+        trackedEntityInstance: D2TrackedEntityInstanceSchema;
+        value: string;
+    };
+    fieldPresets: {
+        $all: Preset<D2TrackedEntityAttributeValue, keyof D2TrackedEntityAttributeValue>;
+        $identifiable: Preset<D2TrackedEntityAttributeValue, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2TrackedEntityAttributeValue, FieldPresets["nameable"]>;
+        $persisted: Preset<D2TrackedEntityAttributeValue, "lastUpdated" | "storedBy" | "created">;
+        $owner: Preset<D2TrackedEntityAttributeValue, "lastUpdated" | "storedBy" | "created">;
+    };
+}
+
+export interface D2TrackedEntityDataElementDimensionSchema {
+    name: "D2TrackedEntityDataElementDimension";
+    model: D2TrackedEntityDataElementDimension;
+    fields: {
+        dataElement: D2DataElementSchema;
+        filter: string;
+        legendSet: D2LegendSetSchema;
+        programStage: D2ProgramStageSchema;
+    };
+    fieldPresets: {
+        $all: Preset<
+            D2TrackedEntityDataElementDimension,
+            keyof D2TrackedEntityDataElementDimension
+        >;
+        $identifiable: Preset<D2TrackedEntityDataElementDimension, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2TrackedEntityDataElementDimension, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2TrackedEntityDataElementDimension,
+            "filter" | "legendSet" | "programStage" | "dataElement"
+        >;
+        $owner: Preset<
+            D2TrackedEntityDataElementDimension,
+            "filter" | "legendSet" | "programStage" | "dataElement"
+        >;
+    };
+}
+
+export interface D2TrackedEntityInstanceSchema {
+    name: "D2TrackedEntityInstance";
+    model: D2TrackedEntityInstance;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        createdAtClient: string;
+        deleted: boolean;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        geometry: D2Geometry;
+        href: string;
+        id: Id;
+        inactive: boolean;
+        lastUpdated: string;
+        lastUpdatedAtClient: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        organisationUnit: D2OrganisationUnitSchema;
+        programInstances: D2ProgramInstanceSchema[];
+        programOwners: any[];
+        publicAccess: string;
+        relationshipItems: any[];
+        trackedEntityAttributeValues: D2TrackedEntityAttributeValueSchema[];
+        trackedEntityType: D2TrackedEntityTypeSchema;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2TrackedEntityInstance, keyof D2TrackedEntityInstance>;
+        $identifiable: Preset<D2TrackedEntityInstance, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2TrackedEntityInstance, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2TrackedEntityInstance,
+            | "programOwners"
+            | "code"
+            | "programInstances"
+            | "organisationUnit"
+            | "createdAtClient"
+            | "lastUpdated"
+            | "inactive"
+            | "relationshipItems"
+            | "id"
+            | "lastUpdatedBy"
+            | "created"
+            | "deleted"
+            | "trackedEntityType"
+            | "geometry"
+            | "trackedEntityAttributeValues"
+            | "lastUpdatedAtClient"
+        >;
+        $owner: Preset<
+            D2TrackedEntityInstance,
+            | "code"
+            | "organisationUnit"
+            | "createdAtClient"
+            | "lastUpdated"
+            | "inactive"
+            | "id"
+            | "lastUpdatedBy"
+            | "created"
+            | "deleted"
+            | "trackedEntityType"
+            | "geometry"
+            | "lastUpdatedAtClient"
+        >;
+    };
+}
+
+export interface D2TrackedEntityInstanceFilterSchema {
+    name: "D2TrackedEntityInstanceFilter";
+    model: D2TrackedEntityInstanceFilter;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        description: string;
+        displayName: string;
+        enrollmentCreatedPeriod: any;
+        enrollmentStatus: "ACTIVE" | "COMPLETED" | "CANCELLED";
+        eventFilters: any[];
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        followup: boolean;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        program: D2ProgramSchema;
+        publicAccess: string;
+        sortOrder: number;
+        style: D2Style;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2TrackedEntityInstanceFilter, keyof D2TrackedEntityInstanceFilter>;
+        $identifiable: Preset<D2TrackedEntityInstanceFilter, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2TrackedEntityInstanceFilter, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2TrackedEntityInstanceFilter,
+            | "code"
+            | "description"
+            | "program"
+            | "enrollmentCreatedPeriod"
+            | "lastUpdated"
+            | "id"
+            | "lastUpdatedBy"
+            | "created"
+            | "followup"
+            | "eventFilters"
+            | "enrollmentStatus"
+            | "sortOrder"
+            | "name"
+            | "style"
+        >;
+        $owner: Preset<
+            D2TrackedEntityInstanceFilter,
+            | "code"
+            | "description"
+            | "program"
+            | "enrollmentCreatedPeriod"
+            | "lastUpdated"
+            | "id"
+            | "lastUpdatedBy"
+            | "created"
+            | "followup"
+            | "eventFilters"
+            | "enrollmentStatus"
+            | "sortOrder"
+            | "name"
+            | "style"
+        >;
+    };
+}
+
 export interface D2TrackedEntityProgramIndicatorDimensionSchema {
     name: "D2TrackedEntityProgramIndicatorDimension";
     model: D2TrackedEntityProgramIndicatorDimension;
@@ -13752,6 +13337,383 @@ export interface D2TrackedEntityProgramIndicatorDimensionSchema {
         $owner: Preset<
             D2TrackedEntityProgramIndicatorDimension,
             "filter" | "legendSet" | "programIndicator"
+        >;
+    };
+}
+
+export interface D2TrackedEntityTypeSchema {
+    name: "D2TrackedEntityType";
+    model: D2TrackedEntityType;
+    fields: {
+        access: D2Access;
+        allowAuditLog: boolean;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
+        formName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        maxTeiCountToReturn: number;
+        minAttributesRequiredToSearch: number;
+        name: string;
+        publicAccess: string;
+        shortName: string;
+        style: D2Style;
+        trackedEntityTypeAttributes: D2TrackedEntityTypeAttributeSchema[];
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2TrackedEntityType, keyof D2TrackedEntityType>;
+        $identifiable: Preset<D2TrackedEntityType, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2TrackedEntityType, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2TrackedEntityType,
+            | "code"
+            | "publicAccess"
+            | "trackedEntityTypeAttributes"
+            | "description"
+            | "lastUpdated"
+            | "allowAuditLog"
+            | "translations"
+            | "formName"
+            | "featureType"
+            | "minAttributesRequiredToSearch"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "maxTeiCountToReturn"
+            | "userAccesses"
+            | "name"
+            | "style"
+            | "user"
+        >;
+        $owner: Preset<
+            D2TrackedEntityType,
+            | "code"
+            | "publicAccess"
+            | "trackedEntityTypeAttributes"
+            | "description"
+            | "lastUpdated"
+            | "allowAuditLog"
+            | "translations"
+            | "formName"
+            | "featureType"
+            | "minAttributesRequiredToSearch"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "maxTeiCountToReturn"
+            | "userAccesses"
+            | "name"
+            | "style"
+            | "user"
+        >;
+    };
+}
+
+export interface D2TrackedEntityTypeAttributeSchema {
+    name: "D2TrackedEntityTypeAttribute";
+    model: D2TrackedEntityTypeAttribute;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        displayInList: boolean;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        mandatory: boolean;
+        name: string;
+        publicAccess: string;
+        searchable: boolean;
+        trackedEntityAttribute: D2TrackedEntityAttributeSchema;
+        trackedEntityType: D2TrackedEntityTypeSchema;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        valueType:
+            | "TEXT"
+            | "LONG_TEXT"
+            | "LETTER"
+            | "PHONE_NUMBER"
+            | "EMAIL"
+            | "BOOLEAN"
+            | "TRUE_ONLY"
+            | "DATE"
+            | "DATETIME"
+            | "TIME"
+            | "NUMBER"
+            | "UNIT_INTERVAL"
+            | "PERCENTAGE"
+            | "INTEGER"
+            | "INTEGER_POSITIVE"
+            | "INTEGER_NEGATIVE"
+            | "INTEGER_ZERO_OR_POSITIVE"
+            | "TRACKER_ASSOCIATE"
+            | "USERNAME"
+            | "COORDINATE"
+            | "ORGANISATION_UNIT"
+            | "AGE"
+            | "URL"
+            | "FILE_RESOURCE"
+            | "IMAGE";
+    };
+    fieldPresets: {
+        $all: Preset<D2TrackedEntityTypeAttribute, keyof D2TrackedEntityTypeAttribute>;
+        $identifiable: Preset<D2TrackedEntityTypeAttribute, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2TrackedEntityTypeAttribute, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2TrackedEntityTypeAttribute,
+            | "code"
+            | "mandatory"
+            | "trackedEntityAttribute"
+            | "lastUpdated"
+            | "id"
+            | "lastUpdatedBy"
+            | "created"
+            | "searchable"
+            | "displayInList"
+            | "trackedEntityType"
+        >;
+        $owner: Preset<
+            D2TrackedEntityTypeAttribute,
+            | "code"
+            | "mandatory"
+            | "trackedEntityAttribute"
+            | "lastUpdated"
+            | "id"
+            | "lastUpdatedBy"
+            | "created"
+            | "searchable"
+            | "displayInList"
+            | "trackedEntityType"
+        >;
+    };
+}
+
+export interface D2UserSchema {
+    name: "D2User";
+    model: D2User;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        avatar: D2FileResourceSchema;
+        birthday: string;
+        code: Id;
+        created: string;
+        dataViewOrganisationUnits: D2OrganisationUnitSchema[];
+        displayName: string;
+        education: string;
+        email: string;
+        employer: string;
+        externalAccess: boolean;
+        facebookMessenger: string;
+        favorite: boolean;
+        favorites: string[];
+        firstName: string;
+        gender: string;
+        href: string;
+        id: Id;
+        interests: string;
+        introduction: string;
+        jobTitle: string;
+        languages: string;
+        lastCheckedInterpretations: string;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        nationality: string;
+        organisationUnits: D2OrganisationUnitSchema[];
+        phoneNumber: string;
+        publicAccess: string;
+        skype: string;
+        surname: string;
+        teiSearchOrganisationUnits: D2OrganisationUnitSchema[];
+        telegram: string;
+        translations: D2Translation[];
+        twitter: string;
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userCredentials: D2UserCredentialsSchema;
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        userGroups: D2UserGroupSchema[];
+        welcomeMessage: string;
+        whatsApp: string;
+    };
+    fieldPresets: {
+        $all: Preset<D2User, keyof D2User>;
+        $identifiable: Preset<D2User, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2User, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2User,
+            | "birthday"
+            | "code"
+            | "education"
+            | "gender"
+            | "jobTitle"
+            | "skype"
+            | "lastUpdated"
+            | "teiSearchOrganisationUnits"
+            | "twitter"
+            | "surname"
+            | "employer"
+            | "id"
+            | "organisationUnits"
+            | "facebookMessenger"
+            | "introduction"
+            | "email"
+            | "dataViewOrganisationUnits"
+            | "whatsApp"
+            | "languages"
+            | "created"
+            | "welcomeMessage"
+            | "userCredentials"
+            | "attributeValues"
+            | "telegram"
+            | "avatar"
+            | "lastCheckedInterpretations"
+            | "userGroups"
+            | "firstName"
+            | "phoneNumber"
+            | "nationality"
+            | "interests"
+        >;
+        $owner: Preset<
+            D2User,
+            | "birthday"
+            | "code"
+            | "education"
+            | "gender"
+            | "jobTitle"
+            | "skype"
+            | "lastUpdated"
+            | "teiSearchOrganisationUnits"
+            | "twitter"
+            | "surname"
+            | "employer"
+            | "id"
+            | "organisationUnits"
+            | "facebookMessenger"
+            | "introduction"
+            | "email"
+            | "dataViewOrganisationUnits"
+            | "whatsApp"
+            | "languages"
+            | "created"
+            | "welcomeMessage"
+            | "userCredentials"
+            | "attributeValues"
+            | "telegram"
+            | "avatar"
+            | "lastCheckedInterpretations"
+            | "firstName"
+            | "phoneNumber"
+            | "nationality"
+            | "interests"
+        >;
+    };
+}
+
+export interface D2UserAccessSchema {
+    name: "D2UserAccess";
+    model: D2UserAccess;
+    fields: { access: string; displayName: string; id: string; userUid: string };
+    fieldPresets: {
+        $all: Preset<D2UserAccess, keyof D2UserAccess>;
+        $identifiable: Preset<D2UserAccess, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2UserAccess, FieldPresets["nameable"]>;
+        $persisted: Preset<D2UserAccess, "access">;
+        $owner: Preset<D2UserAccess, "access">;
+    };
+}
+
+export interface D2UserAuthorityGroupSchema {
+    name: "D2UserAuthorityGroup";
+    model: D2UserAuthorityGroup;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        authorities: string[];
+        code: Id;
+        created: string;
+        description: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        users: D2UserSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2UserAuthorityGroup, keyof D2UserAuthorityGroup>;
+        $identifiable: Preset<D2UserAuthorityGroup, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2UserAuthorityGroup, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2UserAuthorityGroup,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "description"
+            | "authorities"
+            | "lastUpdated"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+        >;
+        $owner: Preset<
+            D2UserAuthorityGroup,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "description"
+            | "authorities"
+            | "lastUpdated"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
         >;
     };
 }
@@ -13849,178 +13811,327 @@ export interface D2UserCredentialsSchema {
     };
 }
 
-export interface D2TrackedEntityAttributeValueSchema {
-    name: "D2TrackedEntityAttributeValue";
-    model: D2TrackedEntityAttributeValue;
-    fields: {
-        created: string;
-        lastUpdated: string;
-        storedBy: string;
-        trackedEntityAttribute: D2TrackedEntityAttributeSchema;
-        trackedEntityInstance: D2TrackedEntityInstanceSchema;
-        value: string;
-    };
-    fieldPresets: {
-        $all: Preset<D2TrackedEntityAttributeValue, keyof D2TrackedEntityAttributeValue>;
-        $identifiable: Preset<D2TrackedEntityAttributeValue, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2TrackedEntityAttributeValue, FieldPresets["nameable"]>;
-        $persisted: Preset<D2TrackedEntityAttributeValue, "lastUpdated" | "storedBy" | "created">;
-        $owner: Preset<D2TrackedEntityAttributeValue, "lastUpdated" | "storedBy" | "created">;
-    };
-}
-
-export interface D2OrganisationUnitGroupSetDimensionSchema {
-    name: "D2OrganisationUnitGroupSetDimension";
-    model: D2OrganisationUnitGroupSetDimension;
-    fields: {
-        organisationUnitGroupSet: D2OrganisationUnitGroupSetSchema;
-        organisationUnitGroups: D2OrganisationUnitGroupSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<
-            D2OrganisationUnitGroupSetDimension,
-            keyof D2OrganisationUnitGroupSetDimension
-        >;
-        $identifiable: Preset<D2OrganisationUnitGroupSetDimension, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OrganisationUnitGroupSetDimension, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2OrganisationUnitGroupSetDimension,
-            "organisationUnitGroupSet" | "organisationUnitGroups"
-        >;
-        $owner: Preset<
-            D2OrganisationUnitGroupSetDimension,
-            "organisationUnitGroupSet" | "organisationUnitGroups"
-        >;
-    };
-}
-
-export interface D2CategoryOptionGroupSetDimensionSchema {
-    name: "D2CategoryOptionGroupSetDimension";
-    model: D2CategoryOptionGroupSetDimension;
-    fields: {
-        categoryOptionGroupSet: D2CategoryOptionGroupSetSchema;
-        categoryOptionGroups: D2CategoryOptionGroupSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2CategoryOptionGroupSetDimension, keyof D2CategoryOptionGroupSetDimension>;
-        $identifiable: Preset<D2CategoryOptionGroupSetDimension, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2CategoryOptionGroupSetDimension, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2CategoryOptionGroupSetDimension,
-            "categoryOptionGroups" | "categoryOptionGroupSet"
-        >;
-        $owner: Preset<
-            D2CategoryOptionGroupSetDimension,
-            "categoryOptionGroups" | "categoryOptionGroupSet"
-        >;
-    };
-}
-
-export interface D2ProgramStageInstanceSchema {
-    name: "D2ProgramStageInstance";
-    model: D2ProgramStageInstance;
+export interface D2UserGroupSchema {
+    name: "D2UserGroup";
+    model: D2UserGroup;
     fields: {
         access: D2Access;
-        assignedUser: D2UserSchema;
-        attributeOptionCombo: D2CategoryOptionComboSchema;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
-        comments: any[];
-        completed: boolean;
-        completedBy: string;
-        completedDate: string;
-        creatableInSearchScope: boolean;
         created: string;
-        createdAtClient: string;
-        deleted: boolean;
         displayName: string;
-        dueDate: string;
-        eventDataValues: any[];
-        eventDate: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
-        geometry: D2Geometry;
         href: string;
         id: Id;
         lastUpdated: string;
-        lastUpdatedAtClient: string;
         lastUpdatedBy: D2UserSchema;
-        messageConversations: D2MessageConversationSchema[];
+        managedByGroups: D2UserGroupSchema[];
+        managedGroups: D2UserGroupSchema[];
         name: string;
-        organisationUnit: D2OrganisationUnitSchema;
-        programInstance: D2ProgramInstanceSchema;
-        programStage: D2ProgramStageSchema;
         publicAccess: string;
-        relationshipItems: any[];
-        status: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";
-        storedBy: string;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
+        users: D2UserSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2ProgramStageInstance, keyof D2ProgramStageInstance>;
-        $identifiable: Preset<D2ProgramStageInstance, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramStageInstance, FieldPresets["nameable"]>;
+        $all: Preset<D2UserGroup, keyof D2UserGroup>;
+        $identifiable: Preset<D2UserGroup, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2UserGroup, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2ProgramStageInstance,
+            D2UserGroup,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
             | "code"
-            | "storedBy"
-            | "organisationUnit"
-            | "dueDate"
-            | "createdAtClient"
-            | "messageConversations"
-            | "lastUpdated"
-            | "eventDataValues"
-            | "relationshipItems"
-            | "id"
-            | "assignedUser"
-            | "programStage"
-            | "comments"
             | "created"
-            | "completedDate"
-            | "programInstance"
-            | "deleted"
-            | "attributeOptionCombo"
-            | "geometry"
-            | "completedBy"
-            | "status"
-            | "lastUpdatedAtClient"
-            | "eventDate"
+            | "publicAccess"
+            | "managedByGroups"
+            | "attributeValues"
+            | "users"
+            | "managedGroups"
+            | "lastUpdated"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
         >;
         $owner: Preset<
-            D2ProgramStageInstance,
+            D2UserGroup,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
             | "code"
-            | "storedBy"
-            | "organisationUnit"
-            | "dueDate"
-            | "createdAtClient"
-            | "messageConversations"
-            | "lastUpdated"
-            | "eventDataValues"
-            | "id"
-            | "assignedUser"
-            | "programStage"
-            | "comments"
             | "created"
-            | "completedDate"
-            | "programInstance"
-            | "deleted"
-            | "attributeOptionCombo"
-            | "geometry"
-            | "completedBy"
-            | "status"
-            | "lastUpdatedAtClient"
-            | "eventDate"
+            | "publicAccess"
+            | "attributeValues"
+            | "users"
+            | "managedGroups"
+            | "lastUpdated"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
         >;
     };
 }
 
-export interface D2TrackedEntityInstanceFilterSchema {
-    name: "D2TrackedEntityInstanceFilter";
-    model: D2TrackedEntityInstanceFilter;
+export interface D2UserGroupAccessSchema {
+    name: "D2UserGroupAccess";
+    model: D2UserGroupAccess;
+    fields: { access: string; displayName: string; id: string; userGroupUid: string };
+    fieldPresets: {
+        $all: Preset<D2UserGroupAccess, keyof D2UserGroupAccess>;
+        $identifiable: Preset<D2UserGroupAccess, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2UserGroupAccess, FieldPresets["nameable"]>;
+        $persisted: Preset<D2UserGroupAccess, "access">;
+        $owner: Preset<D2UserGroupAccess, "access">;
+    };
+}
+
+export interface D2ValidationNotificationTemplateSchema {
+    name: "D2ValidationNotificationTemplate";
+    model: D2ValidationNotificationTemplate;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        messageTemplate: string;
+        name: string;
+        notifyParentOrganisationUnitOnly: boolean;
+        notifyUsersInHierarchyOnly: boolean;
+        publicAccess: string;
+        recipientUserGroups: D2UserGroupSchema[];
+        sendStrategy: "COLLECTIVE_SUMMARY" | "SINGLE_NOTIFICATION";
+        subjectTemplate: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        validationRules: D2ValidationRuleSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ValidationNotificationTemplate, keyof D2ValidationNotificationTemplate>;
+        $identifiable: Preset<D2ValidationNotificationTemplate, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ValidationNotificationTemplate, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ValidationNotificationTemplate,
+            | "code"
+            | "recipientUserGroups"
+            | "lastUpdated"
+            | "subjectTemplate"
+            | "id"
+            | "sendStrategy"
+            | "lastUpdatedBy"
+            | "validationRules"
+            | "created"
+            | "notifyUsersInHierarchyOnly"
+            | "name"
+            | "messageTemplate"
+        >;
+        $owner: Preset<
+            D2ValidationNotificationTemplate,
+            | "code"
+            | "recipientUserGroups"
+            | "lastUpdated"
+            | "subjectTemplate"
+            | "id"
+            | "sendStrategy"
+            | "lastUpdatedBy"
+            | "validationRules"
+            | "created"
+            | "notifyUsersInHierarchyOnly"
+            | "name"
+            | "messageTemplate"
+        >;
+    };
+}
+
+export interface D2ValidationResultSchema {
+    name: "D2ValidationResult";
+    model: D2ValidationResult;
+    fields: {
+        attributeOptionCombo: D2CategoryOptionComboSchema;
+        created: string;
+        dayInPeriod: number;
+        id: string;
+        leftsideValue: number;
+        notificationSent: boolean;
+        organisationUnit: D2OrganisationUnitSchema;
+        period: any;
+        rightsideValue: number;
+        validationRule: D2ValidationRuleSchema;
+    };
+    fieldPresets: {
+        $all: Preset<D2ValidationResult, keyof D2ValidationResult>;
+        $identifiable: Preset<D2ValidationResult, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ValidationResult, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ValidationResult,
+            "created" | "rightsideValue" | "leftsideValue" | "notificationSent"
+        >;
+        $owner: Preset<
+            D2ValidationResult,
+            "created" | "rightsideValue" | "leftsideValue" | "notificationSent"
+        >;
+    };
+}
+
+export interface D2ValidationRuleSchema {
+    name: "D2ValidationRule";
+    model: D2ValidationRule;
+    fields: {
+        access: D2Access;
+        aggregateExportAttributeOptionCombo: string;
+        aggregateExportCategoryOptionCombo: string;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        description: string;
+        dimensionItem: string;
+        dimensionItemType:
+            | "DATA_ELEMENT"
+            | "DATA_ELEMENT_OPERAND"
+            | "INDICATOR"
+            | "REPORTING_RATE"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION"
+            | "OPTION_GROUP"
+            | "DATA_ELEMENT_GROUP"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY_OPTION_GROUP";
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        importance: "HIGH" | "MEDIUM" | "LOW";
+        instruction: string;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        leftSide: D2ExpressionSchema;
+        legendSet: D2LegendSetSchema;
+        legendSets: D2LegendSetSchema[];
+        name: string;
+        notificationTemplates: D2ValidationNotificationTemplateSchema[];
+        operator:
+            | "equal_to"
+            | "not_equal_to"
+            | "greater_than"
+            | "greater_than_or_equal_to"
+            | "less_than"
+            | "less_than_or_equal_to"
+            | "compulsory_pair"
+            | "exclusive_pair";
+        organisationUnitLevels: number[];
+        periodType: string;
+        publicAccess: string;
+        rightSide: D2ExpressionSchema;
+        shortName: string;
+        skipFormValidation: boolean;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        validationRuleGroups: D2ValidationRuleGroupSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ValidationRule, keyof D2ValidationRule>;
+        $identifiable: Preset<D2ValidationRule, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ValidationRule, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ValidationRule,
+            | "validationRuleGroups"
+            | "code"
+            | "importance"
+            | "publicAccess"
+            | "description"
+            | "operator"
+            | "organisationUnitLevels"
+            | "lastUpdated"
+            | "leftSide"
+            | "notificationTemplates"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "rightSide"
+            | "periodType"
+            | "instruction"
+            | "userAccesses"
+            | "name"
+            | "skipFormValidation"
+            | "user"
+        >;
+        $owner: Preset<
+            D2ValidationRule,
+            | "code"
+            | "importance"
+            | "publicAccess"
+            | "description"
+            | "operator"
+            | "organisationUnitLevels"
+            | "lastUpdated"
+            | "leftSide"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "rightSide"
+            | "periodType"
+            | "instruction"
+            | "userAccesses"
+            | "name"
+            | "skipFormValidation"
+            | "user"
+        >;
+    };
+}
+
+export interface D2ValidationRuleGroupSchema {
+    name: "D2ValidationRuleGroup";
+    model: D2ValidationRuleGroup;
     fields: {
         access: D2Access;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
@@ -14028,82 +14139,6 @@ export interface D2TrackedEntityInstanceFilterSchema {
         created: string;
         description: string;
         displayName: string;
-        enrollmentCreatedPeriod: any;
-        enrollmentStatus: "ACTIVE" | "COMPLETED" | "CANCELLED";
-        eventFilters: any[];
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        followup: boolean;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        program: D2ProgramSchema;
-        publicAccess: string;
-        sortOrder: number;
-        style: D2Style;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2TrackedEntityInstanceFilter, keyof D2TrackedEntityInstanceFilter>;
-        $identifiable: Preset<D2TrackedEntityInstanceFilter, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2TrackedEntityInstanceFilter, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2TrackedEntityInstanceFilter,
-            | "code"
-            | "description"
-            | "program"
-            | "enrollmentCreatedPeriod"
-            | "lastUpdated"
-            | "id"
-            | "lastUpdatedBy"
-            | "created"
-            | "followup"
-            | "eventFilters"
-            | "enrollmentStatus"
-            | "sortOrder"
-            | "name"
-            | "style"
-        >;
-        $owner: Preset<
-            D2TrackedEntityInstanceFilter,
-            | "code"
-            | "description"
-            | "program"
-            | "enrollmentCreatedPeriod"
-            | "lastUpdated"
-            | "id"
-            | "lastUpdatedBy"
-            | "created"
-            | "followup"
-            | "eventFilters"
-            | "enrollmentStatus"
-            | "sortOrder"
-            | "name"
-            | "style"
-        >;
-    };
-}
-
-export interface D2InterpretationSchema {
-    name: "D2Interpretation";
-    model: D2Interpretation;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        chart: D2ChartSchema;
-        code: Id;
-        comments: D2InterpretationCommentSchema[];
-        created: string;
-        dataSet: D2DataSetSchema;
-        displayName: string;
-        eventChart: D2EventChartSchema;
-        eventReport: D2EventReportSchema;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
@@ -14111,90 +14146,56 @@ export interface D2InterpretationSchema {
         id: Id;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
-        likedBy: D2UserSchema[];
-        likes: number;
-        map: D2MapSchema;
-        mentions: any[];
         name: string;
-        organisationUnit: D2OrganisationUnitSchema;
-        period: any;
         publicAccess: string;
-        reportTable: D2ReportTableSchema;
-        text: string;
         translations: D2Translation[];
-        type: "REPORT_TABLE" | "CHART" | "MAP" | "EVENT_REPORT" | "EVENT_CHART" | "DATASET_REPORT";
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
+        validationRules: D2ValidationRuleSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2Interpretation, keyof D2Interpretation>;
-        $identifiable: Preset<D2Interpretation, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Interpretation, FieldPresets["nameable"]>;
+        $all: Preset<D2ValidationRuleGroup, keyof D2ValidationRuleGroup>;
+        $identifiable: Preset<D2ValidationRuleGroup, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ValidationRuleGroup, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2Interpretation,
-            | "likedBy"
-            | "organisationUnit"
-            | "publicAccess"
-            | "reportTable"
-            | "lastUpdated"
-            | "id"
-            | "text"
-            | "map"
-            | "dataSet"
-            | "likes"
-            | "period"
+            D2ValidationRuleGroup,
+            | "lastUpdatedBy"
             | "userGroupAccesses"
-            | "comments"
+            | "code"
+            | "validationRules"
             | "created"
-            | "eventReport"
+            | "publicAccess"
+            | "attributeValues"
+            | "description"
+            | "lastUpdated"
+            | "translations"
             | "userAccesses"
-            | "mentions"
-            | "eventChart"
+            | "name"
+            | "id"
             | "user"
-            | "chart"
         >;
         $owner: Preset<
-            D2Interpretation,
-            | "likedBy"
-            | "organisationUnit"
-            | "publicAccess"
-            | "reportTable"
-            | "lastUpdated"
-            | "id"
-            | "text"
-            | "map"
-            | "dataSet"
-            | "likes"
-            | "period"
+            D2ValidationRuleGroup,
+            | "lastUpdatedBy"
             | "userGroupAccesses"
-            | "comments"
+            | "code"
+            | "validationRules"
             | "created"
-            | "eventReport"
+            | "publicAccess"
+            | "attributeValues"
+            | "description"
+            | "lastUpdated"
+            | "translations"
             | "userAccesses"
-            | "mentions"
-            | "eventChart"
+            | "name"
+            | "id"
             | "user"
-            | "chart"
         >;
-    };
-}
-
-export interface D2CategoryDimensionSchema {
-    name: "D2CategoryDimension";
-    model: D2CategoryDimension;
-    fields: { category: D2CategorySchema; categoryOptions: D2CategoryOptionSchema[] };
-    fieldPresets: {
-        $all: Preset<D2CategoryDimension, keyof D2CategoryDimension>;
-        $identifiable: Preset<D2CategoryDimension, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2CategoryDimension, FieldPresets["nameable"]>;
-        $persisted: Preset<D2CategoryDimension, "categoryOptions" | "category">;
-        $owner: Preset<D2CategoryDimension, "categoryOptions" | "category">;
     };
 }
 
 export type D2Model =
-    | D2Predictor
     | D2AnalyticsPeriodBoundary
     | D2AnalyticsTableHook
     | D2Attribute
@@ -14215,7 +14216,6 @@ export type D2Model =
     | D2DataApprovalLevel
     | D2DataApprovalWorkflow
     | D2DataElement
-    | D2TrackedEntityDataElementDimension
     | D2DataElementGroup
     | D2DataElementGroupSet
     | D2DataElementGroupSetDimension
@@ -14229,13 +14229,10 @@ export type D2Model =
     | D2EventChart
     | D2EventReport
     | D2Expression
-    | D2ExternalMapLayer
-    | D2Icon
     | D2ExternalFileResource
-    | D2ValidationNotificationTemplate
-    | D2KeyJsonValue
+    | D2ExternalMapLayer
     | D2FileResource
-    | D2ProgramStageInstance
+    | D2Icon
     | D2Indicator
     | D2IndicatorGroup
     | D2IndicatorGroupSet
@@ -14243,6 +14240,7 @@ export type D2Model =
     | D2Interpretation
     | D2InterpretationComment
     | D2JobConfiguration
+    | D2KeyJsonValue
     | D2Legend
     | D2LegendSet
     | D2Map
@@ -14260,12 +14258,11 @@ export type D2Model =
     | D2OrganisationUnitGroupSet
     | D2OrganisationUnitGroupSetDimension
     | D2OrganisationUnitLevel
+    | D2Predictor
     | D2PredictorGroup
     | D2Program
-    | D2ProgramTrackedEntityAttributeDimensionItem
     | D2ProgramDataElementDimensionItem
     | D2ProgramIndicator
-    | D2TrackedEntityProgramIndicatorDimension
     | D2ProgramIndicatorGroup
     | D2ProgramInstance
     | D2ProgramNotificationTemplate
@@ -14275,9 +14272,11 @@ export type D2Model =
     | D2ProgramSection
     | D2ProgramStage
     | D2ProgramStageDataElement
+    | D2ProgramStageInstance
     | D2ProgramStageInstanceFilter
     | D2ProgramStageSection
     | D2ProgramTrackedEntityAttribute
+    | D2ProgramTrackedEntityAttributeDimensionItem
     | D2ProgramTrackedEntityAttributeGroup
     | D2PushAnalysis
     | D2Relationship
@@ -14285,242 +14284,29 @@ export type D2Model =
     | D2Report
     | D2ReportTable
     | D2ReportingRate
-    | D2Section
     | D2SMSCommand
+    | D2Section
     | D2SqlView
     | D2TrackedEntityAttribute
     | D2TrackedEntityAttributeValue
+    | D2TrackedEntityDataElementDimension
     | D2TrackedEntityInstance
     | D2TrackedEntityInstanceFilter
+    | D2TrackedEntityProgramIndicatorDimension
     | D2TrackedEntityType
     | D2TrackedEntityTypeAttribute
     | D2User
     | D2UserAccess
+    | D2UserAuthorityGroup
     | D2UserCredentials
     | D2UserGroup
     | D2UserGroupAccess
-    | D2UserAuthorityGroup
+    | D2ValidationNotificationTemplate
     | D2ValidationResult
     | D2ValidationRule
     | D2ValidationRuleGroup;
 
 export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
-    predictors: {
-        klass: "org.hisp.dhis.predictor.Predictor",
-        shareable: false,
-        metadata: true,
-        relativeApiEndpoint: "/predictors",
-        plural: "predictors",
-        displayName: "Predictor",
-        collectionName: "predictors",
-        nameableObject: true,
-        translatable: false,
-        identifiableObject: true,
-        dataShareable: false,
-        name: "Predictor",
-        persisted: true,
-        embeddedObject: false,
-        properties: [
-            {
-                name: "favorite",
-                fieldName: "favorites",
-                propertyType: "COLLECTION",
-                itemPropertyType: "TEXT",
-                klass: "java.util.Set",
-                itemKlass: "java.lang.String",
-            },
-            {
-                name: "outputCombo",
-                fieldName: "outputCombo",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.category.CategoryOptionCombo",
-            },
-            {
-                name: "code",
-                fieldName: "code",
-                propertyType: "IDENTIFIER",
-                klass: "java.lang.String",
-            },
-            {
-                name: "access",
-                fieldName: "access",
-                propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.security.acl.Access",
-            },
-            {
-                name: "displayName",
-                fieldName: "displayName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "publicAccess",
-                fieldName: "publicAccess",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "description",
-                fieldName: "description",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "generator",
-                fieldName: "generator",
-                propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.expression.Expression",
-            },
-            {
-                name: "displayShortName",
-                fieldName: "displayShortName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "organisationUnitLevel",
-                fieldName: "organisationUnitLevels",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.organisationunit.OrganisationUnitLevel",
-            },
-            {
-                name: "externalAccess",
-                fieldName: "externalAccess",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "output",
-                fieldName: "output",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.dataelement.DataElement",
-            },
-            {
-                name: "lastUpdated",
-                fieldName: "lastUpdated",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "sampleSkipTest",
-                fieldName: "sampleSkipTest",
-                propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.expression.Expression",
-            },
-            {
-                name: "translation",
-                fieldName: "translations",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.translation.Translation",
-            },
-            {
-                name: "formName",
-                fieldName: "formName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
-            {
-                name: "sequentialSampleCount",
-                fieldName: "sequentialSampleCount",
-                propertyType: "INTEGER",
-                klass: "java.lang.Integer",
-            },
-            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
-            {
-                name: "displayDescription",
-                fieldName: "displayDescription",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "annualSampleCount",
-                fieldName: "annualSampleCount",
-                propertyType: "INTEGER",
-                klass: "java.lang.Integer",
-            },
-            {
-                name: "lastUpdatedBy",
-                fieldName: "lastUpdatedBy",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            {
-                name: "userGroupAccess",
-                fieldName: "userGroupAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
-            },
-            {
-                name: "created",
-                fieldName: "created",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "attributeValue",
-                fieldName: "attributeValues",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
-            },
-            {
-                name: "sequentialSkipCount",
-                fieldName: "sequentialSkipCount",
-                propertyType: "INTEGER",
-                klass: "java.lang.Integer",
-            },
-            {
-                name: "predictorGroup",
-                fieldName: "groups",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.predictor.PredictorGroup",
-            },
-            {
-                name: "displayFormName",
-                fieldName: "displayFormName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "periodType",
-                fieldName: "periodType",
-                propertyType: "TEXT",
-                klass: "org.hisp.dhis.period.PeriodType",
-            },
-            {
-                name: "userAccess",
-                fieldName: "userAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserAccess",
-            },
-            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
-            {
-                name: "shortName",
-                fieldName: "shortName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "user",
-                fieldName: "user",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
-        ],
-    },
     analyticsPeriodBoundaries: {
         klass: "org.hisp.dhis.program.AnalyticsPeriodBoundary",
         shareable: false,
@@ -18309,47 +18095,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             },
         ],
     },
-    trackedEntityDataElementDimensions: {
-        klass: "org.hisp.dhis.trackedentity.TrackedEntityDataElementDimension",
-        shareable: false,
-        metadata: false,
-        plural: "trackedEntityDataElementDimensions",
-        displayName: "Tracked Entity Data Element Dimension",
-        collectionName: "trackedEntityDataElementDimensions",
-        nameableObject: false,
-        translatable: false,
-        identifiableObject: false,
-        dataShareable: false,
-        name: "dataElementDimension",
-        persisted: true,
-        embeddedObject: false,
-        properties: [
-            {
-                name: "filter",
-                fieldName: "filter",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "legendSet",
-                fieldName: "legendSet",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.legend.LegendSet",
-            },
-            {
-                name: "programStage",
-                fieldName: "programStage",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.program.ProgramStage",
-            },
-            {
-                name: "dataElement",
-                fieldName: "dataElement",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.dataelement.DataElement",
-            },
-        ],
-    },
     dataElementGroups: {
         klass: "org.hisp.dhis.dataelement.DataElementGroup",
         shareable: true,
@@ -21074,6 +20819,122 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             },
         ],
     },
+    externalFileResources: {
+        klass: "org.hisp.dhis.fileresource.ExternalFileResource",
+        shareable: false,
+        metadata: true,
+        relativeApiEndpoint: "/externalFileResources",
+        plural: "externalFileResources",
+        displayName: "External File Resource",
+        collectionName: "externalFileResources",
+        nameableObject: false,
+        translatable: false,
+        identifiableObject: true,
+        dataShareable: false,
+        name: "identifiableObject",
+        persisted: true,
+        embeddedObject: false,
+        properties: [
+            {
+                name: "favorite",
+                fieldName: "favorites",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.Set",
+                itemKlass: "java.lang.String",
+            },
+            {
+                name: "lastUpdatedBy",
+                fieldName: "lastUpdatedBy",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "access",
+                fieldName: "access",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.security.acl.Access",
+            },
+            {
+                name: "userGroupAccess",
+                fieldName: "userGroupAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
+            },
+            {
+                name: "code",
+                fieldName: "code",
+                propertyType: "IDENTIFIER",
+                klass: "java.lang.String",
+            },
+            {
+                name: "created",
+                fieldName: "created",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "displayName",
+                fieldName: "displayName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "publicAccess",
+                fieldName: "publicAccess",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "attributeValue",
+                fieldName: "attributeValues",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
+            },
+            {
+                name: "externalAccess",
+                fieldName: "externalAccess",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "lastUpdated",
+                fieldName: "lastUpdated",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "translation",
+                fieldName: "translations",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.translation.Translation",
+            },
+            {
+                name: "userAccess",
+                fieldName: "userAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserAccess",
+            },
+            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
+            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
+            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
+            {
+                name: "user",
+                fieldName: "user",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+        ],
+    },
     externalMapLayers: {
         klass: "org.hisp.dhis.mapping.ExternalMapLayer",
         shareable: true,
@@ -21233,425 +21094,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
         ],
     },
-    icons: {
-        klass: "org.hisp.dhis.icon.Icon",
-        shareable: false,
-        metadata: false,
-        relativeApiEndpoint: "/icons",
-        plural: "icons",
-        displayName: "Icon",
-        collectionName: "icons",
-        nameableObject: false,
-        translatable: false,
-        identifiableObject: false,
-        dataShareable: false,
-        name: "icon",
-        persisted: false,
-        embeddedObject: false,
-        properties: [],
-    },
-    externalFileResources: {
-        klass: "org.hisp.dhis.fileresource.ExternalFileResource",
-        shareable: false,
-        metadata: true,
-        relativeApiEndpoint: "/externalFileResources",
-        plural: "externalFileResources",
-        displayName: "External File Resource",
-        collectionName: "externalFileResources",
-        nameableObject: false,
-        translatable: false,
-        identifiableObject: true,
-        dataShareable: false,
-        name: "identifiableObject",
-        persisted: true,
-        embeddedObject: false,
-        properties: [
-            {
-                name: "favorite",
-                fieldName: "favorites",
-                propertyType: "COLLECTION",
-                itemPropertyType: "TEXT",
-                klass: "java.util.Set",
-                itemKlass: "java.lang.String",
-            },
-            {
-                name: "lastUpdatedBy",
-                fieldName: "lastUpdatedBy",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            {
-                name: "access",
-                fieldName: "access",
-                propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.security.acl.Access",
-            },
-            {
-                name: "userGroupAccess",
-                fieldName: "userGroupAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
-            },
-            {
-                name: "code",
-                fieldName: "code",
-                propertyType: "IDENTIFIER",
-                klass: "java.lang.String",
-            },
-            {
-                name: "created",
-                fieldName: "created",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "displayName",
-                fieldName: "displayName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "publicAccess",
-                fieldName: "publicAccess",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "attributeValue",
-                fieldName: "attributeValues",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
-            },
-            {
-                name: "externalAccess",
-                fieldName: "externalAccess",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "lastUpdated",
-                fieldName: "lastUpdated",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "translation",
-                fieldName: "translations",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.translation.Translation",
-            },
-            {
-                name: "userAccess",
-                fieldName: "userAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserAccess",
-            },
-            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
-            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
-            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
-            {
-                name: "user",
-                fieldName: "user",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
-        ],
-    },
-    validationNotificationTemplates: {
-        klass: "org.hisp.dhis.validation.notification.ValidationNotificationTemplate",
-        shareable: false,
-        metadata: true,
-        relativeApiEndpoint: "/validationNotificationTemplates",
-        plural: "validationNotificationTemplates",
-        displayName: "Validation Notification Template",
-        collectionName: "validationNotificationTemplates",
-        nameableObject: false,
-        translatable: false,
-        identifiableObject: true,
-        dataShareable: false,
-        name: "identifiableObject",
-        persisted: true,
-        embeddedObject: false,
-        properties: [
-            {
-                name: "favorite",
-                fieldName: "favorites",
-                propertyType: "COLLECTION",
-                itemPropertyType: "TEXT",
-                klass: "java.util.Set",
-                itemKlass: "java.lang.String",
-            },
-            {
-                name: "access",
-                fieldName: "access",
-                propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.security.acl.Access",
-            },
-            {
-                name: "code",
-                fieldName: "code",
-                propertyType: "IDENTIFIER",
-                klass: "java.lang.String",
-            },
-            {
-                name: "displayName",
-                fieldName: "displayName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "publicAccess",
-                fieldName: "publicAccess",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "recipientUserGroups",
-                fieldName: "recipientUserGroups",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserGroup",
-            },
-            {
-                name: "externalAccess",
-                fieldName: "externalAccess",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "lastUpdated",
-                fieldName: "lastUpdated",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "translation",
-                fieldName: "translations",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.translation.Translation",
-            },
-            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
-            {
-                name: "subjectTemplate",
-                fieldName: "subjectTemplate",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
-            {
-                name: "sendStrategy",
-                fieldName: "sendStrategy",
-                propertyType: "CONSTANT",
-                klass: "org.hisp.dhis.notification.SendStrategy",
-            },
-            {
-                name: "lastUpdatedBy",
-                fieldName: "lastUpdatedBy",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            {
-                name: "userGroupAccess",
-                fieldName: "userGroupAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
-            },
-            {
-                name: "validationRules",
-                fieldName: "validationRules",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.validation.ValidationRule",
-            },
-            {
-                name: "created",
-                fieldName: "created",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "notifyUsersInHierarchyOnly",
-                fieldName: "notifyUsersInHierarchyOnly",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "attributeValue",
-                fieldName: "attributeValues",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
-            },
-            {
-                name: "notifyParentOrganisationUnitOnly",
-                fieldName: "notifyParentOrganisationUnitOnly",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "userAccess",
-                fieldName: "userAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserAccess",
-            },
-            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
-            {
-                name: "user",
-                fieldName: "user",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
-            {
-                name: "messageTemplate",
-                fieldName: "messageTemplate",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-        ],
-    },
-    dataStores: {
-        klass: "org.hisp.dhis.keyjsonvalue.KeyJsonValue",
-        shareable: true,
-        metadata: false,
-        relativeApiEndpoint: "/dataStore",
-        plural: "dataStores",
-        displayName: "Key Json Value",
-        collectionName: "dataStores",
-        nameableObject: false,
-        translatable: false,
-        identifiableObject: true,
-        dataShareable: false,
-        name: "identifiableObject",
-        persisted: true,
-        embeddedObject: false,
-        properties: [
-            {
-                name: "favorite",
-                fieldName: "favorites",
-                propertyType: "COLLECTION",
-                itemPropertyType: "TEXT",
-                klass: "java.util.Set",
-                itemKlass: "java.lang.String",
-            },
-            {
-                name: "lastUpdatedBy",
-                fieldName: "lastUpdatedBy",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            {
-                name: "access",
-                fieldName: "access",
-                propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.security.acl.Access",
-            },
-            {
-                name: "userGroupAccess",
-                fieldName: "userGroupAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
-            },
-            {
-                name: "code",
-                fieldName: "code",
-                propertyType: "IDENTIFIER",
-                klass: "java.lang.String",
-            },
-            {
-                name: "created",
-                fieldName: "created",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "displayName",
-                fieldName: "displayName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "publicAccess",
-                fieldName: "publicAccess",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "attributeValue",
-                fieldName: "attributeValues",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
-            },
-            {
-                name: "externalAccess",
-                fieldName: "externalAccess",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "lastUpdated",
-                fieldName: "lastUpdated",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "translation",
-                fieldName: "translations",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.translation.Translation",
-            },
-            {
-                name: "userAccess",
-                fieldName: "userAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserAccess",
-            },
-            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
-            {
-                name: "namespace",
-                fieldName: "namespace",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
-            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
-            {
-                name: "user",
-                fieldName: "user",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            { name: "value", fieldName: "value", propertyType: "TEXT", klass: "java.lang.String" },
-            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
-            { name: "key", fieldName: "key", propertyType: "TEXT", klass: "java.lang.String" },
-        ],
-    },
     fileResources: {
         klass: "org.hisp.dhis.fileresource.FileResource",
         shareable: false,
@@ -21804,245 +21246,22 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
         ],
     },
-    programStageInstances: {
-        klass: "org.hisp.dhis.program.ProgramStageInstance",
+    icons: {
+        klass: "org.hisp.dhis.icon.Icon",
         shareable: false,
         metadata: false,
-        relativeApiEndpoint: "/programStageInstances",
-        plural: "programStageInstances",
-        displayName: "Program Stage Instance",
-        collectionName: "programStageInstances",
+        relativeApiEndpoint: "/icons",
+        plural: "icons",
+        displayName: "Icon",
+        collectionName: "icons",
         nameableObject: false,
         translatable: false,
-        identifiableObject: true,
+        identifiableObject: false,
         dataShareable: false,
-        name: "identifiableObject",
-        persisted: true,
+        name: "icon",
+        persisted: false,
         embeddedObject: false,
-        properties: [
-            {
-                name: "favorite",
-                fieldName: "favorites",
-                propertyType: "COLLECTION",
-                itemPropertyType: "TEXT",
-                klass: "java.util.Set",
-                itemKlass: "java.lang.String",
-            },
-            {
-                name: "code",
-                fieldName: "code",
-                propertyType: "IDENTIFIER",
-                klass: "java.lang.String",
-            },
-            {
-                name: "storedBy",
-                fieldName: "storedBy",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "access",
-                fieldName: "access",
-                propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.security.acl.Access",
-            },
-            {
-                name: "organisationUnit",
-                fieldName: "organisationUnit",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.organisationunit.OrganisationUnit",
-            },
-            {
-                name: "displayName",
-                fieldName: "displayName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "publicAccess",
-                fieldName: "publicAccess",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "dueDate",
-                fieldName: "dueDate",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "createdAtClient",
-                fieldName: "createdAtClient",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "messageConversations",
-                fieldName: "messageConversations",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.List",
-                itemKlass: "org.hisp.dhis.message.MessageConversation",
-            },
-            {
-                name: "externalAccess",
-                fieldName: "externalAccess",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "lastUpdated",
-                fieldName: "lastUpdated",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "eventDataValues",
-                fieldName: "eventDataValues",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.eventdatavalue.EventDataValue",
-            },
-            {
-                name: "translation",
-                fieldName: "translations",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.translation.Translation",
-            },
-            {
-                name: "relationshipItem",
-                fieldName: "relationshipItems",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.relationship.RelationshipItem",
-            },
-            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
-            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
-            {
-                name: "assignedUser",
-                fieldName: "assignedUser",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            {
-                name: "lastUpdatedBy",
-                fieldName: "lastUpdatedBy",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            {
-                name: "programStage",
-                fieldName: "programStage",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.program.ProgramStage",
-            },
-            {
-                name: "userGroupAccess",
-                fieldName: "userGroupAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
-            },
-            {
-                name: "comments",
-                fieldName: "comments",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.List",
-                itemKlass: "org.hisp.dhis.trackedentitycomment.TrackedEntityComment",
-            },
-            {
-                name: "created",
-                fieldName: "created",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            { name: "creatableInSearchScope", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
-            {
-                name: "attributeValue",
-                fieldName: "attributeValues",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
-            },
-            { name: "completed", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
-            {
-                name: "completedDate",
-                fieldName: "completedDate",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "programInstance",
-                fieldName: "programInstance",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.program.ProgramInstance",
-            },
-            {
-                name: "deleted",
-                fieldName: "deleted",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "userAccess",
-                fieldName: "userAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserAccess",
-            },
-            {
-                name: "attributeOptionCombo",
-                fieldName: "attributeOptionCombo",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.category.CategoryOptionCombo",
-            },
-            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
-            {
-                name: "geometry",
-                fieldName: "geometry",
-                propertyType: "COMPLEX",
-                klass: "com.vividsolutions.jts.geom.Geometry",
-            },
-            {
-                name: "user",
-                fieldName: "user",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
-            {
-                name: "completedBy",
-                fieldName: "completedBy",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "status",
-                fieldName: "status",
-                propertyType: "CONSTANT",
-                klass: "org.hisp.dhis.event.EventStatus",
-            },
-            {
-                name: "lastUpdatedAtClient",
-                fieldName: "lastUpdatedAtClient",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "eventDate",
-                fieldName: "executionDate",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-        ],
+        properties: [],
     },
     indicators: {
         klass: "org.hisp.dhis.indicator.Indicator",
@@ -23216,6 +22435,130 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 propertyType: "TEXT",
                 klass: "java.lang.String",
             },
+        ],
+    },
+    dataStores: {
+        klass: "org.hisp.dhis.keyjsonvalue.KeyJsonValue",
+        shareable: true,
+        metadata: false,
+        relativeApiEndpoint: "/dataStore",
+        plural: "dataStores",
+        displayName: "Key Json Value",
+        collectionName: "dataStores",
+        nameableObject: false,
+        translatable: false,
+        identifiableObject: true,
+        dataShareable: false,
+        name: "identifiableObject",
+        persisted: true,
+        embeddedObject: false,
+        properties: [
+            {
+                name: "favorite",
+                fieldName: "favorites",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.Set",
+                itemKlass: "java.lang.String",
+            },
+            {
+                name: "lastUpdatedBy",
+                fieldName: "lastUpdatedBy",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "access",
+                fieldName: "access",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.security.acl.Access",
+            },
+            {
+                name: "userGroupAccess",
+                fieldName: "userGroupAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
+            },
+            {
+                name: "code",
+                fieldName: "code",
+                propertyType: "IDENTIFIER",
+                klass: "java.lang.String",
+            },
+            {
+                name: "created",
+                fieldName: "created",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "displayName",
+                fieldName: "displayName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "publicAccess",
+                fieldName: "publicAccess",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "attributeValue",
+                fieldName: "attributeValues",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
+            },
+            {
+                name: "externalAccess",
+                fieldName: "externalAccess",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "lastUpdated",
+                fieldName: "lastUpdated",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "translation",
+                fieldName: "translations",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.translation.Translation",
+            },
+            {
+                name: "userAccess",
+                fieldName: "userAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserAccess",
+            },
+            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
+            {
+                name: "namespace",
+                fieldName: "namespace",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
+            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
+            {
+                name: "user",
+                fieldName: "user",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            { name: "value", fieldName: "value", propertyType: "TEXT", klass: "java.lang.String" },
+            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+            { name: "key", fieldName: "key", propertyType: "TEXT", klass: "java.lang.String" },
         ],
     },
     legends: {
@@ -26431,6 +25774,222 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
         ],
     },
+    predictors: {
+        klass: "org.hisp.dhis.predictor.Predictor",
+        shareable: false,
+        metadata: true,
+        relativeApiEndpoint: "/predictors",
+        plural: "predictors",
+        displayName: "Predictor",
+        collectionName: "predictors",
+        nameableObject: true,
+        translatable: false,
+        identifiableObject: true,
+        dataShareable: false,
+        name: "Predictor",
+        persisted: true,
+        embeddedObject: false,
+        properties: [
+            {
+                name: "favorite",
+                fieldName: "favorites",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.Set",
+                itemKlass: "java.lang.String",
+            },
+            {
+                name: "outputCombo",
+                fieldName: "outputCombo",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.category.CategoryOptionCombo",
+            },
+            {
+                name: "code",
+                fieldName: "code",
+                propertyType: "IDENTIFIER",
+                klass: "java.lang.String",
+            },
+            {
+                name: "access",
+                fieldName: "access",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.security.acl.Access",
+            },
+            {
+                name: "displayName",
+                fieldName: "displayName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "publicAccess",
+                fieldName: "publicAccess",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "description",
+                fieldName: "description",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "generator",
+                fieldName: "generator",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.expression.Expression",
+            },
+            {
+                name: "displayShortName",
+                fieldName: "displayShortName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "organisationUnitLevel",
+                fieldName: "organisationUnitLevels",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.organisationunit.OrganisationUnitLevel",
+            },
+            {
+                name: "externalAccess",
+                fieldName: "externalAccess",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "output",
+                fieldName: "output",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.dataelement.DataElement",
+            },
+            {
+                name: "lastUpdated",
+                fieldName: "lastUpdated",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "sampleSkipTest",
+                fieldName: "sampleSkipTest",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.expression.Expression",
+            },
+            {
+                name: "translation",
+                fieldName: "translations",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.translation.Translation",
+            },
+            {
+                name: "formName",
+                fieldName: "formName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
+            {
+                name: "sequentialSampleCount",
+                fieldName: "sequentialSampleCount",
+                propertyType: "INTEGER",
+                klass: "java.lang.Integer",
+            },
+            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
+            {
+                name: "displayDescription",
+                fieldName: "displayDescription",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "annualSampleCount",
+                fieldName: "annualSampleCount",
+                propertyType: "INTEGER",
+                klass: "java.lang.Integer",
+            },
+            {
+                name: "lastUpdatedBy",
+                fieldName: "lastUpdatedBy",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "userGroupAccess",
+                fieldName: "userGroupAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
+            },
+            {
+                name: "created",
+                fieldName: "created",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "attributeValue",
+                fieldName: "attributeValues",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
+            },
+            {
+                name: "sequentialSkipCount",
+                fieldName: "sequentialSkipCount",
+                propertyType: "INTEGER",
+                klass: "java.lang.Integer",
+            },
+            {
+                name: "predictorGroup",
+                fieldName: "groups",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.predictor.PredictorGroup",
+            },
+            {
+                name: "displayFormName",
+                fieldName: "displayFormName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "periodType",
+                fieldName: "periodType",
+                propertyType: "TEXT",
+                klass: "org.hisp.dhis.period.PeriodType",
+            },
+            {
+                name: "userAccess",
+                fieldName: "userAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserAccess",
+            },
+            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
+            {
+                name: "shortName",
+                fieldName: "shortName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "user",
+                fieldName: "user",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+        ],
+    },
     predictorGroups: {
         klass: "org.hisp.dhis.predictor.PredictorGroup",
         shareable: true,
@@ -26923,195 +26482,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             },
         ],
     },
-    ProgramTrackedEntityAttributeDimensionItems: {
-        klass: "org.hisp.dhis.program.ProgramTrackedEntityAttributeDimensionItem",
-        shareable: false,
-        metadata: false,
-        plural: "ProgramTrackedEntityAttributeDimensionItems",
-        displayName: "Program Tracked Entity Attribute Dimension Item",
-        collectionName: "ProgramTrackedEntityAttributeDimensionItems",
-        nameableObject: true,
-        translatable: false,
-        identifiableObject: true,
-        dataShareable: false,
-        name: "programAttributeDimension",
-        persisted: false,
-        embeddedObject: true,
-        properties: [
-            {
-                name: "favorite",
-                fieldName: "favorites",
-                propertyType: "COLLECTION",
-                itemPropertyType: "TEXT",
-                klass: "java.util.Set",
-                itemKlass: "java.lang.String",
-            },
-            {
-                name: "aggregationType",
-                fieldName: "aggregationType",
-                propertyType: "CONSTANT",
-                klass: "org.hisp.dhis.analytics.AggregationType",
-            },
-            {
-                name: "code",
-                fieldName: "code",
-                propertyType: "IDENTIFIER",
-                klass: "java.lang.String",
-            },
-            {
-                name: "access",
-                fieldName: "access",
-                propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.security.acl.Access",
-            },
-            {
-                name: "displayName",
-                fieldName: "displayName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "publicAccess",
-                fieldName: "publicAccess",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "description",
-                fieldName: "description",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "program",
-                fieldName: "program",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.program.Program",
-            },
-            {
-                name: "displayShortName",
-                fieldName: "displayShortName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "externalAccess",
-                fieldName: "externalAccess",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "lastUpdated",
-                fieldName: "lastUpdated",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "translation",
-                fieldName: "translations",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.translation.Translation",
-            },
-            {
-                name: "formName",
-                fieldName: "formName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
-            {
-                name: "attribute",
-                fieldName: "attribute",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.trackedentity.TrackedEntityAttribute",
-            },
-            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
-            {
-                name: "displayDescription",
-                fieldName: "displayDescription",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "lastUpdatedBy",
-                fieldName: "lastUpdatedBy",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            {
-                name: "userGroupAccess",
-                fieldName: "userGroupAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
-            },
-            { name: "dimensionItem", propertyType: "TEXT", klass: "java.lang.String" },
-            {
-                name: "created",
-                fieldName: "created",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "attributeValue",
-                fieldName: "attributeValues",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
-            },
-            {
-                name: "displayFormName",
-                fieldName: "displayFormName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "userAccess",
-                fieldName: "userAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserAccess",
-            },
-            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
-            {
-                name: "legendSet",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.legend.LegendSet",
-            },
-            {
-                name: "legendSets",
-                fieldName: "legendSets",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.List",
-                itemKlass: "org.hisp.dhis.legend.LegendSet",
-            },
-            {
-                name: "shortName",
-                fieldName: "shortName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "user",
-                fieldName: "user",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
-            {
-                name: "dimensionItemType",
-                fieldName: "dimensionItemType",
-                propertyType: "CONSTANT",
-                klass: "org.hisp.dhis.common.DimensionItemType",
-            },
-        ],
-    },
     programDataElements: {
         klass: "org.hisp.dhis.program.ProgramDataElementDimensionItem",
         shareable: false,
@@ -27552,41 +26922,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 fieldName: "dimensionItemType",
                 propertyType: "CONSTANT",
                 klass: "org.hisp.dhis.common.DimensionItemType",
-            },
-        ],
-    },
-    dataElementDimensions: {
-        klass: "org.hisp.dhis.trackedentity.TrackedEntityProgramIndicatorDimension",
-        shareable: false,
-        metadata: false,
-        plural: "dataElementDimensions",
-        displayName: "Tracked Entity Program Indicator Dimension",
-        collectionName: "dataElementDimensions",
-        nameableObject: false,
-        translatable: false,
-        identifiableObject: false,
-        dataShareable: false,
-        name: "programIndicatorDimension",
-        persisted: true,
-        embeddedObject: false,
-        properties: [
-            {
-                name: "filter",
-                fieldName: "filter",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "legendSet",
-                fieldName: "legendSet",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.legend.LegendSet",
-            },
-            {
-                name: "programIndicator",
-                fieldName: "programIndicator",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.program.ProgramIndicator",
             },
         ],
     },
@@ -29311,6 +28646,246 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
         ],
     },
+    programStageInstances: {
+        klass: "org.hisp.dhis.program.ProgramStageInstance",
+        shareable: false,
+        metadata: false,
+        relativeApiEndpoint: "/programStageInstances",
+        plural: "programStageInstances",
+        displayName: "Program Stage Instance",
+        collectionName: "programStageInstances",
+        nameableObject: false,
+        translatable: false,
+        identifiableObject: true,
+        dataShareable: false,
+        name: "identifiableObject",
+        persisted: true,
+        embeddedObject: false,
+        properties: [
+            {
+                name: "favorite",
+                fieldName: "favorites",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.Set",
+                itemKlass: "java.lang.String",
+            },
+            {
+                name: "code",
+                fieldName: "code",
+                propertyType: "IDENTIFIER",
+                klass: "java.lang.String",
+            },
+            {
+                name: "storedBy",
+                fieldName: "storedBy",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "access",
+                fieldName: "access",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.security.acl.Access",
+            },
+            {
+                name: "organisationUnit",
+                fieldName: "organisationUnit",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.organisationunit.OrganisationUnit",
+            },
+            {
+                name: "displayName",
+                fieldName: "displayName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "publicAccess",
+                fieldName: "publicAccess",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "dueDate",
+                fieldName: "dueDate",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "createdAtClient",
+                fieldName: "createdAtClient",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "messageConversations",
+                fieldName: "messageConversations",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.message.MessageConversation",
+            },
+            {
+                name: "externalAccess",
+                fieldName: "externalAccess",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "lastUpdated",
+                fieldName: "lastUpdated",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "eventDataValues",
+                fieldName: "eventDataValues",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.eventdatavalue.EventDataValue",
+            },
+            {
+                name: "translation",
+                fieldName: "translations",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.translation.Translation",
+            },
+            {
+                name: "relationshipItem",
+                fieldName: "relationshipItems",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.relationship.RelationshipItem",
+            },
+            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
+            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
+            {
+                name: "assignedUser",
+                fieldName: "assignedUser",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "lastUpdatedBy",
+                fieldName: "lastUpdatedBy",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "programStage",
+                fieldName: "programStage",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.program.ProgramStage",
+            },
+            {
+                name: "userGroupAccess",
+                fieldName: "userGroupAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
+            },
+            {
+                name: "comments",
+                fieldName: "comments",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.trackedentitycomment.TrackedEntityComment",
+            },
+            {
+                name: "created",
+                fieldName: "created",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            { name: "creatableInSearchScope", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+            {
+                name: "attributeValue",
+                fieldName: "attributeValues",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
+            },
+            { name: "completed", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+            {
+                name: "completedDate",
+                fieldName: "completedDate",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "programInstance",
+                fieldName: "programInstance",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.program.ProgramInstance",
+            },
+            {
+                name: "deleted",
+                fieldName: "deleted",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "userAccess",
+                fieldName: "userAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserAccess",
+            },
+            {
+                name: "attributeOptionCombo",
+                fieldName: "attributeOptionCombo",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.category.CategoryOptionCombo",
+            },
+            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
+            {
+                name: "geometry",
+                fieldName: "geometry",
+                propertyType: "COMPLEX",
+                klass: "com.vividsolutions.jts.geom.Geometry",
+            },
+            {
+                name: "user",
+                fieldName: "user",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+            {
+                name: "completedBy",
+                fieldName: "completedBy",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "status",
+                fieldName: "status",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.event.EventStatus",
+            },
+            {
+                name: "lastUpdatedAtClient",
+                fieldName: "lastUpdatedAtClient",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "eventDate",
+                fieldName: "executionDate",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+        ],
+    },
     eventFilters: {
         klass: "org.hisp.dhis.programstagefilter.ProgramStageInstanceFilter",
         shareable: true,
@@ -29824,6 +29399,195 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "org.hisp.dhis.user.User",
             },
             { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+        ],
+    },
+    ProgramTrackedEntityAttributeDimensionItems: {
+        klass: "org.hisp.dhis.program.ProgramTrackedEntityAttributeDimensionItem",
+        shareable: false,
+        metadata: false,
+        plural: "ProgramTrackedEntityAttributeDimensionItems",
+        displayName: "Program Tracked Entity Attribute Dimension Item",
+        collectionName: "ProgramTrackedEntityAttributeDimensionItems",
+        nameableObject: true,
+        translatable: false,
+        identifiableObject: true,
+        dataShareable: false,
+        name: "programAttributeDimension",
+        persisted: false,
+        embeddedObject: true,
+        properties: [
+            {
+                name: "favorite",
+                fieldName: "favorites",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.Set",
+                itemKlass: "java.lang.String",
+            },
+            {
+                name: "aggregationType",
+                fieldName: "aggregationType",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.analytics.AggregationType",
+            },
+            {
+                name: "code",
+                fieldName: "code",
+                propertyType: "IDENTIFIER",
+                klass: "java.lang.String",
+            },
+            {
+                name: "access",
+                fieldName: "access",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.security.acl.Access",
+            },
+            {
+                name: "displayName",
+                fieldName: "displayName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "publicAccess",
+                fieldName: "publicAccess",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "description",
+                fieldName: "description",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "program",
+                fieldName: "program",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.program.Program",
+            },
+            {
+                name: "displayShortName",
+                fieldName: "displayShortName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "externalAccess",
+                fieldName: "externalAccess",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "lastUpdated",
+                fieldName: "lastUpdated",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "translation",
+                fieldName: "translations",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.translation.Translation",
+            },
+            {
+                name: "formName",
+                fieldName: "formName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
+            {
+                name: "attribute",
+                fieldName: "attribute",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.trackedentity.TrackedEntityAttribute",
+            },
+            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
+            {
+                name: "displayDescription",
+                fieldName: "displayDescription",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "lastUpdatedBy",
+                fieldName: "lastUpdatedBy",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "userGroupAccess",
+                fieldName: "userGroupAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
+            },
+            { name: "dimensionItem", propertyType: "TEXT", klass: "java.lang.String" },
+            {
+                name: "created",
+                fieldName: "created",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "attributeValue",
+                fieldName: "attributeValues",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
+            },
+            {
+                name: "displayFormName",
+                fieldName: "displayFormName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "userAccess",
+                fieldName: "userAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserAccess",
+            },
+            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
+            {
+                name: "legendSet",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.legend.LegendSet",
+            },
+            {
+                name: "legendSets",
+                fieldName: "legendSets",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.legend.LegendSet",
+            },
+            {
+                name: "shortName",
+                fieldName: "shortName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "user",
+                fieldName: "user",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+            {
+                name: "dimensionItemType",
+                fieldName: "dimensionItemType",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.common.DimensionItemType",
+            },
         ],
     },
     programTrackedEntityAttributeGroups: {
@@ -31340,183 +31104,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             },
         ],
     },
-    sections: {
-        klass: "org.hisp.dhis.dataset.Section",
-        shareable: false,
-        metadata: true,
-        relativeApiEndpoint: "/sections",
-        plural: "sections",
-        displayName: "Section",
-        collectionName: "sections",
-        nameableObject: false,
-        translatable: true,
-        identifiableObject: true,
-        dataShareable: false,
-        name: "section",
-        persisted: true,
-        embeddedObject: false,
-        properties: [
-            {
-                name: "favorite",
-                fieldName: "favorites",
-                propertyType: "COLLECTION",
-                itemPropertyType: "TEXT",
-                klass: "java.util.Set",
-                itemKlass: "java.lang.String",
-            },
-            {
-                name: "code",
-                fieldName: "code",
-                propertyType: "IDENTIFIER",
-                klass: "java.lang.String",
-            },
-            {
-                name: "access",
-                fieldName: "access",
-                propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.security.acl.Access",
-            },
-            {
-                name: "greyedField",
-                fieldName: "greyedFields",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.dataelement.DataElementOperand",
-            },
-            {
-                name: "displayName",
-                fieldName: "displayName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "publicAccess",
-                fieldName: "publicAccess",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "description",
-                fieldName: "description",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "externalAccess",
-                fieldName: "externalAccess",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "lastUpdated",
-                fieldName: "lastUpdated",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "translation",
-                fieldName: "translations",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.translation.Translation",
-            },
-            {
-                name: "categoryCombos",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.category.CategoryCombo",
-            },
-            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
-            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
-            {
-                name: "dataSet",
-                fieldName: "dataSet",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.dataset.DataSet",
-            },
-            {
-                name: "dataElement",
-                fieldName: "dataElements",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.List",
-                itemKlass: "org.hisp.dhis.dataelement.DataElement",
-            },
-            {
-                name: "showColumnTotals",
-                fieldName: "showColumnTotals",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "lastUpdatedBy",
-                fieldName: "lastUpdatedBy",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            {
-                name: "userGroupAccess",
-                fieldName: "userGroupAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
-            },
-            {
-                name: "created",
-                fieldName: "created",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "attributeValue",
-                fieldName: "attributeValues",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
-            },
-            {
-                name: "indicator",
-                fieldName: "indicators",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.List",
-                itemKlass: "org.hisp.dhis.indicator.Indicator",
-            },
-            {
-                name: "sortOrder",
-                fieldName: "sortOrder",
-                propertyType: "INTEGER",
-                klass: "java.lang.Integer",
-            },
-            {
-                name: "userAccess",
-                fieldName: "userAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserAccess",
-            },
-            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
-            {
-                name: "user",
-                fieldName: "user",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            {
-                name: "showRowTotals",
-                fieldName: "showRowTotals",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
-        ],
-    },
     smsCommands: {
         klass: "org.hisp.dhis.sms.command.SMSCommand",
         shareable: false,
@@ -31735,6 +31322,183 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 fieldName: "dataset",
                 propertyType: "REFERENCE",
                 klass: "org.hisp.dhis.dataset.DataSet",
+            },
+            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+        ],
+    },
+    sections: {
+        klass: "org.hisp.dhis.dataset.Section",
+        shareable: false,
+        metadata: true,
+        relativeApiEndpoint: "/sections",
+        plural: "sections",
+        displayName: "Section",
+        collectionName: "sections",
+        nameableObject: false,
+        translatable: true,
+        identifiableObject: true,
+        dataShareable: false,
+        name: "section",
+        persisted: true,
+        embeddedObject: false,
+        properties: [
+            {
+                name: "favorite",
+                fieldName: "favorites",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.Set",
+                itemKlass: "java.lang.String",
+            },
+            {
+                name: "code",
+                fieldName: "code",
+                propertyType: "IDENTIFIER",
+                klass: "java.lang.String",
+            },
+            {
+                name: "access",
+                fieldName: "access",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.security.acl.Access",
+            },
+            {
+                name: "greyedField",
+                fieldName: "greyedFields",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.dataelement.DataElementOperand",
+            },
+            {
+                name: "displayName",
+                fieldName: "displayName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "publicAccess",
+                fieldName: "publicAccess",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "description",
+                fieldName: "description",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "externalAccess",
+                fieldName: "externalAccess",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "lastUpdated",
+                fieldName: "lastUpdated",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "translation",
+                fieldName: "translations",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.translation.Translation",
+            },
+            {
+                name: "categoryCombos",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.category.CategoryCombo",
+            },
+            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
+            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
+            {
+                name: "dataSet",
+                fieldName: "dataSet",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.dataset.DataSet",
+            },
+            {
+                name: "dataElement",
+                fieldName: "dataElements",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.dataelement.DataElement",
+            },
+            {
+                name: "showColumnTotals",
+                fieldName: "showColumnTotals",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "lastUpdatedBy",
+                fieldName: "lastUpdatedBy",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "userGroupAccess",
+                fieldName: "userGroupAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
+            },
+            {
+                name: "created",
+                fieldName: "created",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "attributeValue",
+                fieldName: "attributeValues",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
+            },
+            {
+                name: "indicator",
+                fieldName: "indicators",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.indicator.Indicator",
+            },
+            {
+                name: "sortOrder",
+                fieldName: "sortOrder",
+                propertyType: "INTEGER",
+                klass: "java.lang.Integer",
+            },
+            {
+                name: "userAccess",
+                fieldName: "userAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserAccess",
+            },
+            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
+            {
+                name: "user",
+                fieldName: "user",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "showRowTotals",
+                fieldName: "showRowTotals",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
             },
             { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
         ],
@@ -32203,6 +31967,47 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             },
         ],
     },
+    trackedEntityDataElementDimensions: {
+        klass: "org.hisp.dhis.trackedentity.TrackedEntityDataElementDimension",
+        shareable: false,
+        metadata: false,
+        plural: "trackedEntityDataElementDimensions",
+        displayName: "Tracked Entity Data Element Dimension",
+        collectionName: "trackedEntityDataElementDimensions",
+        nameableObject: false,
+        translatable: false,
+        identifiableObject: false,
+        dataShareable: false,
+        name: "dataElementDimension",
+        persisted: true,
+        embeddedObject: false,
+        properties: [
+            {
+                name: "filter",
+                fieldName: "filter",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "legendSet",
+                fieldName: "legendSet",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.legend.LegendSet",
+            },
+            {
+                name: "programStage",
+                fieldName: "programStage",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.program.ProgramStage",
+            },
+            {
+                name: "dataElement",
+                fieldName: "dataElement",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.dataelement.DataElement",
+            },
+        ],
+    },
     trackedEntityInstances: {
         klass: "org.hisp.dhis.trackedentity.TrackedEntityInstance",
         shareable: false,
@@ -32556,6 +32361,41 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "org.hisp.dhis.user.User",
             },
             { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+        ],
+    },
+    dataElementDimensions: {
+        klass: "org.hisp.dhis.trackedentity.TrackedEntityProgramIndicatorDimension",
+        shareable: false,
+        metadata: false,
+        plural: "dataElementDimensions",
+        displayName: "Tracked Entity Program Indicator Dimension",
+        collectionName: "dataElementDimensions",
+        nameableObject: false,
+        translatable: false,
+        identifiableObject: false,
+        dataShareable: false,
+        name: "programIndicatorDimension",
+        persisted: true,
+        embeddedObject: false,
+        properties: [
+            {
+                name: "filter",
+                fieldName: "filter",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "legendSet",
+                fieldName: "legendSet",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.legend.LegendSet",
+            },
+            {
+                name: "programIndicator",
+                fieldName: "programIndicator",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.program.ProgramIndicator",
+            },
         ],
     },
     trackedEntityTypes: {
@@ -33195,6 +33035,143 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             { name: "userUid", propertyType: "TEXT", klass: "java.lang.String" },
         ],
     },
+    userRoles: {
+        klass: "org.hisp.dhis.user.UserAuthorityGroup",
+        shareable: true,
+        metadata: true,
+        relativeApiEndpoint: "/userRoles",
+        plural: "userRoles",
+        displayName: "User Authority Group",
+        collectionName: "userRoles",
+        nameableObject: false,
+        translatable: true,
+        identifiableObject: true,
+        dataShareable: false,
+        name: "userRole",
+        persisted: true,
+        embeddedObject: false,
+        properties: [
+            {
+                name: "favorite",
+                fieldName: "favorites",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.Set",
+                itemKlass: "java.lang.String",
+            },
+            {
+                name: "lastUpdatedBy",
+                fieldName: "lastUpdatedBy",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "access",
+                fieldName: "access",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.security.acl.Access",
+            },
+            {
+                name: "userGroupAccess",
+                fieldName: "userGroupAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
+            },
+            {
+                name: "code",
+                fieldName: "code",
+                propertyType: "IDENTIFIER",
+                klass: "java.lang.String",
+            },
+            {
+                name: "created",
+                fieldName: "created",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "displayName",
+                fieldName: "displayName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "publicAccess",
+                fieldName: "publicAccess",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "attributeValue",
+                fieldName: "attributeValues",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
+            },
+            {
+                name: "description",
+                fieldName: "description",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "authority",
+                fieldName: "authorities",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.Set",
+                itemKlass: "java.lang.String",
+            },
+            {
+                name: "userObject",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "externalAccess",
+                fieldName: "externalAccess",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "lastUpdated",
+                fieldName: "lastUpdated",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "translation",
+                fieldName: "translations",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.translation.Translation",
+            },
+            {
+                name: "userAccess",
+                fieldName: "userAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserAccess",
+            },
+            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
+            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
+            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
+            {
+                name: "user",
+                fieldName: "user",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+        ],
+    },
     userCredentials: {
         klass: "org.hisp.dhis.user.UserCredentials",
         shareable: false,
@@ -33572,19 +33549,19 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             { name: "displayName", propertyType: "TEXT", klass: "java.lang.String" },
         ],
     },
-    userRoles: {
-        klass: "org.hisp.dhis.user.UserAuthorityGroup",
-        shareable: true,
+    validationNotificationTemplates: {
+        klass: "org.hisp.dhis.validation.notification.ValidationNotificationTemplate",
+        shareable: false,
         metadata: true,
-        relativeApiEndpoint: "/userRoles",
-        plural: "userRoles",
-        displayName: "User Authority Group",
-        collectionName: "userRoles",
+        relativeApiEndpoint: "/validationNotificationTemplates",
+        plural: "validationNotificationTemplates",
+        displayName: "Validation Notification Template",
+        collectionName: "validationNotificationTemplates",
         nameableObject: false,
-        translatable: true,
+        translatable: false,
         identifiableObject: true,
         dataShareable: false,
-        name: "userRole",
+        name: "identifiableObject",
         persisted: true,
         embeddedObject: false,
         properties: [
@@ -33597,36 +33574,16 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 itemKlass: "java.lang.String",
             },
             {
-                name: "lastUpdatedBy",
-                fieldName: "lastUpdatedBy",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            {
                 name: "access",
                 fieldName: "access",
                 propertyType: "COMPLEX",
                 klass: "org.hisp.dhis.security.acl.Access",
             },
             {
-                name: "userGroupAccess",
-                fieldName: "userGroupAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
-            },
-            {
                 name: "code",
                 fieldName: "code",
                 propertyType: "IDENTIFIER",
                 klass: "java.lang.String",
-            },
-            {
-                name: "created",
-                fieldName: "created",
-                propertyType: "DATE",
-                klass: "java.util.Date",
             },
             {
                 name: "displayName",
@@ -33641,33 +33598,12 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "java.lang.String",
             },
             {
-                name: "attributeValue",
-                fieldName: "attributeValues",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
-            },
-            {
-                name: "description",
-                fieldName: "description",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "authority",
-                fieldName: "authorities",
-                propertyType: "COLLECTION",
-                itemPropertyType: "TEXT",
-                klass: "java.util.Set",
-                itemKlass: "java.lang.String",
-            },
-            {
-                name: "userObject",
+                name: "recipientUserGroups",
+                fieldName: "recipientUserGroups",
                 propertyType: "COLLECTION",
                 itemPropertyType: "REFERENCE",
-                klass: "java.util.List",
-                itemKlass: "org.hisp.dhis.user.User",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserGroup",
             },
             {
                 name: "externalAccess",
@@ -33689,6 +33625,68 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "java.util.Set",
                 itemKlass: "org.hisp.dhis.translation.Translation",
             },
+            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
+            {
+                name: "subjectTemplate",
+                fieldName: "subjectTemplate",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
+            {
+                name: "sendStrategy",
+                fieldName: "sendStrategy",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.notification.SendStrategy",
+            },
+            {
+                name: "lastUpdatedBy",
+                fieldName: "lastUpdatedBy",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "userGroupAccess",
+                fieldName: "userGroupAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
+            },
+            {
+                name: "validationRules",
+                fieldName: "validationRules",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.validation.ValidationRule",
+            },
+            {
+                name: "created",
+                fieldName: "created",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "notifyUsersInHierarchyOnly",
+                fieldName: "notifyUsersInHierarchyOnly",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "attributeValue",
+                fieldName: "attributeValues",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
+            },
+            {
+                name: "notifyParentOrganisationUnitOnly",
+                fieldName: "notifyParentOrganisationUnitOnly",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
             {
                 name: "userAccess",
                 fieldName: "userAccesses",
@@ -33698,8 +33696,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 itemKlass: "org.hisp.dhis.user.UserAccess",
             },
             { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
-            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
-            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
             {
                 name: "user",
                 fieldName: "user",
@@ -33707,6 +33703,12 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "org.hisp.dhis.user.User",
             },
             { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+            {
+                name: "messageTemplate",
+                fieldName: "messageTemplate",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
         ],
     },
     validationResults: {
@@ -34171,7 +34173,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
 };
 
 export type D2ModelSchemas = {
-    predictors: D2PredictorSchema;
     analyticsPeriodBoundaries: D2AnalyticsPeriodBoundarySchema;
     analyticsTableHooks: D2AnalyticsTableHookSchema;
     attributes: D2AttributeSchema;
@@ -34192,7 +34193,6 @@ export type D2ModelSchemas = {
     dataApprovalLevels: D2DataApprovalLevelSchema;
     dataApprovalWorkflows: D2DataApprovalWorkflowSchema;
     dataElements: D2DataElementSchema;
-    trackedEntityDataElementDimensions: D2TrackedEntityDataElementDimensionSchema;
     dataElementGroups: D2DataElementGroupSchema;
     dataElementGroupSets: D2DataElementGroupSetSchema;
     dataElementGroupSetDimensions: D2DataElementGroupSetDimensionSchema;
@@ -34206,13 +34206,10 @@ export type D2ModelSchemas = {
     eventCharts: D2EventChartSchema;
     eventReports: D2EventReportSchema;
     expressions: D2ExpressionSchema;
-    externalMapLayers: D2ExternalMapLayerSchema;
-    icons: D2IconSchema;
     externalFileResources: D2ExternalFileResourceSchema;
-    validationNotificationTemplates: D2ValidationNotificationTemplateSchema;
-    dataStores: D2KeyJsonValueSchema;
+    externalMapLayers: D2ExternalMapLayerSchema;
     fileResources: D2FileResourceSchema;
-    programStageInstances: D2ProgramStageInstanceSchema;
+    icons: D2IconSchema;
     indicators: D2IndicatorSchema;
     indicatorGroups: D2IndicatorGroupSchema;
     indicatorGroupSets: D2IndicatorGroupSetSchema;
@@ -34220,6 +34217,7 @@ export type D2ModelSchemas = {
     interpretations: D2InterpretationSchema;
     interpretationComments: D2InterpretationCommentSchema;
     jobConfigurations: D2JobConfigurationSchema;
+    dataStores: D2KeyJsonValueSchema;
     legends: D2LegendSchema;
     legendSets: D2LegendSetSchema;
     maps: D2MapSchema;
@@ -34237,12 +34235,11 @@ export type D2ModelSchemas = {
     organisationUnitGroupSets: D2OrganisationUnitGroupSetSchema;
     organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimensionSchema;
     organisationUnitLevels: D2OrganisationUnitLevelSchema;
+    predictors: D2PredictorSchema;
     predictorGroups: D2PredictorGroupSchema;
     programs: D2ProgramSchema;
-    ProgramTrackedEntityAttributeDimensionItems: D2ProgramTrackedEntityAttributeDimensionItemSchema;
     programDataElements: D2ProgramDataElementDimensionItemSchema;
     programIndicators: D2ProgramIndicatorSchema;
-    dataElementDimensions: D2TrackedEntityProgramIndicatorDimensionSchema;
     programIndicatorGroups: D2ProgramIndicatorGroupSchema;
     programInstances: D2ProgramInstanceSchema;
     programNotificationTemplates: D2ProgramNotificationTemplateSchema;
@@ -34252,9 +34249,11 @@ export type D2ModelSchemas = {
     programSections: D2ProgramSectionSchema;
     programStages: D2ProgramStageSchema;
     programStageDataElements: D2ProgramStageDataElementSchema;
+    programStageInstances: D2ProgramStageInstanceSchema;
     eventFilters: D2ProgramStageInstanceFilterSchema;
     programStageSections: D2ProgramStageSectionSchema;
     programTrackedEntityAttributes: D2ProgramTrackedEntityAttributeSchema;
+    ProgramTrackedEntityAttributeDimensionItems: D2ProgramTrackedEntityAttributeDimensionItemSchema;
     programTrackedEntityAttributeGroups: D2ProgramTrackedEntityAttributeGroupSchema;
     pushAnalysis: D2PushAnalysisSchema;
     relationships: D2RelationshipSchema;
@@ -34262,21 +34261,24 @@ export type D2ModelSchemas = {
     reports: D2ReportSchema;
     reportTables: D2ReportTableSchema;
     reportingRates: D2ReportingRateSchema;
-    sections: D2SectionSchema;
     smsCommands: D2SMSCommandSchema;
+    sections: D2SectionSchema;
     sqlViews: D2SqlViewSchema;
     trackedEntityAttributes: D2TrackedEntityAttributeSchema;
     trackedEntityAttributeValues: D2TrackedEntityAttributeValueSchema;
+    trackedEntityDataElementDimensions: D2TrackedEntityDataElementDimensionSchema;
     trackedEntityInstances: D2TrackedEntityInstanceSchema;
     trackedEntityInstanceFilters: D2TrackedEntityInstanceFilterSchema;
+    dataElementDimensions: D2TrackedEntityProgramIndicatorDimensionSchema;
     trackedEntityTypes: D2TrackedEntityTypeSchema;
     trackedEntityTypeAttributes: D2TrackedEntityTypeAttributeSchema;
     users: D2UserSchema;
     userAccesses: D2UserAccessSchema;
+    userRoles: D2UserAuthorityGroupSchema;
     userCredentials: D2UserCredentialsSchema;
     userGroups: D2UserGroupSchema;
     userGroupAccesses: D2UserGroupAccessSchema;
-    userRoles: D2UserAuthorityGroupSchema;
+    validationNotificationTemplates: D2ValidationNotificationTemplateSchema;
     validationResults: D2ValidationResultSchema;
     validationRules: D2ValidationRuleSchema;
     validationRuleGroups: D2ValidationRuleGroupSchema;

--- a/src/2.33/schemas.ts
+++ b/src/2.33/schemas.ts
@@ -257,6 +257,31 @@ export type D2SqlView = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
+export type D2OAuth2Client = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    cid: Id;
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    grantTypes: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    redirectUris: string[];
+    secret: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
 export type D2Constant = {
     access: D2Access;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
@@ -283,31 +308,6 @@ export type D2Constant = {
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
     value: number;
-};
-
-export type D2OAuth2Client = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    cid: Id;
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    grantTypes: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    redirectUris: string[];
-    secret: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
 };
 
 export type D2Option = {
@@ -456,69 +456,6 @@ export type D2OptionSet = {
     version: number;
 };
 
-export type D2OptionGroup = {
-    access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "FIRST"
-        | "FIRST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
-    name: string;
-    optionSet: D2OptionSet;
-    options: D2Option[];
-    publicAccess: string;
-    shortName: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
 export type D2OptionGroupSet = {
     access: D2Access;
     aggregationType:
@@ -592,22 +529,63 @@ export type D2OptionGroupSet = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2ColorSet = {
+export type D2OptionGroup = {
     access: D2Access;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
-    colors: D2Color[];
     created: string;
+    description: string;
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
+    displayDescription: string;
+    displayFormName: string;
     displayName: string;
+    displayShortName: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
+    formName: string;
     href: string;
     id: Id;
     lastUpdated: string;
     lastUpdatedBy: D2User;
+    legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
     name: string;
+    optionSet: D2OptionSet;
+    options: D2Option[];
     publicAccess: string;
+    shortName: string;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
@@ -631,6 +609,28 @@ export type D2LegendSet = {
     name: string;
     publicAccess: string;
     symbolizer: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ColorSet = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    colors: D2Color[];
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
@@ -1486,6 +1486,29 @@ export type D2DataElementGroupSet = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
+export type D2IndicatorType = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    factor: number;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    number: boolean;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
 export type D2AnalyticsTableHook = {
     access: D2Access;
     analyticsTableType:
@@ -1525,29 +1548,6 @@ export type D2AnalyticsTableHook = {
         | "DATA_APPROVAL_REMAP_LEVEL"
         | "DATA_APPROVAL_MIN_LEVEL";
     sql: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2IndicatorType = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    factor: number;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    number: boolean;
-    publicAccess: string;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
@@ -2171,6 +2171,35 @@ export type D2TrackedEntityType = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
+export type D2ProgramTrackedEntityAttributeGroup = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    attributes: D2ProgramTrackedEntityAttribute[];
+    code: Id;
+    created: string;
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    shortName: string;
+    translations: D2Translation[];
+    uniqunessType: "NONE" | "STRICT" | "VALIDATION";
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
 export type D2TrackedEntityTypeAttribute = {
     access: D2Access;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
@@ -2222,35 +2251,6 @@ export type D2TrackedEntityTypeAttribute = {
         | "URL"
         | "FILE_RESOURCE"
         | "IMAGE";
-};
-
-export type D2ProgramTrackedEntityAttributeGroup = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    attributes: D2ProgramTrackedEntityAttribute[];
-    code: Id;
-    created: string;
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    shortName: string;
-    translations: D2Translation[];
-    uniqunessType: "NONE" | "STRICT" | "VALIDATION";
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
 };
 
 export type D2ProgramNotificationTemplate = {
@@ -2330,6 +2330,51 @@ export type D2ProgramStageSection = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
+export type D2SMSCommand = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    codeValueSeparator: string;
+    completenessMethod: "ALL_DATAVALUE" | "AT_LEAST_ONE_DATAVALUE" | "DO_NOT_MARK_COMPLETE";
+    created: string;
+    currentPeriodUsedForReporting: boolean;
+    dataset: D2DataSet;
+    defaultMessage: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    moreThanOneOrgUnitMessage: string;
+    name: string;
+    noUserMessage: string;
+    parserType:
+        | "KEY_VALUE_PARSER"
+        | "J2ME_PARSER"
+        | "ALERT_PARSER"
+        | "UNREGISTERED_PARSER"
+        | "TRACKED_ENTITY_REGISTRATION_PARSER"
+        | "PROGRAM_STAGE_DATAENTRY_PARSER"
+        | "EVENT_REGISTRATION_PARSER";
+    program: D2Program;
+    programStage: D2ProgramStage;
+    publicAccess: string;
+    receivedMessage: string;
+    separator: string;
+    smsCodes: any[];
+    specialCharacters: any[];
+    successMessage: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroup: D2UserGroup;
+    userGroupAccesses: D2UserGroupAccess[];
+    wrongFormatMessage: string;
+};
+
 export type D2ProgramStage = {
     access: D2Access;
     allowGenerateNextVisit: boolean;
@@ -2383,51 +2428,6 @@ export type D2ProgramStage = {
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
     validationStrategy: "ON_COMPLETE" | "ON_UPDATE_AND_INSERT";
-};
-
-export type D2SMSCommand = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    codeValueSeparator: string;
-    completenessMethod: "ALL_DATAVALUE" | "AT_LEAST_ONE_DATAVALUE" | "DO_NOT_MARK_COMPLETE";
-    created: string;
-    currentPeriodUsedForReporting: boolean;
-    dataset: D2DataSet;
-    defaultMessage: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    moreThanOneOrgUnitMessage: string;
-    name: string;
-    noUserMessage: string;
-    parserType:
-        | "KEY_VALUE_PARSER"
-        | "J2ME_PARSER"
-        | "ALERT_PARSER"
-        | "UNREGISTERED_PARSER"
-        | "TRACKED_ENTITY_REGISTRATION_PARSER"
-        | "PROGRAM_STAGE_DATAENTRY_PARSER"
-        | "EVENT_REGISTRATION_PARSER";
-    program: D2Program;
-    programStage: D2ProgramStage;
-    publicAccess: string;
-    receivedMessage: string;
-    separator: string;
-    smsCodes: any[];
-    specialCharacters: any[];
-    successMessage: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroup: D2UserGroup;
-    userGroupAccesses: D2UserGroupAccess[];
-    wrongFormatMessage: string;
 };
 
 export type D2Program = {
@@ -2821,6 +2821,35 @@ export type D2ProgramIndicator = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
+export type D2RelationshipType = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    bidirectional: boolean;
+    code: Id;
+    created: string;
+    description: string;
+    displayFromToName: string;
+    displayName: string;
+    displayToFromName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    fromConstraint: D2RelationshipConstraint;
+    fromToName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    toConstraint: D2RelationshipConstraint;
+    toFromName: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
 export type D2ProgramIndicatorGroup = {
     access: D2Access;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
@@ -2872,35 +2901,6 @@ export type D2ProgramRuleVariable = {
     trackedEntityAttribute: D2TrackedEntityAttribute;
     translations: D2Translation[];
     useCodeForOptionSet: boolean;
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2RelationshipType = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    bidirectional: boolean;
-    code: Id;
-    created: string;
-    description: string;
-    displayFromToName: string;
-    displayName: string;
-    displayToFromName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    fromConstraint: D2RelationshipConstraint;
-    fromToName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    toConstraint: D2RelationshipConstraint;
-    toFromName: string;
-    translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
@@ -3103,30 +3103,71 @@ export type D2MapView = {
     userOrganisationUnitGrandChildren: boolean;
 };
 
-export type D2ExternalMapLayer = {
+export type D2Map = {
     access: D2Access;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    attribution: string;
+    basemap: string;
     code: Id;
     created: string;
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    interpretations: D2Interpretation[];
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    latitude: number;
+    longitude: number;
+    mapViews: D2MapView[];
+    name: string;
+    publicAccess: string;
+    shortName: string;
+    subscribed: boolean;
+    subscribers: string[];
+    title: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    zoom: number;
+};
+
+export type D2Report = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    cacheStrategy:
+        | "NO_CACHE"
+        | "CACHE_15_MINUTES"
+        | "CACHE_30_MINUTES"
+        | "CACHE_1_HOUR"
+        | "CACHE_6AM_TOMORROW"
+        | "CACHE_TWO_WEEKS"
+        | "RESPECT_SYSTEM_SETTING";
+    code: Id;
+    created: string;
+    designContent: string;
     displayName: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
     href: string;
     id: Id;
-    imageFormat: "PNG" | "JPG";
     lastUpdated: string;
     lastUpdatedBy: D2User;
-    layers: string;
-    legendSet: D2LegendSet;
-    legendSetUrl: string;
-    mapLayerPosition: "BASEMAP" | "OVERLAY";
-    mapService: "WMS" | "TMS" | "XYZ";
     name: string;
     publicAccess: string;
+    relativePeriods: any;
+    reportParams: any;
+    reportTable: D2ReportTable;
     translations: D2Translation[];
-    url: string;
+    type: "JASPER_REPORT_TABLE" | "JASPER_JDBC" | "HTML";
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
@@ -3230,78 +3271,6 @@ export type D2ReportTable = {
     userOrganisationUnit: boolean;
     userOrganisationUnitChildren: boolean;
     userOrganisationUnitGrandChildren: boolean;
-};
-
-export type D2Document = {
-    access: D2Access;
-    attachment: boolean;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    contentType: string;
-    created: string;
-    displayName: string;
-    external: boolean;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    url: string;
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2Report = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    cacheStrategy:
-        | "NO_CACHE"
-        | "CACHE_15_MINUTES"
-        | "CACHE_30_MINUTES"
-        | "CACHE_1_HOUR"
-        | "CACHE_6AM_TOMORROW"
-        | "CACHE_TWO_WEEKS"
-        | "RESPECT_SYSTEM_SETTING";
-    code: Id;
-    created: string;
-    designContent: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    relativePeriods: any;
-    reportParams: any;
-    reportTable: D2ReportTable;
-    translations: D2Translation[];
-    type: "JASPER_REPORT_TABLE" | "JASPER_JDBC" | "HTML";
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2ValidationResult = {
-    attributeOptionCombo: D2CategoryOptionCombo;
-    created: string;
-    dayInPeriod: number;
-    id: string;
-    leftsideValue: number;
-    notificationSent: boolean;
-    organisationUnit: D2OrganisationUnit;
-    period: any;
-    rightsideValue: number;
-    validationRule: D2ValidationRule;
 };
 
 export type D2Chart = {
@@ -3420,40 +3389,71 @@ export type D2Chart = {
     yearlySeries: string[];
 };
 
-export type D2Map = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    basemap: string;
-    code: Id;
+export type D2ValidationResult = {
+    attributeOptionCombo: D2CategoryOptionCombo;
     created: string;
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
+    dayInPeriod: number;
+    id: string;
+    leftsideValue: number;
+    notificationSent: boolean;
+    organisationUnit: D2OrganisationUnit;
+    period: any;
+    rightsideValue: number;
+    validationRule: D2ValidationRule;
+};
+
+export type D2Document = {
+    access: D2Access;
+    attachment: boolean;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    contentType: string;
+    created: string;
     displayName: string;
-    displayShortName: string;
+    external: boolean;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
-    formName: string;
     href: string;
     id: Id;
-    interpretations: D2Interpretation[];
     lastUpdated: string;
     lastUpdatedBy: D2User;
-    latitude: number;
-    longitude: number;
-    mapViews: D2MapView[];
     name: string;
     publicAccess: string;
-    shortName: string;
-    subscribed: boolean;
-    subscribers: string[];
-    title: string;
     translations: D2Translation[];
+    url: string;
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
-    zoom: number;
+};
+
+export type D2ExternalMapLayer = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    attribution: string;
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    imageFormat: "PNG" | "JPG";
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    layers: string;
+    legendSet: D2LegendSet;
+    legendSetUrl: string;
+    mapLayerPosition: "BASEMAP" | "OVERLAY";
+    mapService: "WMS" | "TMS" | "XYZ";
+    name: string;
+    publicAccess: string;
+    translations: D2Translation[];
+    url: string;
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
 };
 
 export type D2Predictor = {
@@ -3646,62 +3646,84 @@ export type D2KeyJsonValue = {
     value: string;
 };
 
-export type D2MinMaxDataElement = {
-    dataElement: D2DataElement;
-    generated: boolean;
-    max: number;
-    min: number;
-    optionCombo: D2CategoryOptionCombo;
-    source: D2OrganisationUnit;
-};
-
-export type D2ProgramStageInstance = {
+export type D2InterpretationComment = {
     access: D2Access;
-    assignedUser: D2User;
-    attributeOptionCombo: D2CategoryOptionCombo;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
-    comments: any[];
-    completed: boolean;
-    completedBy: string;
-    completedDate: string;
-    creatableInSearchScope: boolean;
     created: string;
-    createdAtClient: string;
-    deleted: boolean;
     displayName: string;
-    dueDate: string;
-    eventDataValues: any[];
-    eventDate: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
-    geometry: D2Geometry;
     href: string;
     id: Id;
     lastUpdated: string;
-    lastUpdatedAtClient: string;
     lastUpdatedBy: D2User;
-    messageConversations: D2MessageConversation[];
+    mentions: any[];
     name: string;
-    organisationUnit: D2OrganisationUnit;
-    programInstance: D2ProgramInstance;
-    programStage: D2ProgramStage;
     publicAccess: string;
-    relationshipItems: any[];
-    status: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";
-    storedBy: string;
+    text: string;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2UserAccess = {
-    access: string;
+export type D2TrackedEntityInstance = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    createdAtClient: string;
+    deleted: boolean;
     displayName: string;
-    id: string;
-    userUid: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    geometry: D2Geometry;
+    href: string;
+    id: Id;
+    inactive: boolean;
+    lastUpdated: string;
+    lastUpdatedAtClient: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    organisationUnit: D2OrganisationUnit;
+    programInstances: D2ProgramInstance[];
+    programOwners: any[];
+    publicAccess: string;
+    relationshipItems: any[];
+    trackedEntityAttributeValues: D2TrackedEntityAttributeValue[];
+    trackedEntityType: D2TrackedEntityType;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2Legend = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    color: string;
+    created: string;
+    displayName: string;
+    endValue: number;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    image: string;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    startValue: number;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
 };
 
 export type D2MessageConversation = {
@@ -3741,53 +3763,78 @@ export type D2MessageConversation = {
     userSurname: string;
 };
 
-export type D2OrganisationUnitGroupSetDimension = {
-    organisationUnitGroupSet: D2OrganisationUnitGroupSet;
-    organisationUnitGroups: D2OrganisationUnitGroup[];
+export type D2UserAccess = {
+    access: string;
+    displayName: string;
+    id: string;
+    userUid: string;
 };
 
-export type D2UserCredentials = {
+export type D2MetadataVersion = {
     access: D2Access;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    catDimensionConstraints: D2Category[];
     code: Id;
-    cogsDimensionConstraints: D2CategoryOptionGroupSet[];
     created: string;
-    disabled: boolean;
     displayName: string;
     externalAccess: boolean;
-    externalAuth: boolean;
     favorite: boolean;
     favorites: string[];
+    hashCode: string;
     href: string;
     id: Id;
-    invitation: boolean;
-    lastLogin: string;
+    importDate: string;
     lastUpdated: string;
     lastUpdatedBy: D2User;
-    ldapId: string;
     name: string;
-    openId: string;
-    password: string;
-    passwordLastUpdated: string;
     publicAccess: string;
-    selfRegistered: boolean;
     translations: D2Translation[];
-    twoFA: boolean;
+    type: "BEST_EFFORT" | "ATOMIC";
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
-    userInfo: D2User;
-    userRoles: D2UserAuthorityGroup[];
-    username: string;
 };
 
-export type D2Relationship = {
+export type D2DataElementOperand = {
     access: D2Access;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    attributeOptionCombo: D2CategoryOptionCombo;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    categoryOptionCombo: D2CategoryOptionCombo;
     code: Id;
     created: string;
+    dataElement: D2DataElement;
     description: string;
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
     displayDescription: string;
     displayFormName: string;
     displayName: string;
@@ -3796,27 +3843,188 @@ export type D2Relationship = {
     favorite: boolean;
     favorites: string[];
     formName: string;
-    from: any;
     href: string;
     id: Id;
     lastUpdated: string;
     lastUpdatedBy: D2User;
+    legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
     name: string;
     publicAccess: string;
-    relationshipType: D2RelationshipType;
     shortName: string;
-    style: D2Style;
-    to: any;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2TrackedEntityProgramIndicatorDimension = {
+export type D2AnalyticsPeriodBoundary = {
+    access: D2Access;
+    analyticsPeriodBoundaryType:
+        | "BEFORE_START_OF_REPORTING_PERIOD"
+        | "BEFORE_END_OF_REPORTING_PERIOD"
+        | "AFTER_START_OF_REPORTING_PERIOD"
+        | "AFTER_END_OF_REPORTING_PERIOD";
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    boundaryTarget: string;
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    offsetPeriodType: string;
+    offsetPeriods: number;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramInstance = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    completedBy: string;
+    created: string;
+    createdAtClient: string;
+    deleted: boolean;
+    displayName: string;
+    endDate: string;
+    enrollmentDate: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    followup: boolean;
+    geometry: D2Geometry;
+    href: string;
+    id: Id;
+    incidentDate: string;
+    lastUpdated: string;
+    lastUpdatedAtClient: string;
+    lastUpdatedBy: D2User;
+    messageConversations: D2MessageConversation[];
+    name: string;
+    organisationUnit: D2OrganisationUnit;
+    program: D2Program;
+    programStageInstances: D2ProgramStageInstance[];
+    publicAccess: string;
+    relationshipItems: any[];
+    status: "ACTIVE" | "COMPLETED" | "CANCELLED";
+    storedBy: string;
+    trackedEntityComments: any[];
+    trackedEntityInstance: D2TrackedEntityInstance;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2TrackedEntityDataElementDimension = {
+    dataElement: D2DataElement;
     filter: string;
     legendSet: D2LegendSet;
-    programIndicator: D2ProgramIndicator;
+    programStage: D2ProgramStage;
+};
+
+export type D2ProgramStageInstanceFilter = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    description: string;
+    displayName: string;
+    eventQueryCriteria: any;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    program: Id;
+    programStage: Id;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2DataInputPeriod = {
+    closingDate: string;
+    openingDate: string;
+    period: any;
+};
+
+export type D2ProgramTrackedEntityAttributeDimensionItem = {
+    access: D2Access;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    attribute: D2TrackedEntityAttribute;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    description: string;
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
+    name: string;
+    program: D2Program;
+    publicAccess: string;
+    shortName: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
 };
 
 export type D2DataElementGroupSetDimension = {
@@ -3824,11 +4032,41 @@ export type D2DataElementGroupSetDimension = {
     dataElementGroups: D2DataElementGroup[];
 };
 
+export type D2Icon = {};
+
 export type D2UserGroupAccess = {
     access: string;
     displayName: string;
     id: string;
     userGroupUid: string;
+};
+
+export type D2Color = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    color: string;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2DataSetElement = {
+    categoryCombo: D2CategoryCombo;
+    dataElement: D2DataElement;
+    dataSet: D2DataSet;
 };
 
 export type D2ProgramStageDataElement = {
@@ -3862,54 +4100,116 @@ export type D2ProgramStageDataElement = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2Legend = {
+export type D2ProgramTrackedEntityAttribute = {
     access: D2Access;
+    allowFutureDate: boolean;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
-    color: string;
     created: string;
+    displayInList: boolean;
     displayName: string;
-    endValue: number;
+    displayShortName: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
     href: string;
     id: Id;
-    image: string;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    mandatory: boolean;
+    name: string;
+    program: D2Program;
+    programTrackedEntityAttributeGroups: D2ProgramTrackedEntityAttributeGroup[];
+    publicAccess: string;
+    renderOptionsAsRadio: boolean;
+    renderType: any;
+    searchable: boolean;
+    sortOrder: number;
+    trackedEntityAttribute: D2TrackedEntityAttribute;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    valueType:
+        | "TEXT"
+        | "LONG_TEXT"
+        | "LETTER"
+        | "PHONE_NUMBER"
+        | "EMAIL"
+        | "BOOLEAN"
+        | "TRUE_ONLY"
+        | "DATE"
+        | "DATETIME"
+        | "TIME"
+        | "NUMBER"
+        | "UNIT_INTERVAL"
+        | "PERCENTAGE"
+        | "INTEGER"
+        | "INTEGER_POSITIVE"
+        | "INTEGER_NEGATIVE"
+        | "INTEGER_ZERO_OR_POSITIVE"
+        | "TRACKER_ASSOCIATE"
+        | "USERNAME"
+        | "COORDINATE"
+        | "ORGANISATION_UNIT"
+        | "AGE"
+        | "URL"
+        | "FILE_RESOURCE"
+        | "IMAGE";
+};
+
+export type D2FileResource = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    contentLength: string;
+    contentMd5: string;
+    contentType: string;
+    created: string;
+    displayName: string;
+    domain: "DATA_VALUE" | "PUSH_ANALYSIS" | "DOCUMENT" | "MESSAGE_ATTACHMENT" | "USER_AVATAR";
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    hasMultipleStorageFiles: boolean;
+    href: string;
+    id: Id;
     lastUpdated: string;
     lastUpdatedBy: D2User;
     name: string;
     publicAccess: string;
-    startValue: number;
+    storageStatus: "NONE" | "PENDING" | "FAILED" | "STORED";
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2TrackedEntityInstanceFilter = {
+export type D2Relationship = {
     access: D2Access;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     description: string;
+    displayDescription: string;
+    displayFormName: string;
     displayName: string;
-    enrollmentCreatedPeriod: any;
-    enrollmentStatus: "ACTIVE" | "COMPLETED" | "CANCELLED";
-    eventFilters: any[];
+    displayShortName: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
-    followup: boolean;
+    formName: string;
+    from: any;
     href: string;
     id: Id;
     lastUpdated: string;
     lastUpdatedBy: D2User;
     name: string;
-    program: D2Program;
     publicAccess: string;
-    sortOrder: number;
+    relationshipType: D2RelationshipType;
+    shortName: string;
     style: D2Style;
+    to: any;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
@@ -4005,199 +4305,13 @@ export type D2ProgramDataElementDimensionItem = {
         | "IMAGE";
 };
 
-export type D2ProgramInstance = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    completedBy: string;
-    created: string;
-    createdAtClient: string;
-    deleted: boolean;
-    displayName: string;
-    endDate: string;
-    enrollmentDate: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    followup: boolean;
-    geometry: D2Geometry;
-    href: string;
-    id: Id;
-    incidentDate: string;
-    lastUpdated: string;
-    lastUpdatedAtClient: string;
-    lastUpdatedBy: D2User;
-    messageConversations: D2MessageConversation[];
-    name: string;
-    organisationUnit: D2OrganisationUnit;
-    program: D2Program;
-    programStageInstances: D2ProgramStageInstance[];
-    publicAccess: string;
-    relationshipItems: any[];
-    status: "ACTIVE" | "COMPLETED" | "CANCELLED";
-    storedBy: string;
-    trackedEntityComments: any[];
-    trackedEntityInstance: D2TrackedEntityInstance;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2DataElementOperand = {
-    access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "FIRST"
-        | "FIRST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    attributeOptionCombo: D2CategoryOptionCombo;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    categoryOptionCombo: D2CategoryOptionCombo;
-    code: Id;
-    created: string;
+export type D2MinMaxDataElement = {
     dataElement: D2DataElement;
-    description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
-    name: string;
-    publicAccess: string;
-    shortName: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2ProgramStageInstanceFilter = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    description: string;
-    displayName: string;
-    eventQueryCriteria: any;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    program: Id;
-    programStage: Id;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2Interpretation = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    chart: D2Chart;
-    code: Id;
-    comments: D2InterpretationComment[];
-    created: string;
-    dataSet: D2DataSet;
-    displayName: string;
-    eventChart: D2EventChart;
-    eventReport: D2EventReport;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    likedBy: D2User[];
-    likes: number;
-    map: D2Map;
-    mentions: any[];
-    name: string;
-    organisationUnit: D2OrganisationUnit;
-    period: any;
-    publicAccess: string;
-    reportTable: D2ReportTable;
-    text: string;
-    translations: D2Translation[];
-    type: "REPORT_TABLE" | "CHART" | "MAP" | "EVENT_REPORT" | "EVENT_CHART" | "DATASET_REPORT";
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2FileResource = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    contentLength: string;
-    contentMd5: string;
-    contentType: string;
-    created: string;
-    displayName: string;
-    domain: "DATA_VALUE" | "PUSH_ANALYSIS" | "DOCUMENT" | "MESSAGE_ATTACHMENT" | "USER_AVATAR";
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    hasMultipleStorageFiles: boolean;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    storageStatus: "NONE" | "PENDING" | "FAILED" | "STORED";
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2CategoryDimension = {
-    category: D2Category;
-    categoryOptions: D2CategoryOption[];
+    generated: boolean;
+    max: number;
+    min: number;
+    optionCombo: D2CategoryOptionCombo;
+    source: D2OrganisationUnit;
 };
 
 export type D2ReportingRate = {
@@ -4268,130 +4382,46 @@ export type D2ReportingRate = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2ProgramTrackedEntityAttribute = {
-    access: D2Access;
-    allowFutureDate: boolean;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    displayInList: boolean;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    mandatory: boolean;
-    name: string;
-    program: D2Program;
-    programTrackedEntityAttributeGroups: D2ProgramTrackedEntityAttributeGroup[];
-    publicAccess: string;
-    renderOptionsAsRadio: boolean;
-    renderType: any;
-    searchable: boolean;
-    sortOrder: number;
-    trackedEntityAttribute: D2TrackedEntityAttribute;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    valueType:
-        | "TEXT"
-        | "LONG_TEXT"
-        | "LETTER"
-        | "PHONE_NUMBER"
-        | "EMAIL"
-        | "BOOLEAN"
-        | "TRUE_ONLY"
-        | "DATE"
-        | "DATETIME"
-        | "TIME"
-        | "NUMBER"
-        | "UNIT_INTERVAL"
-        | "PERCENTAGE"
-        | "INTEGER"
-        | "INTEGER_POSITIVE"
-        | "INTEGER_NEGATIVE"
-        | "INTEGER_ZERO_OR_POSITIVE"
-        | "TRACKER_ASSOCIATE"
-        | "USERNAME"
-        | "COORDINATE"
-        | "ORGANISATION_UNIT"
-        | "AGE"
-        | "URL"
-        | "FILE_RESOURCE"
-        | "IMAGE";
-};
-
-export type D2CategoryOptionGroupSetDimension = {
-    categoryOptionGroupSet: D2CategoryOptionGroupSet;
-    categoryOptionGroups: D2CategoryOptionGroup[];
-};
-
-export type D2ProgramTrackedEntityAttributeDimensionItem = {
-    access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "FIRST"
-        | "FIRST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    attribute: D2TrackedEntityAttribute;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
+export type D2TrackedEntityProgramIndicatorDimension = {
+    filter: string;
     legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
+    programIndicator: D2ProgramIndicator;
+};
+
+export type D2UserCredentials = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    catDimensionConstraints: D2Category[];
+    code: Id;
+    cogsDimensionConstraints: D2CategoryOptionGroupSet[];
+    created: string;
+    disabled: boolean;
+    displayName: string;
+    externalAccess: boolean;
+    externalAuth: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    invitation: boolean;
+    lastLogin: string;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    ldapId: string;
     name: string;
-    program: D2Program;
+    openId: string;
+    password: string;
+    passwordLastUpdated: string;
     publicAccess: string;
-    shortName: string;
+    selfRegistered: boolean;
     translations: D2Translation[];
+    twoFA: boolean;
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
+    userInfo: D2User;
+    userRoles: D2UserAuthorityGroup[];
+    username: string;
 };
 
 export type D2TrackedEntityAttributeValue = {
@@ -4403,136 +4433,98 @@ export type D2TrackedEntityAttributeValue = {
     value: string;
 };
 
-export type D2MetadataVersion = {
+export type D2OrganisationUnitGroupSetDimension = {
+    organisationUnitGroupSet: D2OrganisationUnitGroupSet;
+    organisationUnitGroups: D2OrganisationUnitGroup[];
+};
+
+export type D2CategoryOptionGroupSetDimension = {
+    categoryOptionGroupSet: D2CategoryOptionGroupSet;
+    categoryOptionGroups: D2CategoryOptionGroup[];
+};
+
+export type D2ProgramStageInstance = {
     access: D2Access;
+    assignedUser: D2User;
+    attributeOptionCombo: D2CategoryOptionCombo;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    hashCode: string;
-    href: string;
-    id: Id;
-    importDate: string;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    type: "BEST_EFFORT" | "ATOMIC";
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2DataInputPeriod = {
-    closingDate: string;
-    openingDate: string;
-    period: any;
-};
-
-export type D2InterpretationComment = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    mentions: any[];
-    name: string;
-    publicAccess: string;
-    text: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2AnalyticsPeriodBoundary = {
-    access: D2Access;
-    analyticsPeriodBoundaryType:
-        | "BEFORE_START_OF_REPORTING_PERIOD"
-        | "BEFORE_END_OF_REPORTING_PERIOD"
-        | "AFTER_START_OF_REPORTING_PERIOD"
-        | "AFTER_END_OF_REPORTING_PERIOD";
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    boundaryTarget: string;
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    offsetPeriodType: string;
-    offsetPeriods: number;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2TrackedEntityDataElementDimension = {
-    dataElement: D2DataElement;
-    filter: string;
-    legendSet: D2LegendSet;
-    programStage: D2ProgramStage;
-};
-
-export type D2Icon = {};
-
-export type D2TrackedEntityInstance = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
+    comments: any[];
+    completed: boolean;
+    completedBy: string;
+    completedDate: string;
+    creatableInSearchScope: boolean;
     created: string;
     createdAtClient: string;
     deleted: boolean;
     displayName: string;
+    dueDate: string;
+    eventDataValues: any[];
+    eventDate: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
     geometry: D2Geometry;
     href: string;
     id: Id;
-    inactive: boolean;
     lastUpdated: string;
     lastUpdatedAtClient: string;
     lastUpdatedBy: D2User;
+    messageConversations: D2MessageConversation[];
     name: string;
     organisationUnit: D2OrganisationUnit;
-    programInstances: D2ProgramInstance[];
-    programOwners: any[];
+    programInstance: D2ProgramInstance;
+    programStage: D2ProgramStage;
     publicAccess: string;
     relationshipItems: any[];
-    trackedEntityAttributeValues: D2TrackedEntityAttributeValue[];
-    trackedEntityType: D2TrackedEntityType;
+    status: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";
+    storedBy: string;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2Color = {
+export type D2TrackedEntityInstanceFilter = {
     access: D2Access;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
-    color: string;
     created: string;
+    description: string;
     displayName: string;
+    enrollmentCreatedPeriod: any;
+    enrollmentStatus: "ACTIVE" | "COMPLETED" | "CANCELLED";
+    eventFilters: any[];
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    followup: boolean;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    program: D2Program;
+    publicAccess: string;
+    sortOrder: number;
+    style: D2Style;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2Interpretation = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    chart: D2Chart;
+    code: Id;
+    comments: D2InterpretationComment[];
+    created: string;
+    dataSet: D2DataSet;
+    displayName: string;
+    eventChart: D2EventChart;
+    eventReport: D2EventReport;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
@@ -4540,18 +4532,26 @@ export type D2Color = {
     id: Id;
     lastUpdated: string;
     lastUpdatedBy: D2User;
+    likedBy: D2User[];
+    likes: number;
+    map: D2Map;
+    mentions: any[];
     name: string;
+    organisationUnit: D2OrganisationUnit;
+    period: any;
     publicAccess: string;
+    reportTable: D2ReportTable;
+    text: string;
     translations: D2Translation[];
+    type: "REPORT_TABLE" | "CHART" | "MAP" | "EVENT_REPORT" | "EVENT_CHART" | "DATASET_REPORT";
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2DataSetElement = {
-    categoryCombo: D2CategoryCombo;
-    dataElement: D2DataElement;
-    dataSet: D2DataSet;
+export type D2CategoryDimension = {
+    category: D2Category;
+    categoryOptions: D2CategoryOption[];
 };
 
 export interface D2AttributeSchema {
@@ -5152,6 +5152,66 @@ export interface D2SqlViewSchema {
     };
 }
 
+export interface D2OAuth2ClientSchema {
+    name: "D2OAuth2Client";
+    model: D2OAuth2Client;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        cid: Id;
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        grantTypes: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        redirectUris: string[];
+        secret: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2OAuth2Client, keyof D2OAuth2Client>;
+        $identifiable: Preset<D2OAuth2Client, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OAuth2Client, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2OAuth2Client,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "secret"
+            | "redirectUris"
+            | "lastUpdated"
+            | "grantTypes"
+            | "name"
+            | "id"
+            | "cid"
+        >;
+        $owner: Preset<
+            D2OAuth2Client,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "secret"
+            | "redirectUris"
+            | "lastUpdated"
+            | "grantTypes"
+            | "name"
+            | "id"
+            | "cid"
+        >;
+    };
+}
+
 export interface D2ConstantSchema {
     name: "D2Constant";
     model: D2Constant;
@@ -5221,66 +5281,6 @@ export interface D2ConstantSchema {
             | "name"
             | "shortName"
             | "user"
-        >;
-    };
-}
-
-export interface D2OAuth2ClientSchema {
-    name: "D2OAuth2Client";
-    model: D2OAuth2Client;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        cid: Id;
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        grantTypes: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        redirectUris: string[];
-        secret: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2OAuth2Client, keyof D2OAuth2Client>;
-        $identifiable: Preset<D2OAuth2Client, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OAuth2Client, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2OAuth2Client,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "secret"
-            | "redirectUris"
-            | "lastUpdated"
-            | "grantTypes"
-            | "name"
-            | "id"
-            | "cid"
-        >;
-        $owner: Preset<
-            D2OAuth2Client,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "secret"
-            | "redirectUris"
-            | "lastUpdated"
-            | "grantTypes"
-            | "name"
-            | "id"
-            | "cid"
         >;
     };
 }
@@ -5570,112 +5570,6 @@ export interface D2OptionSetSchema {
     };
 }
 
-export interface D2OptionGroupSchema {
-    name: "D2OptionGroup";
-    model: D2OptionGroup;
-    fields: {
-        access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "FIRST"
-            | "FIRST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        description: string;
-        dimensionItem: string;
-        dimensionItemType:
-            | "DATA_ELEMENT"
-            | "DATA_ELEMENT_OPERAND"
-            | "INDICATOR"
-            | "REPORTING_RATE"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION"
-            | "OPTION_GROUP"
-            | "DATA_ELEMENT_GROUP"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY_OPTION_GROUP";
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        legendSet: D2LegendSetSchema;
-        legendSets: D2LegendSetSchema[];
-        name: string;
-        optionSet: D2OptionSetSchema;
-        options: D2OptionSchema[];
-        publicAccess: string;
-        shortName: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2OptionGroup, keyof D2OptionGroup>;
-        $identifiable: Preset<D2OptionGroup, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OptionGroup, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2OptionGroup,
-            | "code"
-            | "publicAccess"
-            | "lastUpdated"
-            | "optionSet"
-            | "translations"
-            | "options"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "userAccesses"
-            | "name"
-            | "shortName"
-            | "user"
-        >;
-        $owner: Preset<
-            D2OptionGroup,
-            | "code"
-            | "publicAccess"
-            | "lastUpdated"
-            | "optionSet"
-            | "translations"
-            | "options"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "userAccesses"
-            | "name"
-            | "shortName"
-            | "user"
-        >;
-    };
-}
-
 export interface D2OptionGroupSetSchema {
     name: "D2OptionGroupSet";
     model: D2OptionGroupSet;
@@ -5794,55 +5688,108 @@ export interface D2OptionGroupSetSchema {
     };
 }
 
-export interface D2ColorSetSchema {
-    name: "D2ColorSet";
-    model: D2ColorSet;
+export interface D2OptionGroupSchema {
+    name: "D2OptionGroup";
+    model: D2OptionGroup;
     fields: {
         access: D2Access;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
-        colors: D2ColorSchema[];
         created: string;
+        description: string;
+        dimensionItem: string;
+        dimensionItemType:
+            | "DATA_ELEMENT"
+            | "DATA_ELEMENT_OPERAND"
+            | "INDICATOR"
+            | "REPORTING_RATE"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION"
+            | "OPTION_GROUP"
+            | "DATA_ELEMENT_GROUP"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY_OPTION_GROUP";
+        displayDescription: string;
+        displayFormName: string;
         displayName: string;
+        displayShortName: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
+        formName: string;
         href: string;
         id: Id;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
+        legendSet: D2LegendSetSchema;
+        legendSets: D2LegendSetSchema[];
         name: string;
+        optionSet: D2OptionSetSchema;
+        options: D2OptionSchema[];
         publicAccess: string;
+        shortName: string;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2ColorSet, keyof D2ColorSet>;
-        $identifiable: Preset<D2ColorSet, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ColorSet, FieldPresets["nameable"]>;
+        $all: Preset<D2OptionGroup, keyof D2OptionGroup>;
+        $identifiable: Preset<D2OptionGroup, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OptionGroup, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2ColorSet,
-            | "lastUpdatedBy"
+            D2OptionGroup,
             | "code"
-            | "created"
-            | "colors"
+            | "publicAccess"
             | "lastUpdated"
+            | "optionSet"
             | "translations"
-            | "name"
+            | "options"
             | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "userAccesses"
+            | "name"
+            | "shortName"
+            | "user"
         >;
         $owner: Preset<
-            D2ColorSet,
-            | "lastUpdatedBy"
+            D2OptionGroup,
             | "code"
-            | "created"
-            | "colors"
+            | "publicAccess"
             | "lastUpdated"
+            | "optionSet"
             | "translations"
-            | "name"
+            | "options"
             | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "userAccesses"
+            | "name"
+            | "shortName"
+            | "user"
         >;
     };
 }
@@ -5909,6 +5856,59 @@ export interface D2LegendSetSchema {
             | "name"
             | "id"
             | "user"
+        >;
+    };
+}
+
+export interface D2ColorSetSchema {
+    name: "D2ColorSet";
+    model: D2ColorSet;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        colors: D2ColorSchema[];
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ColorSet, keyof D2ColorSet>;
+        $identifiable: Preset<D2ColorSet, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ColorSet, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ColorSet,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "colors"
+            | "lastUpdated"
+            | "translations"
+            | "name"
+            | "id"
+        >;
+        $owner: Preset<
+            D2ColorSet,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "colors"
+            | "lastUpdated"
+            | "translations"
+            | "name"
+            | "id"
         >;
     };
 }
@@ -7396,6 +7396,62 @@ export interface D2DataElementGroupSetSchema {
     };
 }
 
+export interface D2IndicatorTypeSchema {
+    name: "D2IndicatorType";
+    model: D2IndicatorType;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        factor: number;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        number: boolean;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2IndicatorType, keyof D2IndicatorType>;
+        $identifiable: Preset<D2IndicatorType, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2IndicatorType, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2IndicatorType,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "lastUpdated"
+            | "number"
+            | "translations"
+            | "name"
+            | "id"
+            | "factor"
+        >;
+        $owner: Preset<
+            D2IndicatorType,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "lastUpdated"
+            | "number"
+            | "translations"
+            | "name"
+            | "id"
+            | "factor"
+        >;
+    };
+}
+
 export interface D2AnalyticsTableHookSchema {
     name: "D2AnalyticsTableHook";
     model: D2AnalyticsTableHook;
@@ -7472,62 +7528,6 @@ export interface D2AnalyticsTableHookSchema {
             | "name"
             | "resourceTableType"
             | "id"
-        >;
-    };
-}
-
-export interface D2IndicatorTypeSchema {
-    name: "D2IndicatorType";
-    model: D2IndicatorType;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        factor: number;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        number: boolean;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2IndicatorType, keyof D2IndicatorType>;
-        $identifiable: Preset<D2IndicatorType, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2IndicatorType, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2IndicatorType,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "lastUpdated"
-            | "number"
-            | "translations"
-            | "name"
-            | "id"
-            | "factor"
-        >;
-        $owner: Preset<
-            D2IndicatorType,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "lastUpdated"
-            | "number"
-            | "translations"
-            | "name"
-            | "id"
-            | "factor"
         >;
     };
 }
@@ -8902,6 +8902,74 @@ export interface D2TrackedEntityTypeSchema {
     };
 }
 
+export interface D2ProgramTrackedEntityAttributeGroupSchema {
+    name: "D2ProgramTrackedEntityAttributeGroup";
+    model: D2ProgramTrackedEntityAttributeGroup;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        attributes: D2ProgramTrackedEntityAttributeSchema[];
+        code: Id;
+        created: string;
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        shortName: string;
+        translations: D2Translation[];
+        uniqunessType: "NONE" | "STRICT" | "VALIDATION";
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<
+            D2ProgramTrackedEntityAttributeGroup,
+            keyof D2ProgramTrackedEntityAttributeGroup
+        >;
+        $identifiable: Preset<D2ProgramTrackedEntityAttributeGroup, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramTrackedEntityAttributeGroup, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramTrackedEntityAttributeGroup,
+            | "code"
+            | "uniqunessType"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "created"
+            | "name"
+            | "attributes"
+            | "shortName"
+        >;
+        $owner: Preset<
+            D2ProgramTrackedEntityAttributeGroup,
+            | "code"
+            | "uniqunessType"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "created"
+            | "name"
+            | "shortName"
+        >;
+    };
+}
+
 export interface D2TrackedEntityTypeAttributeSchema {
     name: "D2TrackedEntityTypeAttribute";
     model: D2TrackedEntityTypeAttribute;
@@ -8986,74 +9054,6 @@ export interface D2TrackedEntityTypeAttributeSchema {
             | "searchable"
             | "displayInList"
             | "trackedEntityType"
-        >;
-    };
-}
-
-export interface D2ProgramTrackedEntityAttributeGroupSchema {
-    name: "D2ProgramTrackedEntityAttributeGroup";
-    model: D2ProgramTrackedEntityAttributeGroup;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        attributes: D2ProgramTrackedEntityAttributeSchema[];
-        code: Id;
-        created: string;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        shortName: string;
-        translations: D2Translation[];
-        uniqunessType: "NONE" | "STRICT" | "VALIDATION";
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<
-            D2ProgramTrackedEntityAttributeGroup,
-            keyof D2ProgramTrackedEntityAttributeGroup
-        >;
-        $identifiable: Preset<D2ProgramTrackedEntityAttributeGroup, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramTrackedEntityAttributeGroup, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramTrackedEntityAttributeGroup,
-            | "code"
-            | "uniqunessType"
-            | "description"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "created"
-            | "name"
-            | "attributes"
-            | "shortName"
-        >;
-        $owner: Preset<
-            D2ProgramTrackedEntityAttributeGroup,
-            | "code"
-            | "uniqunessType"
-            | "description"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "created"
-            | "name"
-            | "shortName"
         >;
     };
 }
@@ -9229,6 +9229,108 @@ export interface D2ProgramStageSectionSchema {
     };
 }
 
+export interface D2SMSCommandSchema {
+    name: "D2SMSCommand";
+    model: D2SMSCommand;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        codeValueSeparator: string;
+        completenessMethod: "ALL_DATAVALUE" | "AT_LEAST_ONE_DATAVALUE" | "DO_NOT_MARK_COMPLETE";
+        created: string;
+        currentPeriodUsedForReporting: boolean;
+        dataset: D2DataSetSchema;
+        defaultMessage: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        moreThanOneOrgUnitMessage: string;
+        name: string;
+        noUserMessage: string;
+        parserType:
+            | "KEY_VALUE_PARSER"
+            | "J2ME_PARSER"
+            | "ALERT_PARSER"
+            | "UNREGISTERED_PARSER"
+            | "TRACKED_ENTITY_REGISTRATION_PARSER"
+            | "PROGRAM_STAGE_DATAENTRY_PARSER"
+            | "EVENT_REGISTRATION_PARSER";
+        program: D2ProgramSchema;
+        programStage: D2ProgramStageSchema;
+        publicAccess: string;
+        receivedMessage: string;
+        separator: string;
+        smsCodes: any[];
+        specialCharacters: any[];
+        successMessage: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroup: D2UserGroupSchema;
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        wrongFormatMessage: string;
+    };
+    fieldPresets: {
+        $all: Preset<D2SMSCommand, keyof D2SMSCommand>;
+        $identifiable: Preset<D2SMSCommand, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2SMSCommand, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2SMSCommand,
+            | "moreThanOneOrgUnitMessage"
+            | "smsCodes"
+            | "specialCharacters"
+            | "currentPeriodUsedForReporting"
+            | "program"
+            | "noUserMessage"
+            | "lastUpdated"
+            | "receivedMessage"
+            | "defaultMessage"
+            | "id"
+            | "userGroup"
+            | "programStage"
+            | "completenessMethod"
+            | "created"
+            | "wrongFormatMessage"
+            | "separator"
+            | "successMessage"
+            | "codeValueSeparator"
+            | "parserType"
+            | "name"
+            | "dataset"
+        >;
+        $owner: Preset<
+            D2SMSCommand,
+            | "moreThanOneOrgUnitMessage"
+            | "smsCodes"
+            | "specialCharacters"
+            | "currentPeriodUsedForReporting"
+            | "program"
+            | "noUserMessage"
+            | "lastUpdated"
+            | "receivedMessage"
+            | "defaultMessage"
+            | "id"
+            | "userGroup"
+            | "programStage"
+            | "completenessMethod"
+            | "created"
+            | "wrongFormatMessage"
+            | "separator"
+            | "successMessage"
+            | "codeValueSeparator"
+            | "parserType"
+            | "name"
+            | "dataset"
+        >;
+    };
+}
+
 export interface D2ProgramStageSchema {
     name: "D2ProgramStage";
     model: D2ProgramStage;
@@ -9377,108 +9479,6 @@ export interface D2ProgramStageSchema {
             | "blockEntryForm"
             | "user"
             | "programStageSections"
-        >;
-    };
-}
-
-export interface D2SMSCommandSchema {
-    name: "D2SMSCommand";
-    model: D2SMSCommand;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        codeValueSeparator: string;
-        completenessMethod: "ALL_DATAVALUE" | "AT_LEAST_ONE_DATAVALUE" | "DO_NOT_MARK_COMPLETE";
-        created: string;
-        currentPeriodUsedForReporting: boolean;
-        dataset: D2DataSetSchema;
-        defaultMessage: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        moreThanOneOrgUnitMessage: string;
-        name: string;
-        noUserMessage: string;
-        parserType:
-            | "KEY_VALUE_PARSER"
-            | "J2ME_PARSER"
-            | "ALERT_PARSER"
-            | "UNREGISTERED_PARSER"
-            | "TRACKED_ENTITY_REGISTRATION_PARSER"
-            | "PROGRAM_STAGE_DATAENTRY_PARSER"
-            | "EVENT_REGISTRATION_PARSER";
-        program: D2ProgramSchema;
-        programStage: D2ProgramStageSchema;
-        publicAccess: string;
-        receivedMessage: string;
-        separator: string;
-        smsCodes: any[];
-        specialCharacters: any[];
-        successMessage: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroup: D2UserGroupSchema;
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        wrongFormatMessage: string;
-    };
-    fieldPresets: {
-        $all: Preset<D2SMSCommand, keyof D2SMSCommand>;
-        $identifiable: Preset<D2SMSCommand, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2SMSCommand, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2SMSCommand,
-            | "moreThanOneOrgUnitMessage"
-            | "smsCodes"
-            | "specialCharacters"
-            | "currentPeriodUsedForReporting"
-            | "program"
-            | "noUserMessage"
-            | "lastUpdated"
-            | "receivedMessage"
-            | "defaultMessage"
-            | "id"
-            | "userGroup"
-            | "programStage"
-            | "completenessMethod"
-            | "created"
-            | "wrongFormatMessage"
-            | "separator"
-            | "successMessage"
-            | "codeValueSeparator"
-            | "parserType"
-            | "name"
-            | "dataset"
-        >;
-        $owner: Preset<
-            D2SMSCommand,
-            | "moreThanOneOrgUnitMessage"
-            | "smsCodes"
-            | "specialCharacters"
-            | "currentPeriodUsedForReporting"
-            | "program"
-            | "noUserMessage"
-            | "lastUpdated"
-            | "receivedMessage"
-            | "defaultMessage"
-            | "id"
-            | "userGroup"
-            | "programStage"
-            | "completenessMethod"
-            | "created"
-            | "wrongFormatMessage"
-            | "separator"
-            | "successMessage"
-            | "codeValueSeparator"
-            | "parserType"
-            | "name"
-            | "dataset"
         >;
     };
 }
@@ -10398,6 +10398,84 @@ export interface D2ProgramIndicatorSchema {
     };
 }
 
+export interface D2RelationshipTypeSchema {
+    name: "D2RelationshipType";
+    model: D2RelationshipType;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        bidirectional: boolean;
+        code: Id;
+        created: string;
+        description: string;
+        displayFromToName: string;
+        displayName: string;
+        displayToFromName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        fromConstraint: D2RelationshipConstraint;
+        fromToName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        toConstraint: D2RelationshipConstraint;
+        toFromName: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2RelationshipType, keyof D2RelationshipType>;
+        $identifiable: Preset<D2RelationshipType, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2RelationshipType, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2RelationshipType,
+            | "bidirectional"
+            | "code"
+            | "publicAccess"
+            | "description"
+            | "fromToName"
+            | "lastUpdated"
+            | "translations"
+            | "toConstraint"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "toFromName"
+            | "fromConstraint"
+            | "userAccesses"
+            | "name"
+            | "user"
+        >;
+        $owner: Preset<
+            D2RelationshipType,
+            | "bidirectional"
+            | "code"
+            | "publicAccess"
+            | "description"
+            | "fromToName"
+            | "lastUpdated"
+            | "translations"
+            | "toConstraint"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "toFromName"
+            | "fromConstraint"
+            | "userAccesses"
+            | "name"
+            | "user"
+        >;
+    };
+}
+
 export interface D2ProgramIndicatorGroupSchema {
     name: "D2ProgramIndicatorGroup";
     model: D2ProgramIndicatorGroup;
@@ -10530,84 +10608,6 @@ export interface D2ProgramRuleVariableSchema {
             | "useCodeForOptionSet"
             | "dataElement"
             | "name"
-        >;
-    };
-}
-
-export interface D2RelationshipTypeSchema {
-    name: "D2RelationshipType";
-    model: D2RelationshipType;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        bidirectional: boolean;
-        code: Id;
-        created: string;
-        description: string;
-        displayFromToName: string;
-        displayName: string;
-        displayToFromName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        fromConstraint: D2RelationshipConstraint;
-        fromToName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        toConstraint: D2RelationshipConstraint;
-        toFromName: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2RelationshipType, keyof D2RelationshipType>;
-        $identifiable: Preset<D2RelationshipType, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2RelationshipType, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2RelationshipType,
-            | "bidirectional"
-            | "code"
-            | "publicAccess"
-            | "description"
-            | "fromToName"
-            | "lastUpdated"
-            | "translations"
-            | "toConstraint"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "toFromName"
-            | "fromConstraint"
-            | "userAccesses"
-            | "name"
-            | "user"
-        >;
-        $owner: Preset<
-            D2RelationshipType,
-            | "bidirectional"
-            | "code"
-            | "publicAccess"
-            | "description"
-            | "fromToName"
-            | "lastUpdated"
-            | "translations"
-            | "toConstraint"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "toFromName"
-            | "fromConstraint"
-            | "userAccesses"
-            | "name"
-            | "user"
         >;
     };
 }
@@ -11030,81 +11030,180 @@ export interface D2MapViewSchema {
     };
 }
 
-export interface D2ExternalMapLayerSchema {
-    name: "D2ExternalMapLayer";
-    model: D2ExternalMapLayer;
+export interface D2MapSchema {
+    name: "D2Map";
+    model: D2Map;
     fields: {
         access: D2Access;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        attribution: string;
+        basemap: string;
         code: Id;
         created: string;
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        interpretations: D2InterpretationSchema[];
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        latitude: number;
+        longitude: number;
+        mapViews: D2MapViewSchema[];
+        name: string;
+        publicAccess: string;
+        shortName: string;
+        subscribed: boolean;
+        subscribers: string[];
+        title: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        zoom: number;
+    };
+    fieldPresets: {
+        $all: Preset<D2Map, keyof D2Map>;
+        $identifiable: Preset<D2Map, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Map, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Map,
+            | "favorites"
+            | "code"
+            | "publicAccess"
+            | "basemap"
+            | "latitude"
+            | "description"
+            | "title"
+            | "externalAccess"
+            | "lastUpdated"
+            | "translations"
+            | "mapViews"
+            | "id"
+            | "interpretations"
+            | "longitude"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "subscribers"
+            | "created"
+            | "zoom"
+            | "userAccesses"
+            | "name"
+            | "user"
+        >;
+        $owner: Preset<
+            D2Map,
+            | "favorites"
+            | "code"
+            | "publicAccess"
+            | "basemap"
+            | "latitude"
+            | "description"
+            | "title"
+            | "externalAccess"
+            | "lastUpdated"
+            | "translations"
+            | "mapViews"
+            | "id"
+            | "longitude"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "subscribers"
+            | "created"
+            | "zoom"
+            | "userAccesses"
+            | "name"
+            | "user"
+        >;
+    };
+}
+
+export interface D2ReportSchema {
+    name: "D2Report";
+    model: D2Report;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        cacheStrategy:
+            | "NO_CACHE"
+            | "CACHE_15_MINUTES"
+            | "CACHE_30_MINUTES"
+            | "CACHE_1_HOUR"
+            | "CACHE_6AM_TOMORROW"
+            | "CACHE_TWO_WEEKS"
+            | "RESPECT_SYSTEM_SETTING";
+        code: Id;
+        created: string;
+        designContent: string;
         displayName: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
         href: string;
         id: Id;
-        imageFormat: "PNG" | "JPG";
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
-        layers: string;
-        legendSet: D2LegendSetSchema;
-        legendSetUrl: string;
-        mapLayerPosition: "BASEMAP" | "OVERLAY";
-        mapService: "WMS" | "TMS" | "XYZ";
         name: string;
         publicAccess: string;
+        relativePeriods: any;
+        reportParams: any;
+        reportTable: D2ReportTableSchema;
         translations: D2Translation[];
-        url: string;
+        type: "JASPER_REPORT_TABLE" | "JASPER_JDBC" | "HTML";
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2ExternalMapLayer, keyof D2ExternalMapLayer>;
-        $identifiable: Preset<D2ExternalMapLayer, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ExternalMapLayer, FieldPresets["nameable"]>;
+        $all: Preset<D2Report, keyof D2Report>;
+        $identifiable: Preset<D2Report, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Report, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2ExternalMapLayer,
-            | "imageFormat"
+            D2Report,
+            | "designContent"
             | "code"
             | "publicAccess"
-            | "legendSetUrl"
-            | "mapService"
+            | "type"
+            | "externalAccess"
+            | "reportTable"
             | "lastUpdated"
-            | "layers"
+            | "relativePeriods"
+            | "reportParams"
+            | "translations"
             | "id"
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "created"
-            | "mapLayerPosition"
-            | "url"
             | "userAccesses"
             | "name"
-            | "legendSet"
-            | "attribution"
+            | "cacheStrategy"
             | "user"
         >;
         $owner: Preset<
-            D2ExternalMapLayer,
-            | "imageFormat"
+            D2Report,
+            | "designContent"
             | "code"
             | "publicAccess"
-            | "legendSetUrl"
-            | "mapService"
+            | "type"
+            | "externalAccess"
+            | "reportTable"
             | "lastUpdated"
-            | "layers"
+            | "relativePeriods"
+            | "reportParams"
+            | "translations"
             | "id"
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "created"
-            | "mapLayerPosition"
-            | "url"
             | "userAccesses"
             | "name"
-            | "legendSet"
-            | "attribution"
+            | "cacheStrategy"
             | "user"
         >;
     };
@@ -11344,195 +11443,6 @@ export interface D2ReportTableSchema {
             | "legendSet"
             | "user"
             | "skipRounding"
-        >;
-    };
-}
-
-export interface D2DocumentSchema {
-    name: "D2Document";
-    model: D2Document;
-    fields: {
-        access: D2Access;
-        attachment: boolean;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        contentType: string;
-        created: string;
-        displayName: string;
-        external: boolean;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        url: string;
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Document, keyof D2Document>;
-        $identifiable: Preset<D2Document, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Document, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Document,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "url"
-            | "externalAccess"
-            | "lastUpdated"
-            | "external"
-            | "attachment"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-            | "contentType"
-        >;
-        $owner: Preset<
-            D2Document,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "url"
-            | "externalAccess"
-            | "lastUpdated"
-            | "external"
-            | "attachment"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-            | "contentType"
-        >;
-    };
-}
-
-export interface D2ReportSchema {
-    name: "D2Report";
-    model: D2Report;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        cacheStrategy:
-            | "NO_CACHE"
-            | "CACHE_15_MINUTES"
-            | "CACHE_30_MINUTES"
-            | "CACHE_1_HOUR"
-            | "CACHE_6AM_TOMORROW"
-            | "CACHE_TWO_WEEKS"
-            | "RESPECT_SYSTEM_SETTING";
-        code: Id;
-        created: string;
-        designContent: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        relativePeriods: any;
-        reportParams: any;
-        reportTable: D2ReportTableSchema;
-        translations: D2Translation[];
-        type: "JASPER_REPORT_TABLE" | "JASPER_JDBC" | "HTML";
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Report, keyof D2Report>;
-        $identifiable: Preset<D2Report, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Report, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Report,
-            | "designContent"
-            | "code"
-            | "publicAccess"
-            | "type"
-            | "externalAccess"
-            | "reportTable"
-            | "lastUpdated"
-            | "relativePeriods"
-            | "reportParams"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "userAccesses"
-            | "name"
-            | "cacheStrategy"
-            | "user"
-        >;
-        $owner: Preset<
-            D2Report,
-            | "designContent"
-            | "code"
-            | "publicAccess"
-            | "type"
-            | "externalAccess"
-            | "reportTable"
-            | "lastUpdated"
-            | "relativePeriods"
-            | "reportParams"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "userAccesses"
-            | "name"
-            | "cacheStrategy"
-            | "user"
-        >;
-    };
-}
-
-export interface D2ValidationResultSchema {
-    name: "D2ValidationResult";
-    model: D2ValidationResult;
-    fields: {
-        attributeOptionCombo: D2CategoryOptionComboSchema;
-        created: string;
-        dayInPeriod: number;
-        id: string;
-        leftsideValue: number;
-        notificationSent: boolean;
-        organisationUnit: D2OrganisationUnitSchema;
-        period: any;
-        rightsideValue: number;
-        validationRule: D2ValidationRuleSchema;
-    };
-    fieldPresets: {
-        $all: Preset<D2ValidationResult, keyof D2ValidationResult>;
-        $identifiable: Preset<D2ValidationResult, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ValidationResult, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ValidationResult,
-            "created" | "rightsideValue" | "leftsideValue" | "notificationSent"
-        >;
-        $owner: Preset<
-            D2ValidationResult,
-            "created" | "rightsideValue" | "leftsideValue" | "notificationSent"
         >;
     };
 }
@@ -11800,95 +11710,185 @@ export interface D2ChartSchema {
     };
 }
 
-export interface D2MapSchema {
-    name: "D2Map";
-    model: D2Map;
+export interface D2ValidationResultSchema {
+    name: "D2ValidationResult";
+    model: D2ValidationResult;
+    fields: {
+        attributeOptionCombo: D2CategoryOptionComboSchema;
+        created: string;
+        dayInPeriod: number;
+        id: string;
+        leftsideValue: number;
+        notificationSent: boolean;
+        organisationUnit: D2OrganisationUnitSchema;
+        period: any;
+        rightsideValue: number;
+        validationRule: D2ValidationRuleSchema;
+    };
+    fieldPresets: {
+        $all: Preset<D2ValidationResult, keyof D2ValidationResult>;
+        $identifiable: Preset<D2ValidationResult, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ValidationResult, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ValidationResult,
+            "created" | "rightsideValue" | "leftsideValue" | "notificationSent"
+        >;
+        $owner: Preset<
+            D2ValidationResult,
+            "created" | "rightsideValue" | "leftsideValue" | "notificationSent"
+        >;
+    };
+}
+
+export interface D2DocumentSchema {
+    name: "D2Document";
+    model: D2Document;
     fields: {
         access: D2Access;
+        attachment: boolean;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        basemap: string;
         code: Id;
+        contentType: string;
         created: string;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
         displayName: string;
-        displayShortName: string;
+        external: boolean;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
-        formName: string;
         href: string;
         id: Id;
-        interpretations: D2InterpretationSchema[];
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
-        latitude: number;
-        longitude: number;
-        mapViews: D2MapViewSchema[];
         name: string;
         publicAccess: string;
-        shortName: string;
-        subscribed: boolean;
-        subscribers: string[];
-        title: string;
         translations: D2Translation[];
+        url: string;
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
-        zoom: number;
     };
     fieldPresets: {
-        $all: Preset<D2Map, keyof D2Map>;
-        $identifiable: Preset<D2Map, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Map, FieldPresets["nameable"]>;
+        $all: Preset<D2Document, keyof D2Document>;
+        $identifiable: Preset<D2Document, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Document, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2Map,
-            | "favorites"
-            | "code"
-            | "publicAccess"
-            | "basemap"
-            | "latitude"
-            | "description"
-            | "title"
-            | "externalAccess"
-            | "lastUpdated"
-            | "translations"
-            | "mapViews"
-            | "id"
-            | "interpretations"
-            | "longitude"
+            D2Document,
             | "lastUpdatedBy"
             | "userGroupAccesses"
-            | "subscribers"
+            | "code"
             | "created"
-            | "zoom"
+            | "publicAccess"
+            | "attributeValues"
+            | "url"
+            | "externalAccess"
+            | "lastUpdated"
+            | "external"
+            | "attachment"
+            | "translations"
             | "userAccesses"
             | "name"
+            | "id"
+            | "user"
+            | "contentType"
+        >;
+        $owner: Preset<
+            D2Document,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "attributeValues"
+            | "url"
+            | "externalAccess"
+            | "lastUpdated"
+            | "external"
+            | "attachment"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+            | "contentType"
+        >;
+    };
+}
+
+export interface D2ExternalMapLayerSchema {
+    name: "D2ExternalMapLayer";
+    model: D2ExternalMapLayer;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        attribution: string;
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        imageFormat: "PNG" | "JPG";
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        layers: string;
+        legendSet: D2LegendSetSchema;
+        legendSetUrl: string;
+        mapLayerPosition: "BASEMAP" | "OVERLAY";
+        mapService: "WMS" | "TMS" | "XYZ";
+        name: string;
+        publicAccess: string;
+        translations: D2Translation[];
+        url: string;
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ExternalMapLayer, keyof D2ExternalMapLayer>;
+        $identifiable: Preset<D2ExternalMapLayer, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ExternalMapLayer, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ExternalMapLayer,
+            | "imageFormat"
+            | "code"
+            | "publicAccess"
+            | "legendSetUrl"
+            | "mapService"
+            | "lastUpdated"
+            | "layers"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "mapLayerPosition"
+            | "url"
+            | "userAccesses"
+            | "name"
+            | "legendSet"
+            | "attribution"
             | "user"
         >;
         $owner: Preset<
-            D2Map,
-            | "favorites"
+            D2ExternalMapLayer,
+            | "imageFormat"
             | "code"
             | "publicAccess"
-            | "basemap"
-            | "latitude"
-            | "description"
-            | "title"
-            | "externalAccess"
+            | "legendSetUrl"
+            | "mapService"
             | "lastUpdated"
-            | "translations"
-            | "mapViews"
+            | "layers"
             | "id"
-            | "longitude"
             | "lastUpdatedBy"
             | "userGroupAccesses"
-            | "subscribers"
             | "created"
-            | "zoom"
+            | "mapLayerPosition"
+            | "url"
             | "userAccesses"
             | "name"
+            | "legendSet"
+            | "attribution"
             | "user"
         >;
     };
@@ -12349,144 +12349,180 @@ export interface D2KeyJsonValueSchema {
     };
 }
 
-export interface D2MinMaxDataElementSchema {
-    name: "D2MinMaxDataElement";
-    model: D2MinMaxDataElement;
-    fields: {
-        dataElement: D2DataElementSchema;
-        generated: boolean;
-        max: number;
-        min: number;
-        optionCombo: D2CategoryOptionComboSchema;
-        source: D2OrganisationUnitSchema;
-    };
-    fieldPresets: {
-        $all: Preset<D2MinMaxDataElement, keyof D2MinMaxDataElement>;
-        $identifiable: Preset<D2MinMaxDataElement, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2MinMaxDataElement, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2MinMaxDataElement,
-            "min" | "generated" | "max" | "dataElement" | "source" | "optionCombo"
-        >;
-        $owner: Preset<
-            D2MinMaxDataElement,
-            "min" | "generated" | "max" | "dataElement" | "source" | "optionCombo"
-        >;
-    };
-}
-
-export interface D2ProgramStageInstanceSchema {
-    name: "D2ProgramStageInstance";
-    model: D2ProgramStageInstance;
+export interface D2InterpretationCommentSchema {
+    name: "D2InterpretationComment";
+    model: D2InterpretationComment;
     fields: {
         access: D2Access;
-        assignedUser: D2UserSchema;
-        attributeOptionCombo: D2CategoryOptionComboSchema;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
-        comments: any[];
-        completed: boolean;
-        completedBy: string;
-        completedDate: string;
-        creatableInSearchScope: boolean;
         created: string;
-        createdAtClient: string;
-        deleted: boolean;
         displayName: string;
-        dueDate: string;
-        eventDataValues: any[];
-        eventDate: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
-        geometry: D2Geometry;
         href: string;
         id: Id;
         lastUpdated: string;
-        lastUpdatedAtClient: string;
         lastUpdatedBy: D2UserSchema;
-        messageConversations: D2MessageConversationSchema[];
+        mentions: any[];
         name: string;
-        organisationUnit: D2OrganisationUnitSchema;
-        programInstance: D2ProgramInstanceSchema;
-        programStage: D2ProgramStageSchema;
         publicAccess: string;
-        relationshipItems: any[];
-        status: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";
-        storedBy: string;
+        text: string;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2ProgramStageInstance, keyof D2ProgramStageInstance>;
-        $identifiable: Preset<D2ProgramStageInstance, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramStageInstance, FieldPresets["nameable"]>;
+        $all: Preset<D2InterpretationComment, keyof D2InterpretationComment>;
+        $identifiable: Preset<D2InterpretationComment, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2InterpretationComment, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2ProgramStageInstance,
-            | "code"
-            | "storedBy"
-            | "organisationUnit"
-            | "dueDate"
-            | "createdAtClient"
-            | "messageConversations"
-            | "lastUpdated"
-            | "eventDataValues"
-            | "relationshipItems"
-            | "id"
-            | "assignedUser"
-            | "programStage"
-            | "comments"
-            | "created"
-            | "completedDate"
-            | "programInstance"
-            | "deleted"
-            | "attributeOptionCombo"
-            | "geometry"
-            | "completedBy"
-            | "status"
-            | "lastUpdatedAtClient"
-            | "eventDate"
+            D2InterpretationComment,
+            "created" | "lastUpdated" | "mentions" | "text" | "id" | "user"
         >;
         $owner: Preset<
-            D2ProgramStageInstance,
-            | "code"
-            | "storedBy"
-            | "organisationUnit"
-            | "dueDate"
-            | "createdAtClient"
-            | "messageConversations"
-            | "lastUpdated"
-            | "eventDataValues"
-            | "id"
-            | "assignedUser"
-            | "programStage"
-            | "comments"
-            | "created"
-            | "completedDate"
-            | "programInstance"
-            | "deleted"
-            | "attributeOptionCombo"
-            | "geometry"
-            | "completedBy"
-            | "status"
-            | "lastUpdatedAtClient"
-            | "eventDate"
+            D2InterpretationComment,
+            "created" | "lastUpdated" | "mentions" | "text" | "id" | "user"
         >;
     };
 }
 
-export interface D2UserAccessSchema {
-    name: "D2UserAccess";
-    model: D2UserAccess;
-    fields: { access: string; displayName: string; id: string; userUid: string };
+export interface D2TrackedEntityInstanceSchema {
+    name: "D2TrackedEntityInstance";
+    model: D2TrackedEntityInstance;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        createdAtClient: string;
+        deleted: boolean;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        geometry: D2Geometry;
+        href: string;
+        id: Id;
+        inactive: boolean;
+        lastUpdated: string;
+        lastUpdatedAtClient: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        organisationUnit: D2OrganisationUnitSchema;
+        programInstances: D2ProgramInstanceSchema[];
+        programOwners: any[];
+        publicAccess: string;
+        relationshipItems: any[];
+        trackedEntityAttributeValues: D2TrackedEntityAttributeValueSchema[];
+        trackedEntityType: D2TrackedEntityTypeSchema;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
     fieldPresets: {
-        $all: Preset<D2UserAccess, keyof D2UserAccess>;
-        $identifiable: Preset<D2UserAccess, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2UserAccess, FieldPresets["nameable"]>;
-        $persisted: Preset<D2UserAccess, "access">;
-        $owner: Preset<D2UserAccess, "access">;
+        $all: Preset<D2TrackedEntityInstance, keyof D2TrackedEntityInstance>;
+        $identifiable: Preset<D2TrackedEntityInstance, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2TrackedEntityInstance, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2TrackedEntityInstance,
+            | "programOwners"
+            | "code"
+            | "programInstances"
+            | "organisationUnit"
+            | "createdAtClient"
+            | "lastUpdated"
+            | "inactive"
+            | "relationshipItems"
+            | "id"
+            | "lastUpdatedBy"
+            | "created"
+            | "deleted"
+            | "trackedEntityType"
+            | "geometry"
+            | "trackedEntityAttributeValues"
+            | "lastUpdatedAtClient"
+        >;
+        $owner: Preset<
+            D2TrackedEntityInstance,
+            | "code"
+            | "organisationUnit"
+            | "createdAtClient"
+            | "lastUpdated"
+            | "inactive"
+            | "id"
+            | "lastUpdatedBy"
+            | "created"
+            | "deleted"
+            | "trackedEntityType"
+            | "geometry"
+            | "lastUpdatedAtClient"
+        >;
+    };
+}
+
+export interface D2LegendSchema {
+    name: "D2Legend";
+    model: D2Legend;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        color: string;
+        created: string;
+        displayName: string;
+        endValue: number;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        image: string;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        startValue: number;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2Legend, keyof D2Legend>;
+        $identifiable: Preset<D2Legend, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Legend, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Legend,
+            | "lastUpdatedBy"
+            | "image"
+            | "code"
+            | "endValue"
+            | "color"
+            | "created"
+            | "lastUpdated"
+            | "translations"
+            | "name"
+            | "startValue"
+            | "id"
+        >;
+        $owner: Preset<
+            D2Legend,
+            | "lastUpdatedBy"
+            | "image"
+            | "code"
+            | "endValue"
+            | "color"
+            | "created"
+            | "lastUpdated"
+            | "translations"
+            | "name"
+            | "startValue"
+            | "id"
+        >;
     };
 }
 
@@ -12570,466 +12606,79 @@ export interface D2MessageConversationSchema {
     };
 }
 
-export interface D2OrganisationUnitGroupSetDimensionSchema {
-    name: "D2OrganisationUnitGroupSetDimension";
-    model: D2OrganisationUnitGroupSetDimension;
-    fields: {
-        organisationUnitGroupSet: D2OrganisationUnitGroupSetSchema;
-        organisationUnitGroups: D2OrganisationUnitGroupSchema[];
-    };
+export interface D2UserAccessSchema {
+    name: "D2UserAccess";
+    model: D2UserAccess;
+    fields: { access: string; displayName: string; id: string; userUid: string };
     fieldPresets: {
-        $all: Preset<
-            D2OrganisationUnitGroupSetDimension,
-            keyof D2OrganisationUnitGroupSetDimension
-        >;
-        $identifiable: Preset<D2OrganisationUnitGroupSetDimension, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OrganisationUnitGroupSetDimension, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2OrganisationUnitGroupSetDimension,
-            "organisationUnitGroupSet" | "organisationUnitGroups"
-        >;
-        $owner: Preset<
-            D2OrganisationUnitGroupSetDimension,
-            "organisationUnitGroupSet" | "organisationUnitGroups"
-        >;
+        $all: Preset<D2UserAccess, keyof D2UserAccess>;
+        $identifiable: Preset<D2UserAccess, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2UserAccess, FieldPresets["nameable"]>;
+        $persisted: Preset<D2UserAccess, "access">;
+        $owner: Preset<D2UserAccess, "access">;
     };
 }
 
-export interface D2UserCredentialsSchema {
-    name: "D2UserCredentials";
-    model: D2UserCredentials;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        catDimensionConstraints: D2CategorySchema[];
-        code: Id;
-        cogsDimensionConstraints: D2CategoryOptionGroupSetSchema[];
-        created: string;
-        disabled: boolean;
-        displayName: string;
-        externalAccess: boolean;
-        externalAuth: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        invitation: boolean;
-        lastLogin: string;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        ldapId: string;
-        name: string;
-        openId: string;
-        password: string;
-        passwordLastUpdated: string;
-        publicAccess: string;
-        selfRegistered: boolean;
-        translations: D2Translation[];
-        twoFA: boolean;
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        userInfo: D2UserSchema;
-        userRoles: D2UserAuthorityGroupSchema[];
-        username: string;
-    };
-    fieldPresets: {
-        $all: Preset<D2UserCredentials, keyof D2UserCredentials>;
-        $identifiable: Preset<D2UserCredentials, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2UserCredentials, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2UserCredentials,
-            | "lastLogin"
-            | "userInfo"
-            | "code"
-            | "openId"
-            | "externalAuth"
-            | "cogsDimensionConstraints"
-            | "catDimensionConstraints"
-            | "lastUpdated"
-            | "password"
-            | "ldapId"
-            | "disabled"
-            | "id"
-            | "twoFA"
-            | "passwordLastUpdated"
-            | "lastUpdatedBy"
-            | "invitation"
-            | "created"
-            | "selfRegistered"
-            | "userRoles"
-            | "user"
-            | "username"
-        >;
-        $owner: Preset<
-            D2UserCredentials,
-            | "lastLogin"
-            | "userInfo"
-            | "code"
-            | "openId"
-            | "externalAuth"
-            | "cogsDimensionConstraints"
-            | "catDimensionConstraints"
-            | "lastUpdated"
-            | "password"
-            | "ldapId"
-            | "disabled"
-            | "id"
-            | "twoFA"
-            | "passwordLastUpdated"
-            | "lastUpdatedBy"
-            | "invitation"
-            | "created"
-            | "selfRegistered"
-            | "userRoles"
-            | "user"
-            | "username"
-        >;
-    };
-}
-
-export interface D2RelationshipSchema {
-    name: "D2Relationship";
-    model: D2Relationship;
+export interface D2MetadataVersionSchema {
+    name: "D2MetadataVersion";
+    model: D2MetadataVersion;
     fields: {
         access: D2Access;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
         displayName: string;
-        displayShortName: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
-        formName: string;
-        from: any;
+        hashCode: string;
         href: string;
         id: Id;
+        importDate: string;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
         name: string;
         publicAccess: string;
-        relationshipType: D2RelationshipTypeSchema;
-        shortName: string;
-        style: D2Style;
-        to: any;
         translations: D2Translation[];
+        type: "BEST_EFFORT" | "ATOMIC";
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2Relationship, keyof D2Relationship>;
-        $identifiable: Preset<D2Relationship, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Relationship, FieldPresets["nameable"]>;
+        $all: Preset<D2MetadataVersion, keyof D2MetadataVersion>;
+        $identifiable: Preset<D2MetadataVersion, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2MetadataVersion, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2Relationship,
-            | "code"
-            | "description"
-            | "lastUpdated"
-            | "formName"
-            | "from"
-            | "id"
+            D2MetadataVersion,
             | "lastUpdatedBy"
-            | "relationshipType"
-            | "created"
-            | "style"
-            | "to"
-        >;
-        $owner: Preset<
-            D2Relationship,
             | "code"
-            | "description"
-            | "lastUpdated"
-            | "formName"
-            | "from"
-            | "id"
-            | "lastUpdatedBy"
-            | "relationshipType"
             | "created"
-            | "style"
-            | "to"
-        >;
-    };
-}
-
-export interface D2TrackedEntityProgramIndicatorDimensionSchema {
-    name: "D2TrackedEntityProgramIndicatorDimension";
-    model: D2TrackedEntityProgramIndicatorDimension;
-    fields: {
-        filter: string;
-        legendSet: D2LegendSetSchema;
-        programIndicator: D2ProgramIndicatorSchema;
-    };
-    fieldPresets: {
-        $all: Preset<
-            D2TrackedEntityProgramIndicatorDimension,
-            keyof D2TrackedEntityProgramIndicatorDimension
-        >;
-        $identifiable: Preset<
-            D2TrackedEntityProgramIndicatorDimension,
-            FieldPresets["identifiable"]
-        >;
-        $nameable: Preset<D2TrackedEntityProgramIndicatorDimension, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2TrackedEntityProgramIndicatorDimension,
-            "filter" | "legendSet" | "programIndicator"
-        >;
-        $owner: Preset<
-            D2TrackedEntityProgramIndicatorDimension,
-            "filter" | "legendSet" | "programIndicator"
-        >;
-    };
-}
-
-export interface D2DataElementGroupSetDimensionSchema {
-    name: "D2DataElementGroupSetDimension";
-    model: D2DataElementGroupSetDimension;
-    fields: {
-        dataElementGroupSet: D2DataElementGroupSetSchema;
-        dataElementGroups: D2DataElementGroupSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2DataElementGroupSetDimension, keyof D2DataElementGroupSetDimension>;
-        $identifiable: Preset<D2DataElementGroupSetDimension, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2DataElementGroupSetDimension, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2DataElementGroupSetDimension,
-            "dataElementGroups" | "dataElementGroupSet"
-        >;
-        $owner: Preset<D2DataElementGroupSetDimension, "dataElementGroups" | "dataElementGroupSet">;
-    };
-}
-
-export interface D2UserGroupAccessSchema {
-    name: "D2UserGroupAccess";
-    model: D2UserGroupAccess;
-    fields: { access: string; displayName: string; id: string; userGroupUid: string };
-    fieldPresets: {
-        $all: Preset<D2UserGroupAccess, keyof D2UserGroupAccess>;
-        $identifiable: Preset<D2UserGroupAccess, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2UserGroupAccess, FieldPresets["nameable"]>;
-        $persisted: Preset<D2UserGroupAccess, "access">;
-        $owner: Preset<D2UserGroupAccess, "access">;
-    };
-}
-
-export interface D2ProgramStageDataElementSchema {
-    name: "D2ProgramStageDataElement";
-    model: D2ProgramStageDataElement;
-    fields: {
-        access: D2Access;
-        allowFutureDate: boolean;
-        allowProvidedElsewhere: boolean;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        compulsory: boolean;
-        created: string;
-        dataElement: D2DataElementSchema;
-        displayInReports: boolean;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        programStage: D2ProgramStageSchema;
-        publicAccess: string;
-        renderOptionsAsRadio: boolean;
-        renderType: any;
-        skipSynchronization: boolean;
-        sortOrder: number;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramStageDataElement, keyof D2ProgramStageDataElement>;
-        $identifiable: Preset<D2ProgramStageDataElement, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramStageDataElement, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramStageDataElement,
-            | "displayInReports"
-            | "code"
-            | "skipSynchronization"
+            | "type"
             | "lastUpdated"
-            | "renderOptionsAsRadio"
-            | "id"
-            | "allowFutureDate"
-            | "renderType"
-            | "lastUpdatedBy"
-            | "programStage"
-            | "created"
-            | "dataElement"
-            | "compulsory"
-            | "allowProvidedElsewhere"
-            | "sortOrder"
-        >;
-        $owner: Preset<
-            D2ProgramStageDataElement,
-            | "displayInReports"
-            | "code"
-            | "skipSynchronization"
-            | "lastUpdated"
-            | "renderOptionsAsRadio"
-            | "id"
-            | "allowFutureDate"
-            | "renderType"
-            | "lastUpdatedBy"
-            | "programStage"
-            | "created"
-            | "dataElement"
-            | "compulsory"
-            | "allowProvidedElsewhere"
-            | "sortOrder"
-        >;
-    };
-}
-
-export interface D2LegendSchema {
-    name: "D2Legend";
-    model: D2Legend;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        color: string;
-        created: string;
-        displayName: string;
-        endValue: number;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        image: string;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        startValue: number;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Legend, keyof D2Legend>;
-        $identifiable: Preset<D2Legend, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Legend, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Legend,
-            | "lastUpdatedBy"
-            | "image"
-            | "code"
-            | "endValue"
-            | "color"
-            | "created"
-            | "lastUpdated"
-            | "translations"
+            | "importDate"
+            | "hashCode"
             | "name"
-            | "startValue"
             | "id"
         >;
         $owner: Preset<
-            D2Legend,
+            D2MetadataVersion,
             | "lastUpdatedBy"
-            | "image"
             | "code"
-            | "endValue"
-            | "color"
             | "created"
+            | "type"
             | "lastUpdated"
-            | "translations"
+            | "importDate"
+            | "hashCode"
             | "name"
-            | "startValue"
             | "id"
         >;
     };
 }
 
-export interface D2TrackedEntityInstanceFilterSchema {
-    name: "D2TrackedEntityInstanceFilter";
-    model: D2TrackedEntityInstanceFilter;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        description: string;
-        displayName: string;
-        enrollmentCreatedPeriod: any;
-        enrollmentStatus: "ACTIVE" | "COMPLETED" | "CANCELLED";
-        eventFilters: any[];
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        followup: boolean;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        program: D2ProgramSchema;
-        publicAccess: string;
-        sortOrder: number;
-        style: D2Style;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2TrackedEntityInstanceFilter, keyof D2TrackedEntityInstanceFilter>;
-        $identifiable: Preset<D2TrackedEntityInstanceFilter, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2TrackedEntityInstanceFilter, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2TrackedEntityInstanceFilter,
-            | "code"
-            | "description"
-            | "program"
-            | "enrollmentCreatedPeriod"
-            | "lastUpdated"
-            | "id"
-            | "lastUpdatedBy"
-            | "created"
-            | "followup"
-            | "eventFilters"
-            | "enrollmentStatus"
-            | "sortOrder"
-            | "name"
-            | "style"
-        >;
-        $owner: Preset<
-            D2TrackedEntityInstanceFilter,
-            | "code"
-            | "description"
-            | "program"
-            | "enrollmentCreatedPeriod"
-            | "lastUpdated"
-            | "id"
-            | "lastUpdatedBy"
-            | "created"
-            | "followup"
-            | "eventFilters"
-            | "enrollmentStatus"
-            | "sortOrder"
-            | "name"
-            | "style"
-        >;
-    };
-}
-
-export interface D2ProgramDataElementDimensionItemSchema {
-    name: "D2ProgramDataElementDimensionItem";
-    model: D2ProgramDataElementDimensionItem;
+export interface D2DataElementOperandSchema {
+    name: "D2DataElementOperand";
+    model: D2DataElementOperand;
     fields: {
         access: D2Access;
         aggregationType:
@@ -13048,7 +12697,9 @@ export interface D2ProgramDataElementDimensionItemSchema {
             | "NONE"
             | "CUSTOM"
             | "DEFAULT";
+        attributeOptionCombo: D2CategoryOptionComboSchema;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        categoryOptionCombo: D2CategoryOptionComboSchema;
         code: Id;
         created: string;
         dataElement: D2DataElementSchema;
@@ -13084,46 +12735,81 @@ export interface D2ProgramDataElementDimensionItemSchema {
         legendSet: D2LegendSetSchema;
         legendSets: D2LegendSetSchema[];
         name: string;
-        program: D2ProgramSchema;
         publicAccess: string;
         shortName: string;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
-        valueType:
-            | "TEXT"
-            | "LONG_TEXT"
-            | "LETTER"
-            | "PHONE_NUMBER"
-            | "EMAIL"
-            | "BOOLEAN"
-            | "TRUE_ONLY"
-            | "DATE"
-            | "DATETIME"
-            | "TIME"
-            | "NUMBER"
-            | "UNIT_INTERVAL"
-            | "PERCENTAGE"
-            | "INTEGER"
-            | "INTEGER_POSITIVE"
-            | "INTEGER_NEGATIVE"
-            | "INTEGER_ZERO_OR_POSITIVE"
-            | "TRACKER_ASSOCIATE"
-            | "USERNAME"
-            | "COORDINATE"
-            | "ORGANISATION_UNIT"
-            | "AGE"
-            | "URL"
-            | "FILE_RESOURCE"
-            | "IMAGE";
     };
     fieldPresets: {
-        $all: Preset<D2ProgramDataElementDimensionItem, keyof D2ProgramDataElementDimensionItem>;
-        $identifiable: Preset<D2ProgramDataElementDimensionItem, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramDataElementDimensionItem, FieldPresets["nameable"]>;
-        $persisted: Preset<D2ProgramDataElementDimensionItem, never>;
-        $owner: Preset<D2ProgramDataElementDimensionItem, never>;
+        $all: Preset<D2DataElementOperand, keyof D2DataElementOperand>;
+        $identifiable: Preset<D2DataElementOperand, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2DataElementOperand, FieldPresets["nameable"]>;
+        $persisted: Preset<D2DataElementOperand, "categoryOptionCombo" | "dataElement">;
+        $owner: Preset<D2DataElementOperand, "categoryOptionCombo" | "dataElement">;
+    };
+}
+
+export interface D2AnalyticsPeriodBoundarySchema {
+    name: "D2AnalyticsPeriodBoundary";
+    model: D2AnalyticsPeriodBoundary;
+    fields: {
+        access: D2Access;
+        analyticsPeriodBoundaryType:
+            | "BEFORE_START_OF_REPORTING_PERIOD"
+            | "BEFORE_END_OF_REPORTING_PERIOD"
+            | "AFTER_START_OF_REPORTING_PERIOD"
+            | "AFTER_END_OF_REPORTING_PERIOD";
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        boundaryTarget: string;
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        offsetPeriodType: string;
+        offsetPeriods: number;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2AnalyticsPeriodBoundary, keyof D2AnalyticsPeriodBoundary>;
+        $identifiable: Preset<D2AnalyticsPeriodBoundary, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2AnalyticsPeriodBoundary, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2AnalyticsPeriodBoundary,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "lastUpdated"
+            | "offsetPeriodType"
+            | "id"
+            | "analyticsPeriodBoundaryType"
+            | "boundaryTarget"
+            | "offsetPeriods"
+        >;
+        $owner: Preset<
+            D2AnalyticsPeriodBoundary,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "lastUpdated"
+            | "offsetPeriodType"
+            | "id"
+            | "analyticsPeriodBoundaryType"
+            | "boundaryTarget"
+            | "offsetPeriods"
+        >;
     };
 }
 
@@ -13222,78 +12908,30 @@ export interface D2ProgramInstanceSchema {
     };
 }
 
-export interface D2DataElementOperandSchema {
-    name: "D2DataElementOperand";
-    model: D2DataElementOperand;
+export interface D2TrackedEntityDataElementDimensionSchema {
+    name: "D2TrackedEntityDataElementDimension";
+    model: D2TrackedEntityDataElementDimension;
     fields: {
-        access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "FIRST"
-            | "FIRST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
-        attributeOptionCombo: D2CategoryOptionComboSchema;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        categoryOptionCombo: D2CategoryOptionComboSchema;
-        code: Id;
-        created: string;
         dataElement: D2DataElementSchema;
-        description: string;
-        dimensionItem: string;
-        dimensionItemType:
-            | "DATA_ELEMENT"
-            | "DATA_ELEMENT_OPERAND"
-            | "INDICATOR"
-            | "REPORTING_RATE"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION"
-            | "OPTION_GROUP"
-            | "DATA_ELEMENT_GROUP"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY_OPTION_GROUP";
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
+        filter: string;
         legendSet: D2LegendSetSchema;
-        legendSets: D2LegendSetSchema[];
-        name: string;
-        publicAccess: string;
-        shortName: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
+        programStage: D2ProgramStageSchema;
     };
     fieldPresets: {
-        $all: Preset<D2DataElementOperand, keyof D2DataElementOperand>;
-        $identifiable: Preset<D2DataElementOperand, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2DataElementOperand, FieldPresets["nameable"]>;
-        $persisted: Preset<D2DataElementOperand, "categoryOptionCombo" | "dataElement">;
-        $owner: Preset<D2DataElementOperand, "categoryOptionCombo" | "dataElement">;
+        $all: Preset<
+            D2TrackedEntityDataElementDimension,
+            keyof D2TrackedEntityDataElementDimension
+        >;
+        $identifiable: Preset<D2TrackedEntityDataElementDimension, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2TrackedEntityDataElementDimension, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2TrackedEntityDataElementDimension,
+            "filter" | "legendSet" | "programStage" | "dataElement"
+        >;
+        $owner: Preset<
+            D2TrackedEntityDataElementDimension,
+            "filter" | "legendSet" | "programStage" | "dataElement"
+        >;
     };
 }
 
@@ -13363,178 +13001,22 @@ export interface D2ProgramStageInstanceFilterSchema {
     };
 }
 
-export interface D2InterpretationSchema {
-    name: "D2Interpretation";
-    model: D2Interpretation;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        chart: D2ChartSchema;
-        code: Id;
-        comments: D2InterpretationCommentSchema[];
-        created: string;
-        dataSet: D2DataSetSchema;
-        displayName: string;
-        eventChart: D2EventChartSchema;
-        eventReport: D2EventReportSchema;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        likedBy: D2UserSchema[];
-        likes: number;
-        map: D2MapSchema;
-        mentions: any[];
-        name: string;
-        organisationUnit: D2OrganisationUnitSchema;
-        period: any;
-        publicAccess: string;
-        reportTable: D2ReportTableSchema;
-        text: string;
-        translations: D2Translation[];
-        type: "REPORT_TABLE" | "CHART" | "MAP" | "EVENT_REPORT" | "EVENT_CHART" | "DATASET_REPORT";
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
+export interface D2DataInputPeriodSchema {
+    name: "D2DataInputPeriod";
+    model: D2DataInputPeriod;
+    fields: { closingDate: string; openingDate: string; period: any };
     fieldPresets: {
-        $all: Preset<D2Interpretation, keyof D2Interpretation>;
-        $identifiable: Preset<D2Interpretation, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Interpretation, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Interpretation,
-            | "likedBy"
-            | "organisationUnit"
-            | "publicAccess"
-            | "reportTable"
-            | "lastUpdated"
-            | "id"
-            | "text"
-            | "map"
-            | "dataSet"
-            | "likes"
-            | "period"
-            | "userGroupAccesses"
-            | "comments"
-            | "created"
-            | "eventReport"
-            | "userAccesses"
-            | "mentions"
-            | "eventChart"
-            | "user"
-            | "chart"
-        >;
-        $owner: Preset<
-            D2Interpretation,
-            | "likedBy"
-            | "organisationUnit"
-            | "publicAccess"
-            | "reportTable"
-            | "lastUpdated"
-            | "id"
-            | "text"
-            | "map"
-            | "dataSet"
-            | "likes"
-            | "period"
-            | "userGroupAccesses"
-            | "comments"
-            | "created"
-            | "eventReport"
-            | "userAccesses"
-            | "mentions"
-            | "eventChart"
-            | "user"
-            | "chart"
-        >;
+        $all: Preset<D2DataInputPeriod, keyof D2DataInputPeriod>;
+        $identifiable: Preset<D2DataInputPeriod, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2DataInputPeriod, FieldPresets["nameable"]>;
+        $persisted: Preset<D2DataInputPeriod, "period" | "closingDate" | "openingDate">;
+        $owner: Preset<D2DataInputPeriod, "period" | "closingDate" | "openingDate">;
     };
 }
 
-export interface D2FileResourceSchema {
-    name: "D2FileResource";
-    model: D2FileResource;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        contentLength: string;
-        contentMd5: string;
-        contentType: string;
-        created: string;
-        displayName: string;
-        domain: "DATA_VALUE" | "PUSH_ANALYSIS" | "DOCUMENT" | "MESSAGE_ATTACHMENT" | "USER_AVATAR";
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        hasMultipleStorageFiles: boolean;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        storageStatus: "NONE" | "PENDING" | "FAILED" | "STORED";
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2FileResource, keyof D2FileResource>;
-        $identifiable: Preset<D2FileResource, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2FileResource, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2FileResource,
-            | "contentMd5"
-            | "code"
-            | "lastUpdated"
-            | "id"
-            | "contentType"
-            | "lastUpdatedBy"
-            | "created"
-            | "domain"
-            | "hasMultipleStorageFiles"
-            | "name"
-            | "contentLength"
-            | "user"
-        >;
-        $owner: Preset<
-            D2FileResource,
-            | "contentMd5"
-            | "code"
-            | "lastUpdated"
-            | "id"
-            | "contentType"
-            | "lastUpdatedBy"
-            | "created"
-            | "domain"
-            | "hasMultipleStorageFiles"
-            | "name"
-            | "contentLength"
-            | "user"
-        >;
-    };
-}
-
-export interface D2CategoryDimensionSchema {
-    name: "D2CategoryDimension";
-    model: D2CategoryDimension;
-    fields: { category: D2CategorySchema; categoryOptions: D2CategoryOptionSchema[] };
-    fieldPresets: {
-        $all: Preset<D2CategoryDimension, keyof D2CategoryDimension>;
-        $identifiable: Preset<D2CategoryDimension, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2CategoryDimension, FieldPresets["nameable"]>;
-        $persisted: Preset<D2CategoryDimension, "categoryOptions" | "category">;
-        $owner: Preset<D2CategoryDimension, "categoryOptions" | "category">;
-    };
-}
-
-export interface D2ReportingRateSchema {
-    name: "D2ReportingRate";
-    model: D2ReportingRate;
+export interface D2ProgramTrackedEntityAttributeDimensionItemSchema {
+    name: "D2ProgramTrackedEntityAttributeDimensionItem";
+    model: D2ProgramTrackedEntityAttributeDimensionItem;
     fields: {
         access: D2Access;
         aggregationType:
@@ -13553,10 +13035,10 @@ export interface D2ReportingRateSchema {
             | "NONE"
             | "CUSTOM"
             | "DEFAULT";
+        attribute: D2TrackedEntityAttributeSchema;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
-        dataSet: D2DataSetSchema;
         description: string;
         dimensionItem: string;
         dimensionItemType:
@@ -13588,13 +13070,8 @@ export interface D2ReportingRateSchema {
         lastUpdatedBy: D2UserSchema;
         legendSet: D2LegendSetSchema;
         legendSets: D2LegendSetSchema[];
-        metric:
-            | "REPORTING_RATE"
-            | "REPORTING_RATE_ON_TIME"
-            | "ACTUAL_REPORTS"
-            | "ACTUAL_REPORTS_ON_TIME"
-            | "EXPECTED_REPORTS";
         name: string;
+        program: D2ProgramSchema;
         publicAccess: string;
         shortName: string;
         translations: D2Translation[];
@@ -13603,11 +13080,208 @@ export interface D2ReportingRateSchema {
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2ReportingRate, keyof D2ReportingRate>;
-        $identifiable: Preset<D2ReportingRate, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ReportingRate, FieldPresets["nameable"]>;
-        $persisted: Preset<D2ReportingRate, never>;
-        $owner: Preset<D2ReportingRate, never>;
+        $all: Preset<
+            D2ProgramTrackedEntityAttributeDimensionItem,
+            keyof D2ProgramTrackedEntityAttributeDimensionItem
+        >;
+        $identifiable: Preset<
+            D2ProgramTrackedEntityAttributeDimensionItem,
+            FieldPresets["identifiable"]
+        >;
+        $nameable: Preset<D2ProgramTrackedEntityAttributeDimensionItem, FieldPresets["nameable"]>;
+        $persisted: Preset<D2ProgramTrackedEntityAttributeDimensionItem, never>;
+        $owner: Preset<D2ProgramTrackedEntityAttributeDimensionItem, never>;
+    };
+}
+
+export interface D2DataElementGroupSetDimensionSchema {
+    name: "D2DataElementGroupSetDimension";
+    model: D2DataElementGroupSetDimension;
+    fields: {
+        dataElementGroupSet: D2DataElementGroupSetSchema;
+        dataElementGroups: D2DataElementGroupSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2DataElementGroupSetDimension, keyof D2DataElementGroupSetDimension>;
+        $identifiable: Preset<D2DataElementGroupSetDimension, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2DataElementGroupSetDimension, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2DataElementGroupSetDimension,
+            "dataElementGroups" | "dataElementGroupSet"
+        >;
+        $owner: Preset<D2DataElementGroupSetDimension, "dataElementGroups" | "dataElementGroupSet">;
+    };
+}
+
+export interface D2IconSchema {
+    name: "D2Icon";
+    model: D2Icon;
+    fields: {};
+    fieldPresets: {
+        $all: Preset<D2Icon, keyof D2Icon>;
+        $identifiable: Preset<D2Icon, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Icon, FieldPresets["nameable"]>;
+        $persisted: Preset<D2Icon, never>;
+        $owner: Preset<D2Icon, never>;
+    };
+}
+
+export interface D2UserGroupAccessSchema {
+    name: "D2UserGroupAccess";
+    model: D2UserGroupAccess;
+    fields: { access: string; displayName: string; id: string; userGroupUid: string };
+    fieldPresets: {
+        $all: Preset<D2UserGroupAccess, keyof D2UserGroupAccess>;
+        $identifiable: Preset<D2UserGroupAccess, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2UserGroupAccess, FieldPresets["nameable"]>;
+        $persisted: Preset<D2UserGroupAccess, "access">;
+        $owner: Preset<D2UserGroupAccess, "access">;
+    };
+}
+
+export interface D2ColorSchema {
+    name: "D2Color";
+    model: D2Color;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        color: string;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2Color, keyof D2Color>;
+        $identifiable: Preset<D2Color, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Color, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Color,
+            | "lastUpdatedBy"
+            | "code"
+            | "color"
+            | "created"
+            | "lastUpdated"
+            | "translations"
+            | "name"
+            | "id"
+        >;
+        $owner: Preset<
+            D2Color,
+            | "lastUpdatedBy"
+            | "code"
+            | "color"
+            | "created"
+            | "lastUpdated"
+            | "translations"
+            | "name"
+            | "id"
+        >;
+    };
+}
+
+export interface D2DataSetElementSchema {
+    name: "D2DataSetElement";
+    model: D2DataSetElement;
+    fields: {
+        categoryCombo: D2CategoryComboSchema;
+        dataElement: D2DataElementSchema;
+        dataSet: D2DataSetSchema;
+    };
+    fieldPresets: {
+        $all: Preset<D2DataSetElement, keyof D2DataSetElement>;
+        $identifiable: Preset<D2DataSetElement, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2DataSetElement, FieldPresets["nameable"]>;
+        $persisted: Preset<D2DataSetElement, "dataElement" | "categoryCombo" | "dataSet">;
+        $owner: Preset<D2DataSetElement, "dataElement" | "categoryCombo" | "dataSet">;
+    };
+}
+
+export interface D2ProgramStageDataElementSchema {
+    name: "D2ProgramStageDataElement";
+    model: D2ProgramStageDataElement;
+    fields: {
+        access: D2Access;
+        allowFutureDate: boolean;
+        allowProvidedElsewhere: boolean;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        compulsory: boolean;
+        created: string;
+        dataElement: D2DataElementSchema;
+        displayInReports: boolean;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        programStage: D2ProgramStageSchema;
+        publicAccess: string;
+        renderOptionsAsRadio: boolean;
+        renderType: any;
+        skipSynchronization: boolean;
+        sortOrder: number;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramStageDataElement, keyof D2ProgramStageDataElement>;
+        $identifiable: Preset<D2ProgramStageDataElement, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramStageDataElement, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramStageDataElement,
+            | "displayInReports"
+            | "code"
+            | "skipSynchronization"
+            | "lastUpdated"
+            | "renderOptionsAsRadio"
+            | "id"
+            | "allowFutureDate"
+            | "renderType"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "dataElement"
+            | "compulsory"
+            | "allowProvidedElsewhere"
+            | "sortOrder"
+        >;
+        $owner: Preset<
+            D2ProgramStageDataElement,
+            | "displayInReports"
+            | "code"
+            | "skipSynchronization"
+            | "lastUpdated"
+            | "renderOptionsAsRadio"
+            | "id"
+            | "allowFutureDate"
+            | "renderType"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "dataElement"
+            | "compulsory"
+            | "allowProvidedElsewhere"
+            | "sortOrder"
+        >;
     };
 }
 
@@ -13714,31 +13388,143 @@ export interface D2ProgramTrackedEntityAttributeSchema {
     };
 }
 
-export interface D2CategoryOptionGroupSetDimensionSchema {
-    name: "D2CategoryOptionGroupSetDimension";
-    model: D2CategoryOptionGroupSetDimension;
+export interface D2FileResourceSchema {
+    name: "D2FileResource";
+    model: D2FileResource;
     fields: {
-        categoryOptionGroupSet: D2CategoryOptionGroupSetSchema;
-        categoryOptionGroups: D2CategoryOptionGroupSchema[];
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        contentLength: string;
+        contentMd5: string;
+        contentType: string;
+        created: string;
+        displayName: string;
+        domain: "DATA_VALUE" | "PUSH_ANALYSIS" | "DOCUMENT" | "MESSAGE_ATTACHMENT" | "USER_AVATAR";
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        hasMultipleStorageFiles: boolean;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        storageStatus: "NONE" | "PENDING" | "FAILED" | "STORED";
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2CategoryOptionGroupSetDimension, keyof D2CategoryOptionGroupSetDimension>;
-        $identifiable: Preset<D2CategoryOptionGroupSetDimension, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2CategoryOptionGroupSetDimension, FieldPresets["nameable"]>;
+        $all: Preset<D2FileResource, keyof D2FileResource>;
+        $identifiable: Preset<D2FileResource, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2FileResource, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2CategoryOptionGroupSetDimension,
-            "categoryOptionGroups" | "categoryOptionGroupSet"
+            D2FileResource,
+            | "contentMd5"
+            | "code"
+            | "lastUpdated"
+            | "id"
+            | "contentType"
+            | "lastUpdatedBy"
+            | "created"
+            | "domain"
+            | "hasMultipleStorageFiles"
+            | "name"
+            | "contentLength"
+            | "user"
         >;
         $owner: Preset<
-            D2CategoryOptionGroupSetDimension,
-            "categoryOptionGroups" | "categoryOptionGroupSet"
+            D2FileResource,
+            | "contentMd5"
+            | "code"
+            | "lastUpdated"
+            | "id"
+            | "contentType"
+            | "lastUpdatedBy"
+            | "created"
+            | "domain"
+            | "hasMultipleStorageFiles"
+            | "name"
+            | "contentLength"
+            | "user"
         >;
     };
 }
 
-export interface D2ProgramTrackedEntityAttributeDimensionItemSchema {
-    name: "D2ProgramTrackedEntityAttributeDimensionItem";
-    model: D2ProgramTrackedEntityAttributeDimensionItem;
+export interface D2RelationshipSchema {
+    name: "D2Relationship";
+    model: D2Relationship;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        from: any;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        relationshipType: D2RelationshipTypeSchema;
+        shortName: string;
+        style: D2Style;
+        to: any;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2Relationship, keyof D2Relationship>;
+        $identifiable: Preset<D2Relationship, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Relationship, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Relationship,
+            | "code"
+            | "description"
+            | "lastUpdated"
+            | "formName"
+            | "from"
+            | "id"
+            | "lastUpdatedBy"
+            | "relationshipType"
+            | "created"
+            | "style"
+            | "to"
+        >;
+        $owner: Preset<
+            D2Relationship,
+            | "code"
+            | "description"
+            | "lastUpdated"
+            | "formName"
+            | "from"
+            | "id"
+            | "lastUpdatedBy"
+            | "relationshipType"
+            | "created"
+            | "style"
+            | "to"
+        >;
+    };
+}
+
+export interface D2ProgramDataElementDimensionItemSchema {
+    name: "D2ProgramDataElementDimensionItem";
+    model: D2ProgramDataElementDimensionItem;
     fields: {
         access: D2Access;
         aggregationType:
@@ -13757,10 +13543,10 @@ export interface D2ProgramTrackedEntityAttributeDimensionItemSchema {
             | "NONE"
             | "CUSTOM"
             | "DEFAULT";
-        attribute: D2TrackedEntityAttributeSchema;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
+        dataElement: D2DataElementSchema;
         description: string;
         dimensionItem: string;
         dimensionItemType:
@@ -13800,19 +13586,266 @@ export interface D2ProgramTrackedEntityAttributeDimensionItemSchema {
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
+        valueType:
+            | "TEXT"
+            | "LONG_TEXT"
+            | "LETTER"
+            | "PHONE_NUMBER"
+            | "EMAIL"
+            | "BOOLEAN"
+            | "TRUE_ONLY"
+            | "DATE"
+            | "DATETIME"
+            | "TIME"
+            | "NUMBER"
+            | "UNIT_INTERVAL"
+            | "PERCENTAGE"
+            | "INTEGER"
+            | "INTEGER_POSITIVE"
+            | "INTEGER_NEGATIVE"
+            | "INTEGER_ZERO_OR_POSITIVE"
+            | "TRACKER_ASSOCIATE"
+            | "USERNAME"
+            | "COORDINATE"
+            | "ORGANISATION_UNIT"
+            | "AGE"
+            | "URL"
+            | "FILE_RESOURCE"
+            | "IMAGE";
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramDataElementDimensionItem, keyof D2ProgramDataElementDimensionItem>;
+        $identifiable: Preset<D2ProgramDataElementDimensionItem, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramDataElementDimensionItem, FieldPresets["nameable"]>;
+        $persisted: Preset<D2ProgramDataElementDimensionItem, never>;
+        $owner: Preset<D2ProgramDataElementDimensionItem, never>;
+    };
+}
+
+export interface D2MinMaxDataElementSchema {
+    name: "D2MinMaxDataElement";
+    model: D2MinMaxDataElement;
+    fields: {
+        dataElement: D2DataElementSchema;
+        generated: boolean;
+        max: number;
+        min: number;
+        optionCombo: D2CategoryOptionComboSchema;
+        source: D2OrganisationUnitSchema;
+    };
+    fieldPresets: {
+        $all: Preset<D2MinMaxDataElement, keyof D2MinMaxDataElement>;
+        $identifiable: Preset<D2MinMaxDataElement, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2MinMaxDataElement, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2MinMaxDataElement,
+            "min" | "generated" | "max" | "dataElement" | "source" | "optionCombo"
+        >;
+        $owner: Preset<
+            D2MinMaxDataElement,
+            "min" | "generated" | "max" | "dataElement" | "source" | "optionCombo"
+        >;
+    };
+}
+
+export interface D2ReportingRateSchema {
+    name: "D2ReportingRate";
+    model: D2ReportingRate;
+    fields: {
+        access: D2Access;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        dataSet: D2DataSetSchema;
+        description: string;
+        dimensionItem: string;
+        dimensionItemType:
+            | "DATA_ELEMENT"
+            | "DATA_ELEMENT_OPERAND"
+            | "INDICATOR"
+            | "REPORTING_RATE"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION"
+            | "OPTION_GROUP"
+            | "DATA_ELEMENT_GROUP"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY_OPTION_GROUP";
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendSet: D2LegendSetSchema;
+        legendSets: D2LegendSetSchema[];
+        metric:
+            | "REPORTING_RATE"
+            | "REPORTING_RATE_ON_TIME"
+            | "ACTUAL_REPORTS"
+            | "ACTUAL_REPORTS_ON_TIME"
+            | "EXPECTED_REPORTS";
+        name: string;
+        publicAccess: string;
+        shortName: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ReportingRate, keyof D2ReportingRate>;
+        $identifiable: Preset<D2ReportingRate, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ReportingRate, FieldPresets["nameable"]>;
+        $persisted: Preset<D2ReportingRate, never>;
+        $owner: Preset<D2ReportingRate, never>;
+    };
+}
+
+export interface D2TrackedEntityProgramIndicatorDimensionSchema {
+    name: "D2TrackedEntityProgramIndicatorDimension";
+    model: D2TrackedEntityProgramIndicatorDimension;
+    fields: {
+        filter: string;
+        legendSet: D2LegendSetSchema;
+        programIndicator: D2ProgramIndicatorSchema;
     };
     fieldPresets: {
         $all: Preset<
-            D2ProgramTrackedEntityAttributeDimensionItem,
-            keyof D2ProgramTrackedEntityAttributeDimensionItem
+            D2TrackedEntityProgramIndicatorDimension,
+            keyof D2TrackedEntityProgramIndicatorDimension
         >;
         $identifiable: Preset<
-            D2ProgramTrackedEntityAttributeDimensionItem,
+            D2TrackedEntityProgramIndicatorDimension,
             FieldPresets["identifiable"]
         >;
-        $nameable: Preset<D2ProgramTrackedEntityAttributeDimensionItem, FieldPresets["nameable"]>;
-        $persisted: Preset<D2ProgramTrackedEntityAttributeDimensionItem, never>;
-        $owner: Preset<D2ProgramTrackedEntityAttributeDimensionItem, never>;
+        $nameable: Preset<D2TrackedEntityProgramIndicatorDimension, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2TrackedEntityProgramIndicatorDimension,
+            "filter" | "legendSet" | "programIndicator"
+        >;
+        $owner: Preset<
+            D2TrackedEntityProgramIndicatorDimension,
+            "filter" | "legendSet" | "programIndicator"
+        >;
+    };
+}
+
+export interface D2UserCredentialsSchema {
+    name: "D2UserCredentials";
+    model: D2UserCredentials;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        catDimensionConstraints: D2CategorySchema[];
+        code: Id;
+        cogsDimensionConstraints: D2CategoryOptionGroupSetSchema[];
+        created: string;
+        disabled: boolean;
+        displayName: string;
+        externalAccess: boolean;
+        externalAuth: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        invitation: boolean;
+        lastLogin: string;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        ldapId: string;
+        name: string;
+        openId: string;
+        password: string;
+        passwordLastUpdated: string;
+        publicAccess: string;
+        selfRegistered: boolean;
+        translations: D2Translation[];
+        twoFA: boolean;
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        userInfo: D2UserSchema;
+        userRoles: D2UserAuthorityGroupSchema[];
+        username: string;
+    };
+    fieldPresets: {
+        $all: Preset<D2UserCredentials, keyof D2UserCredentials>;
+        $identifiable: Preset<D2UserCredentials, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2UserCredentials, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2UserCredentials,
+            | "lastLogin"
+            | "userInfo"
+            | "code"
+            | "openId"
+            | "externalAuth"
+            | "cogsDimensionConstraints"
+            | "catDimensionConstraints"
+            | "lastUpdated"
+            | "password"
+            | "ldapId"
+            | "disabled"
+            | "id"
+            | "twoFA"
+            | "passwordLastUpdated"
+            | "lastUpdatedBy"
+            | "invitation"
+            | "created"
+            | "selfRegistered"
+            | "userRoles"
+            | "user"
+            | "username"
+        >;
+        $owner: Preset<
+            D2UserCredentials,
+            | "lastLogin"
+            | "userInfo"
+            | "code"
+            | "openId"
+            | "externalAuth"
+            | "cogsDimensionConstraints"
+            | "catDimensionConstraints"
+            | "lastUpdated"
+            | "password"
+            | "ldapId"
+            | "disabled"
+            | "id"
+            | "twoFA"
+            | "passwordLastUpdated"
+            | "lastUpdatedBy"
+            | "invitation"
+            | "created"
+            | "selfRegistered"
+            | "userRoles"
+            | "user"
+            | "username"
+        >;
     };
 }
 
@@ -13836,303 +13869,241 @@ export interface D2TrackedEntityAttributeValueSchema {
     };
 }
 
-export interface D2MetadataVersionSchema {
-    name: "D2MetadataVersion";
-    model: D2MetadataVersion;
+export interface D2OrganisationUnitGroupSetDimensionSchema {
+    name: "D2OrganisationUnitGroupSetDimension";
+    model: D2OrganisationUnitGroupSetDimension;
     fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        hashCode: string;
-        href: string;
-        id: Id;
-        importDate: string;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        type: "BEST_EFFORT" | "ATOMIC";
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2MetadataVersion, keyof D2MetadataVersion>;
-        $identifiable: Preset<D2MetadataVersion, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2MetadataVersion, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2MetadataVersion,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "type"
-            | "lastUpdated"
-            | "importDate"
-            | "hashCode"
-            | "name"
-            | "id"
-        >;
-        $owner: Preset<
-            D2MetadataVersion,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "type"
-            | "lastUpdated"
-            | "importDate"
-            | "hashCode"
-            | "name"
-            | "id"
-        >;
-    };
-}
-
-export interface D2DataInputPeriodSchema {
-    name: "D2DataInputPeriod";
-    model: D2DataInputPeriod;
-    fields: { closingDate: string; openingDate: string; period: any };
-    fieldPresets: {
-        $all: Preset<D2DataInputPeriod, keyof D2DataInputPeriod>;
-        $identifiable: Preset<D2DataInputPeriod, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2DataInputPeriod, FieldPresets["nameable"]>;
-        $persisted: Preset<D2DataInputPeriod, "period" | "closingDate" | "openingDate">;
-        $owner: Preset<D2DataInputPeriod, "period" | "closingDate" | "openingDate">;
-    };
-}
-
-export interface D2InterpretationCommentSchema {
-    name: "D2InterpretationComment";
-    model: D2InterpretationComment;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        mentions: any[];
-        name: string;
-        publicAccess: string;
-        text: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2InterpretationComment, keyof D2InterpretationComment>;
-        $identifiable: Preset<D2InterpretationComment, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2InterpretationComment, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2InterpretationComment,
-            "created" | "lastUpdated" | "mentions" | "text" | "id" | "user"
-        >;
-        $owner: Preset<
-            D2InterpretationComment,
-            "created" | "lastUpdated" | "mentions" | "text" | "id" | "user"
-        >;
-    };
-}
-
-export interface D2AnalyticsPeriodBoundarySchema {
-    name: "D2AnalyticsPeriodBoundary";
-    model: D2AnalyticsPeriodBoundary;
-    fields: {
-        access: D2Access;
-        analyticsPeriodBoundaryType:
-            | "BEFORE_START_OF_REPORTING_PERIOD"
-            | "BEFORE_END_OF_REPORTING_PERIOD"
-            | "AFTER_START_OF_REPORTING_PERIOD"
-            | "AFTER_END_OF_REPORTING_PERIOD";
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        boundaryTarget: string;
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        offsetPeriodType: string;
-        offsetPeriods: number;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2AnalyticsPeriodBoundary, keyof D2AnalyticsPeriodBoundary>;
-        $identifiable: Preset<D2AnalyticsPeriodBoundary, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2AnalyticsPeriodBoundary, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2AnalyticsPeriodBoundary,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "lastUpdated"
-            | "offsetPeriodType"
-            | "id"
-            | "analyticsPeriodBoundaryType"
-            | "boundaryTarget"
-            | "offsetPeriods"
-        >;
-        $owner: Preset<
-            D2AnalyticsPeriodBoundary,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "lastUpdated"
-            | "offsetPeriodType"
-            | "id"
-            | "analyticsPeriodBoundaryType"
-            | "boundaryTarget"
-            | "offsetPeriods"
-        >;
-    };
-}
-
-export interface D2TrackedEntityDataElementDimensionSchema {
-    name: "D2TrackedEntityDataElementDimension";
-    model: D2TrackedEntityDataElementDimension;
-    fields: {
-        dataElement: D2DataElementSchema;
-        filter: string;
-        legendSet: D2LegendSetSchema;
-        programStage: D2ProgramStageSchema;
+        organisationUnitGroupSet: D2OrganisationUnitGroupSetSchema;
+        organisationUnitGroups: D2OrganisationUnitGroupSchema[];
     };
     fieldPresets: {
         $all: Preset<
-            D2TrackedEntityDataElementDimension,
-            keyof D2TrackedEntityDataElementDimension
+            D2OrganisationUnitGroupSetDimension,
+            keyof D2OrganisationUnitGroupSetDimension
         >;
-        $identifiable: Preset<D2TrackedEntityDataElementDimension, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2TrackedEntityDataElementDimension, FieldPresets["nameable"]>;
+        $identifiable: Preset<D2OrganisationUnitGroupSetDimension, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OrganisationUnitGroupSetDimension, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2TrackedEntityDataElementDimension,
-            "filter" | "legendSet" | "programStage" | "dataElement"
+            D2OrganisationUnitGroupSetDimension,
+            "organisationUnitGroupSet" | "organisationUnitGroups"
         >;
         $owner: Preset<
-            D2TrackedEntityDataElementDimension,
-            "filter" | "legendSet" | "programStage" | "dataElement"
+            D2OrganisationUnitGroupSetDimension,
+            "organisationUnitGroupSet" | "organisationUnitGroups"
         >;
     };
 }
 
-export interface D2IconSchema {
-    name: "D2Icon";
-    model: D2Icon;
-    fields: {};
+export interface D2CategoryOptionGroupSetDimensionSchema {
+    name: "D2CategoryOptionGroupSetDimension";
+    model: D2CategoryOptionGroupSetDimension;
+    fields: {
+        categoryOptionGroupSet: D2CategoryOptionGroupSetSchema;
+        categoryOptionGroups: D2CategoryOptionGroupSchema[];
+    };
     fieldPresets: {
-        $all: Preset<D2Icon, keyof D2Icon>;
-        $identifiable: Preset<D2Icon, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Icon, FieldPresets["nameable"]>;
-        $persisted: Preset<D2Icon, never>;
-        $owner: Preset<D2Icon, never>;
+        $all: Preset<D2CategoryOptionGroupSetDimension, keyof D2CategoryOptionGroupSetDimension>;
+        $identifiable: Preset<D2CategoryOptionGroupSetDimension, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2CategoryOptionGroupSetDimension, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2CategoryOptionGroupSetDimension,
+            "categoryOptionGroups" | "categoryOptionGroupSet"
+        >;
+        $owner: Preset<
+            D2CategoryOptionGroupSetDimension,
+            "categoryOptionGroups" | "categoryOptionGroupSet"
+        >;
     };
 }
 
-export interface D2TrackedEntityInstanceSchema {
-    name: "D2TrackedEntityInstance";
-    model: D2TrackedEntityInstance;
+export interface D2ProgramStageInstanceSchema {
+    name: "D2ProgramStageInstance";
+    model: D2ProgramStageInstance;
     fields: {
         access: D2Access;
+        assignedUser: D2UserSchema;
+        attributeOptionCombo: D2CategoryOptionComboSchema;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
+        comments: any[];
+        completed: boolean;
+        completedBy: string;
+        completedDate: string;
+        creatableInSearchScope: boolean;
         created: string;
         createdAtClient: string;
         deleted: boolean;
         displayName: string;
+        dueDate: string;
+        eventDataValues: any[];
+        eventDate: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
         geometry: D2Geometry;
         href: string;
         id: Id;
-        inactive: boolean;
         lastUpdated: string;
         lastUpdatedAtClient: string;
         lastUpdatedBy: D2UserSchema;
+        messageConversations: D2MessageConversationSchema[];
         name: string;
         organisationUnit: D2OrganisationUnitSchema;
-        programInstances: D2ProgramInstanceSchema[];
-        programOwners: any[];
+        programInstance: D2ProgramInstanceSchema;
+        programStage: D2ProgramStageSchema;
         publicAccess: string;
         relationshipItems: any[];
-        trackedEntityAttributeValues: D2TrackedEntityAttributeValueSchema[];
-        trackedEntityType: D2TrackedEntityTypeSchema;
+        status: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";
+        storedBy: string;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2TrackedEntityInstance, keyof D2TrackedEntityInstance>;
-        $identifiable: Preset<D2TrackedEntityInstance, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2TrackedEntityInstance, FieldPresets["nameable"]>;
+        $all: Preset<D2ProgramStageInstance, keyof D2ProgramStageInstance>;
+        $identifiable: Preset<D2ProgramStageInstance, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramStageInstance, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2TrackedEntityInstance,
-            | "programOwners"
+            D2ProgramStageInstance,
             | "code"
-            | "programInstances"
+            | "storedBy"
             | "organisationUnit"
+            | "dueDate"
             | "createdAtClient"
+            | "messageConversations"
             | "lastUpdated"
-            | "inactive"
+            | "eventDataValues"
             | "relationshipItems"
             | "id"
-            | "lastUpdatedBy"
+            | "assignedUser"
+            | "programStage"
+            | "comments"
             | "created"
+            | "completedDate"
+            | "programInstance"
             | "deleted"
-            | "trackedEntityType"
+            | "attributeOptionCombo"
             | "geometry"
-            | "trackedEntityAttributeValues"
+            | "completedBy"
+            | "status"
             | "lastUpdatedAtClient"
+            | "eventDate"
         >;
         $owner: Preset<
-            D2TrackedEntityInstance,
+            D2ProgramStageInstance,
             | "code"
+            | "storedBy"
             | "organisationUnit"
+            | "dueDate"
             | "createdAtClient"
+            | "messageConversations"
             | "lastUpdated"
-            | "inactive"
+            | "eventDataValues"
             | "id"
-            | "lastUpdatedBy"
+            | "assignedUser"
+            | "programStage"
+            | "comments"
             | "created"
+            | "completedDate"
+            | "programInstance"
             | "deleted"
-            | "trackedEntityType"
+            | "attributeOptionCombo"
             | "geometry"
+            | "completedBy"
+            | "status"
             | "lastUpdatedAtClient"
+            | "eventDate"
         >;
     };
 }
 
-export interface D2ColorSchema {
-    name: "D2Color";
-    model: D2Color;
+export interface D2TrackedEntityInstanceFilterSchema {
+    name: "D2TrackedEntityInstanceFilter";
+    model: D2TrackedEntityInstanceFilter;
     fields: {
         access: D2Access;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
-        color: string;
         created: string;
+        description: string;
         displayName: string;
+        enrollmentCreatedPeriod: any;
+        enrollmentStatus: "ACTIVE" | "COMPLETED" | "CANCELLED";
+        eventFilters: any[];
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        followup: boolean;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        program: D2ProgramSchema;
+        publicAccess: string;
+        sortOrder: number;
+        style: D2Style;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2TrackedEntityInstanceFilter, keyof D2TrackedEntityInstanceFilter>;
+        $identifiable: Preset<D2TrackedEntityInstanceFilter, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2TrackedEntityInstanceFilter, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2TrackedEntityInstanceFilter,
+            | "code"
+            | "description"
+            | "program"
+            | "enrollmentCreatedPeriod"
+            | "lastUpdated"
+            | "id"
+            | "lastUpdatedBy"
+            | "created"
+            | "followup"
+            | "eventFilters"
+            | "enrollmentStatus"
+            | "sortOrder"
+            | "name"
+            | "style"
+        >;
+        $owner: Preset<
+            D2TrackedEntityInstanceFilter,
+            | "code"
+            | "description"
+            | "program"
+            | "enrollmentCreatedPeriod"
+            | "lastUpdated"
+            | "id"
+            | "lastUpdatedBy"
+            | "created"
+            | "followup"
+            | "eventFilters"
+            | "enrollmentStatus"
+            | "sortOrder"
+            | "name"
+            | "style"
+        >;
+    };
+}
+
+export interface D2InterpretationSchema {
+    name: "D2Interpretation";
+    model: D2Interpretation;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        chart: D2ChartSchema;
+        code: Id;
+        comments: D2InterpretationCommentSchema[];
+        created: string;
+        dataSet: D2DataSetSchema;
+        displayName: string;
+        eventChart: D2EventChartSchema;
+        eventReport: D2EventReportSchema;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
@@ -14140,56 +14111,85 @@ export interface D2ColorSchema {
         id: Id;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
+        likedBy: D2UserSchema[];
+        likes: number;
+        map: D2MapSchema;
+        mentions: any[];
         name: string;
+        organisationUnit: D2OrganisationUnitSchema;
+        period: any;
         publicAccess: string;
+        reportTable: D2ReportTableSchema;
+        text: string;
         translations: D2Translation[];
+        type: "REPORT_TABLE" | "CHART" | "MAP" | "EVENT_REPORT" | "EVENT_CHART" | "DATASET_REPORT";
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2Color, keyof D2Color>;
-        $identifiable: Preset<D2Color, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Color, FieldPresets["nameable"]>;
+        $all: Preset<D2Interpretation, keyof D2Interpretation>;
+        $identifiable: Preset<D2Interpretation, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Interpretation, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2Color,
-            | "lastUpdatedBy"
-            | "code"
-            | "color"
-            | "created"
+            D2Interpretation,
+            | "likedBy"
+            | "organisationUnit"
+            | "publicAccess"
+            | "reportTable"
             | "lastUpdated"
-            | "translations"
-            | "name"
             | "id"
+            | "text"
+            | "map"
+            | "dataSet"
+            | "likes"
+            | "period"
+            | "userGroupAccesses"
+            | "comments"
+            | "created"
+            | "eventReport"
+            | "userAccesses"
+            | "mentions"
+            | "eventChart"
+            | "user"
+            | "chart"
         >;
         $owner: Preset<
-            D2Color,
-            | "lastUpdatedBy"
-            | "code"
-            | "color"
-            | "created"
+            D2Interpretation,
+            | "likedBy"
+            | "organisationUnit"
+            | "publicAccess"
+            | "reportTable"
             | "lastUpdated"
-            | "translations"
-            | "name"
             | "id"
+            | "text"
+            | "map"
+            | "dataSet"
+            | "likes"
+            | "period"
+            | "userGroupAccesses"
+            | "comments"
+            | "created"
+            | "eventReport"
+            | "userAccesses"
+            | "mentions"
+            | "eventChart"
+            | "user"
+            | "chart"
         >;
     };
 }
 
-export interface D2DataSetElementSchema {
-    name: "D2DataSetElement";
-    model: D2DataSetElement;
-    fields: {
-        categoryCombo: D2CategoryComboSchema;
-        dataElement: D2DataElementSchema;
-        dataSet: D2DataSetSchema;
-    };
+export interface D2CategoryDimensionSchema {
+    name: "D2CategoryDimension";
+    model: D2CategoryDimension;
+    fields: { category: D2CategorySchema; categoryOptions: D2CategoryOptionSchema[] };
     fieldPresets: {
-        $all: Preset<D2DataSetElement, keyof D2DataSetElement>;
-        $identifiable: Preset<D2DataSetElement, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2DataSetElement, FieldPresets["nameable"]>;
-        $persisted: Preset<D2DataSetElement, "dataElement" | "categoryCombo" | "dataSet">;
-        $owner: Preset<D2DataSetElement, "dataElement" | "categoryCombo" | "dataSet">;
+        $all: Preset<D2CategoryDimension, keyof D2CategoryDimension>;
+        $identifiable: Preset<D2CategoryDimension, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2CategoryDimension, FieldPresets["nameable"]>;
+        $persisted: Preset<D2CategoryDimension, "categoryOptions" | "category">;
+        $owner: Preset<D2CategoryDimension, "categoryOptions" | "category">;
     };
 }
 
@@ -14234,8 +14234,8 @@ export type D2Model =
     | D2ExternalFileResource
     | D2ValidationNotificationTemplate
     | D2KeyJsonValue
-    | D2ProgramStageInstance
     | D2FileResource
+    | D2ProgramStageInstance
     | D2Indicator
     | D2IndicatorGroup
     | D2IndicatorGroupSet
@@ -21652,6 +21652,158 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             { name: "key", fieldName: "key", propertyType: "TEXT", klass: "java.lang.String" },
         ],
     },
+    fileResources: {
+        klass: "org.hisp.dhis.fileresource.FileResource",
+        shareable: false,
+        metadata: false,
+        relativeApiEndpoint: "/fileResources",
+        plural: "fileResources",
+        displayName: "File Resource",
+        collectionName: "fileResources",
+        nameableObject: false,
+        translatable: false,
+        identifiableObject: true,
+        dataShareable: false,
+        name: "identifiableObject",
+        persisted: true,
+        embeddedObject: false,
+        properties: [
+            {
+                name: "favorite",
+                fieldName: "favorites",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.Set",
+                itemKlass: "java.lang.String",
+            },
+            {
+                name: "contentMd5",
+                fieldName: "contentMd5",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "access",
+                fieldName: "access",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.security.acl.Access",
+            },
+            {
+                name: "code",
+                fieldName: "code",
+                propertyType: "IDENTIFIER",
+                klass: "java.lang.String",
+            },
+            {
+                name: "displayName",
+                fieldName: "displayName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "publicAccess",
+                fieldName: "publicAccess",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "storageStatus",
+                fieldName: "storageStatus",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.fileresource.FileResourceStorageStatus",
+            },
+            {
+                name: "externalAccess",
+                fieldName: "externalAccess",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "lastUpdated",
+                fieldName: "lastUpdated",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "translation",
+                fieldName: "translations",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.translation.Translation",
+            },
+            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
+            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
+            {
+                name: "contentType",
+                fieldName: "contentType",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "lastUpdatedBy",
+                fieldName: "lastUpdatedBy",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "userGroupAccess",
+                fieldName: "userGroupAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
+            },
+            {
+                name: "created",
+                fieldName: "created",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "attributeValue",
+                fieldName: "attributeValues",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
+            },
+            {
+                name: "userAccess",
+                fieldName: "userAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserAccess",
+            },
+            {
+                name: "domain",
+                fieldName: "domain",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.fileresource.FileResourceDomain",
+            },
+            {
+                name: "hasMultipleStorageFiles",
+                fieldName: "hasMultipleStorageFiles",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
+            {
+                name: "contentLength",
+                fieldName: "contentLength",
+                propertyType: "TEXT",
+                klass: "java.lang.Long",
+            },
+            {
+                name: "user",
+                fieldName: "user",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+        ],
+    },
     programStageInstances: {
         klass: "org.hisp.dhis.program.ProgramStageInstance",
         shareable: false,
@@ -21890,158 +22042,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 propertyType: "DATE",
                 klass: "java.util.Date",
             },
-        ],
-    },
-    fileResources: {
-        klass: "org.hisp.dhis.fileresource.FileResource",
-        shareable: false,
-        metadata: false,
-        relativeApiEndpoint: "/fileResources",
-        plural: "fileResources",
-        displayName: "File Resource",
-        collectionName: "fileResources",
-        nameableObject: false,
-        translatable: false,
-        identifiableObject: true,
-        dataShareable: false,
-        name: "identifiableObject",
-        persisted: true,
-        embeddedObject: false,
-        properties: [
-            {
-                name: "favorite",
-                fieldName: "favorites",
-                propertyType: "COLLECTION",
-                itemPropertyType: "TEXT",
-                klass: "java.util.Set",
-                itemKlass: "java.lang.String",
-            },
-            {
-                name: "contentMd5",
-                fieldName: "contentMd5",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "access",
-                fieldName: "access",
-                propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.security.acl.Access",
-            },
-            {
-                name: "code",
-                fieldName: "code",
-                propertyType: "IDENTIFIER",
-                klass: "java.lang.String",
-            },
-            {
-                name: "displayName",
-                fieldName: "displayName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "publicAccess",
-                fieldName: "publicAccess",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "storageStatus",
-                fieldName: "storageStatus",
-                propertyType: "CONSTANT",
-                klass: "org.hisp.dhis.fileresource.FileResourceStorageStatus",
-            },
-            {
-                name: "externalAccess",
-                fieldName: "externalAccess",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "lastUpdated",
-                fieldName: "lastUpdated",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "translation",
-                fieldName: "translations",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.translation.Translation",
-            },
-            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
-            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
-            {
-                name: "contentType",
-                fieldName: "contentType",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "lastUpdatedBy",
-                fieldName: "lastUpdatedBy",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            {
-                name: "userGroupAccess",
-                fieldName: "userGroupAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
-            },
-            {
-                name: "created",
-                fieldName: "created",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "attributeValue",
-                fieldName: "attributeValues",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
-            },
-            {
-                name: "userAccess",
-                fieldName: "userAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserAccess",
-            },
-            {
-                name: "domain",
-                fieldName: "domain",
-                propertyType: "CONSTANT",
-                klass: "org.hisp.dhis.fileresource.FileResourceDomain",
-            },
-            {
-                name: "hasMultipleStorageFiles",
-                fieldName: "hasMultipleStorageFiles",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
-            {
-                name: "contentLength",
-                fieldName: "contentLength",
-                propertyType: "TEXT",
-                klass: "java.lang.Long",
-            },
-            {
-                name: "user",
-                fieldName: "user",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
         ],
     },
     indicators: {
@@ -34211,8 +34211,8 @@ export type D2ModelSchemas = {
     externalFileResources: D2ExternalFileResourceSchema;
     validationNotificationTemplates: D2ValidationNotificationTemplateSchema;
     dataStores: D2KeyJsonValueSchema;
-    programStageInstances: D2ProgramStageInstanceSchema;
     fileResources: D2FileResourceSchema;
+    programStageInstances: D2ProgramStageInstanceSchema;
     indicators: D2IndicatorSchema;
     indicatorGroups: D2IndicatorGroupSchema;
     indicatorGroupSets: D2IndicatorGroupSetSchema;

--- a/src/2.34/index.ts
+++ b/src/2.34/index.ts
@@ -1,0 +1,21 @@
+import { D2ModelSchemas, models } from "./schemas";
+import { MetadataPickBase, MetadataPayloadBase } from "../api/metadata";
+import { D2ApiDefinitionBase, FilterBase } from "../api/common";
+import { D2ApiVersioned, D2ApiOptions } from "../api/d2Api";
+
+export * from "../api/index";
+export * from "./schemas";
+
+export interface D2ApiDefinition extends D2ApiDefinitionBase {
+    schemas: D2ModelSchemas;
+    filter: FilterBase;
+}
+
+export type MetadataPick<RootSelector> = MetadataPickBase<D2ApiDefinition, RootSelector>;
+export type MetadataPayload = MetadataPayloadBase<D2ModelSchemas>;
+
+export class D2Api extends D2ApiVersioned<D2ApiDefinition> {
+    public constructor(options?: D2ApiOptions) {
+        super(models, options);
+    }
+}

--- a/src/2.34/schemas.ts
+++ b/src/2.34/schemas.ts
@@ -15,16 +15,9 @@ import {
     D2RelationshipConstraint,
 } from "../schemas/base";
 
-export type D2AttributeValue = {
-    attribute: D2Attribute;
-    created: string;
-    lastUpdated: string;
-    value: string;
-};
-
 export type D2UserAuthorityGroup = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     authorities: string[];
     code: Id;
     created: string;
@@ -48,7 +41,7 @@ export type D2UserAuthorityGroup = {
 
 export type D2Attribute = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     categoryAttribute: boolean;
     categoryOptionAttribute: boolean;
     categoryOptionComboAttribute: boolean;
@@ -135,7 +128,7 @@ export type D2Attribute = {
 
 export type D2User = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     avatar: D2FileResource;
     birthday: string;
     code: Id;
@@ -182,7 +175,7 @@ export type D2User = {
 
 export type D2UserGroup = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     displayName: string;
@@ -213,7 +206,7 @@ export type D2Expression = {
 
 export type D2ExternalFileResource = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     displayName: string;
@@ -234,9 +227,12 @@ export type D2ExternalFileResource = {
 
 export type D2SqlView = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     cacheStrategy:
         | "NO_CACHE"
+        | "CACHE_1_MINUTE"
+        | "CACHE_5_MINUTES"
+        | "CACHE_10_MINUTES"
         | "CACHE_15_MINUTES"
         | "CACHE_30_MINUTES"
         | "CACHE_1_HOUR"
@@ -264,34 +260,9 @@ export type D2SqlView = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2OAuth2Client = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    cid: Id;
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    grantTypes: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    redirectUris: string[];
-    secret: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
 export type D2Constant = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     description: string;
@@ -317,73 +288,34 @@ export type D2Constant = {
     value: number;
 };
 
-export type D2JobConfiguration = {
+export type D2OAuth2Client = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    cid: Id;
     code: Id;
-    configurable: boolean;
-    continuousExecution: boolean;
     created: string;
-    cronExpression: string;
     displayName: string;
-    enabled: boolean;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
+    grantTypes: string[];
     href: string;
     id: Id;
-    jobParameters: string;
-    jobStatus: "RUNNING" | "COMPLETED" | "STOPPED" | "SCHEDULED" | "DISABLED" | "FAILED";
-    jobType:
-        | "DATA_STATISTICS"
-        | "DATA_INTEGRITY"
-        | "RESOURCE_TABLE"
-        | "ANALYTICS_TABLE"
-        | "DATA_SYNC"
-        | "PROGRAM_DATA_SYNC"
-        | "FILE_RESOURCE_CLEANUP"
-        | "META_DATA_SYNC"
-        | "SMS_SEND"
-        | "SEND_SCHEDULED_MESSAGE"
-        | "PROGRAM_NOTIFICATIONS"
-        | "VALIDATION_RESULTS_NOTIFICATION"
-        | "CREDENTIALS_EXPIRY_ALERT"
-        | "MONITORING"
-        | "PUSH_ANALYSIS"
-        | "PREDICTOR"
-        | "DATA_SET_NOTIFICATION"
-        | "REMOVE_EXPIRED_RESERVED_VALUES"
-        | "MOCK"
-        | "DATAVALUE_IMPORT"
-        | "ANALYTICSTABLE_UPDATE"
-        | "METADATA_IMPORT"
-        | "GML_IMPORT"
-        | "DATAVALUE_IMPORT_INTERNAL"
-        | "EVENT_IMPORT"
-        | "ENROLLMENT_IMPORT"
-        | "TEI_IMPORT"
-        | "LEADER_ELECTION"
-        | "LEADER_RENEWAL"
-        | "COMPLETE_DATA_SET_REGISTRATION_IMPORT";
-    lastExecuted: string;
-    lastExecutedStatus: "RUNNING" | "COMPLETED" | "STOPPED" | "SCHEDULED" | "DISABLED" | "FAILED";
-    lastRuntimeExecution: string;
     lastUpdated: string;
     lastUpdatedBy: D2User;
-    leaderOnlyJob: boolean;
     name: string;
-    nextExecutionTime: string;
     publicAccess: string;
+    redirectUris: string[];
+    secret: string;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
-    userUid: string;
 };
 
 export type D2Option = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: string;
     created: string;
     description: string;
@@ -411,9 +343,95 @@ export type D2Option = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
+export type D2JobConfiguration = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    configurable: boolean;
+    created: string;
+    cronExpression: string;
+    delay: number;
+    displayName: string;
+    enabled: boolean;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    jobParameters: string;
+    jobStatus:
+        | "RUNNING"
+        | "COMPLETED"
+        | "STOPPED"
+        | "SCHEDULED"
+        | "DISABLED"
+        | "FAILED"
+        | "NOT_STARTED";
+    jobType:
+        | "DATA_STATISTICS"
+        | "DATA_INTEGRITY"
+        | "RESOURCE_TABLE"
+        | "ANALYTICS_TABLE"
+        | "CONTINUOUS_ANALYTICS_TABLE"
+        | "DATA_SYNC"
+        | "TRACKER_PROGRAMS_DATA_SYNC"
+        | "EVENT_PROGRAMS_DATA_SYNC"
+        | "FILE_RESOURCE_CLEANUP"
+        | "IMAGE_PROCESSING"
+        | "META_DATA_SYNC"
+        | "SMS_SEND"
+        | "SEND_SCHEDULED_MESSAGE"
+        | "PROGRAM_NOTIFICATIONS"
+        | "VALIDATION_RESULTS_NOTIFICATION"
+        | "CREDENTIALS_EXPIRY_ALERT"
+        | "MONITORING"
+        | "PUSH_ANALYSIS"
+        | "PREDICTOR"
+        | "DATA_SET_NOTIFICATION"
+        | "REMOVE_EXPIRED_RESERVED_VALUES"
+        | "TRACKER_IMPORT_JOB"
+        | "TRACKER_IMPORT_NOTIFICATION_JOB"
+        | "TRACKER_IMPORT_RULE_ENGINE_JOB"
+        | "MOCK"
+        | "DATAVALUE_IMPORT"
+        | "ANALYTICSTABLE_UPDATE"
+        | "METADATA_IMPORT"
+        | "GML_IMPORT"
+        | "DATAVALUE_IMPORT_INTERNAL"
+        | "EVENT_IMPORT"
+        | "ENROLLMENT_IMPORT"
+        | "TEI_IMPORT"
+        | "LEADER_ELECTION"
+        | "LEADER_RENEWAL"
+        | "COMPLETE_DATA_SET_REGISTRATION_IMPORT"
+        | "PROGRAM_DATA_SYNC";
+    lastExecuted: string;
+    lastExecutedStatus:
+        | "RUNNING"
+        | "COMPLETED"
+        | "STOPPED"
+        | "SCHEDULED"
+        | "DISABLED"
+        | "FAILED"
+        | "NOT_STARTED";
+    lastRuntimeExecution: string;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    leaderOnlyJob: boolean;
+    name: string;
+    nextExecutionTime: string;
+    publicAccess: string;
+    schedulingType: "CRON" | "FIXED_DELAY";
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    userUid: string;
+};
+
 export type D2OptionSet = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     displayName: string;
@@ -468,6 +486,8 @@ export type D2OptionGroupSet = {
         | "AVERAGE_SUM_ORG_UNIT"
         | "LAST"
         | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
         | "COUNT"
         | "STDDEV"
         | "VARIANCE"
@@ -477,7 +497,7 @@ export type D2OptionGroupSet = {
         | "CUSTOM"
         | "DEFAULT";
     allItems: boolean;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     dataDimension: boolean;
@@ -522,6 +542,7 @@ export type D2OptionGroupSet = {
     name: string;
     optionGroups: D2OptionGroup[];
     optionSet: D2OptionSet;
+    programStage: D2ProgramStage;
     publicAccess: string;
     shortName: string;
     translations: D2Translation[];
@@ -538,6 +559,8 @@ export type D2OptionGroup = {
         | "AVERAGE_SUM_ORG_UNIT"
         | "LAST"
         | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
         | "COUNT"
         | "STDDEV"
         | "VARIANCE"
@@ -546,7 +569,7 @@ export type D2OptionGroup = {
         | "NONE"
         | "CUSTOM"
         | "DEFAULT";
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     description: string;
@@ -591,31 +614,9 @@ export type D2OptionGroup = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2ColorSet = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    colors: D2Color[];
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
 export type D2LegendSet = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     displayName: string;
@@ -636,6 +637,28 @@ export type D2LegendSet = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
+export type D2ColorSet = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    colors: D2Color[];
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
 export type D2OrganisationUnit = {
     access: D2Access;
     address: string;
@@ -645,6 +668,8 @@ export type D2OrganisationUnit = {
         | "AVERAGE_SUM_ORG_UNIT"
         | "LAST"
         | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
         | "COUNT"
         | "STDDEV"
         | "VARIANCE"
@@ -654,7 +679,7 @@ export type D2OrganisationUnit = {
         | "CUSTOM"
         | "DEFAULT";
     ancestors: D2OrganisationUnit[];
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     children: D2OrganisationUnit[];
     closedDate: string;
     code: Id;
@@ -718,7 +743,7 @@ export type D2OrganisationUnit = {
 
 export type D2OrganisationUnitLevel = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     displayName: string;
@@ -747,6 +772,8 @@ export type D2OrganisationUnitGroup = {
         | "AVERAGE_SUM_ORG_UNIT"
         | "LAST"
         | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
         | "COUNT"
         | "STDDEV"
         | "VARIANCE"
@@ -755,7 +782,7 @@ export type D2OrganisationUnitGroup = {
         | "NONE"
         | "CUSTOM"
         | "DEFAULT";
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     color: string;
     created: string;
@@ -812,6 +839,8 @@ export type D2OrganisationUnitGroupSet = {
         | "AVERAGE_SUM_ORG_UNIT"
         | "LAST"
         | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
         | "COUNT"
         | "STDDEV"
         | "VARIANCE"
@@ -821,7 +850,7 @@ export type D2OrganisationUnitGroupSet = {
         | "CUSTOM"
         | "DEFAULT";
     allItems: boolean;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     compulsory: boolean;
     created: string;
@@ -867,6 +896,7 @@ export type D2OrganisationUnitGroupSet = {
     legendSet: D2LegendSet;
     name: string;
     organisationUnitGroups: D2OrganisationUnitGroup[];
+    programStage: D2ProgramStage;
     publicAccess: string;
     shortName: string;
     translations: D2Translation[];
@@ -883,6 +913,8 @@ export type D2CategoryOption = {
         | "AVERAGE_SUM_ORG_UNIT"
         | "LAST"
         | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
         | "COUNT"
         | "STDDEV"
         | "VARIANCE"
@@ -891,7 +923,7 @@ export type D2CategoryOption = {
         | "NONE"
         | "CUSTOM"
         | "DEFAULT";
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     categories: D2Category[];
     categoryOptionCombos: D2CategoryOptionCombo[];
     categoryOptionGroups: D2CategoryOptionGroup[];
@@ -950,6 +982,8 @@ export type D2CategoryOptionGroup = {
         | "AVERAGE_SUM_ORG_UNIT"
         | "LAST"
         | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
         | "COUNT"
         | "STDDEV"
         | "VARIANCE"
@@ -958,7 +992,7 @@ export type D2CategoryOptionGroup = {
         | "NONE"
         | "CUSTOM"
         | "DEFAULT";
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     categoryOptions: D2CategoryOption[];
     code: Id;
     created: string;
@@ -1012,6 +1046,8 @@ export type D2CategoryOptionGroupSet = {
         | "AVERAGE_SUM_ORG_UNIT"
         | "LAST"
         | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
         | "COUNT"
         | "STDDEV"
         | "VARIANCE"
@@ -1021,7 +1057,7 @@ export type D2CategoryOptionGroupSet = {
         | "CUSTOM"
         | "DEFAULT";
     allItems: boolean;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     categoryOptionGroups: D2CategoryOptionGroup[];
     code: Id;
     created: string;
@@ -1065,6 +1101,7 @@ export type D2CategoryOptionGroupSet = {
     lastUpdatedBy: D2User;
     legendSet: D2LegendSet;
     name: string;
+    programStage: D2ProgramStage;
     publicAccess: string;
     shortName: string;
     translations: D2Translation[];
@@ -1081,6 +1118,8 @@ export type D2Category = {
         | "AVERAGE_SUM_ORG_UNIT"
         | "LAST"
         | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
         | "COUNT"
         | "STDDEV"
         | "VARIANCE"
@@ -1090,7 +1129,7 @@ export type D2Category = {
         | "CUSTOM"
         | "DEFAULT";
     allItems: boolean;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     categoryCombos: D2CategoryCombo[];
     categoryOptions: D2CategoryOption[];
     code: Id;
@@ -1135,6 +1174,7 @@ export type D2Category = {
     lastUpdatedBy: D2User;
     legendSet: D2LegendSet;
     name: string;
+    programStage: D2ProgramStage;
     publicAccess: string;
     shortName: string;
     translations: D2Translation[];
@@ -1145,7 +1185,7 @@ export type D2Category = {
 
 export type D2CategoryCombo = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     categories: D2Category[];
     categoryOptionCombos: D2CategoryOptionCombo[];
     code: Id;
@@ -1177,6 +1217,8 @@ export type D2CategoryOptionCombo = {
         | "AVERAGE_SUM_ORG_UNIT"
         | "LAST"
         | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
         | "COUNT"
         | "STDDEV"
         | "VARIANCE"
@@ -1185,7 +1227,7 @@ export type D2CategoryOptionCombo = {
         | "NONE"
         | "CUSTOM"
         | "DEFAULT";
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     categoryCombo: D2CategoryCombo;
     categoryOptions: D2CategoryOption[];
     code: Id;
@@ -1240,6 +1282,8 @@ export type D2DataElement = {
         | "AVERAGE_SUM_ORG_UNIT"
         | "LAST"
         | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
         | "COUNT"
         | "STDDEV"
         | "VARIANCE"
@@ -1248,7 +1292,7 @@ export type D2DataElement = {
         | "NONE"
         | "CUSTOM"
         | "DEFAULT";
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     categoryCombo: D2CategoryCombo;
     code: Id;
     commentOptionSet: D2OptionSet;
@@ -1336,6 +1380,8 @@ export type D2DataElementGroup = {
         | "AVERAGE_SUM_ORG_UNIT"
         | "LAST"
         | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
         | "COUNT"
         | "STDDEV"
         | "VARIANCE"
@@ -1344,7 +1390,7 @@ export type D2DataElementGroup = {
         | "NONE"
         | "CUSTOM"
         | "DEFAULT";
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     dataElements: D2DataElement[];
@@ -1397,6 +1443,8 @@ export type D2DataElementGroupSet = {
         | "AVERAGE_SUM_ORG_UNIT"
         | "LAST"
         | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
         | "COUNT"
         | "STDDEV"
         | "VARIANCE"
@@ -1406,7 +1454,7 @@ export type D2DataElementGroupSet = {
         | "CUSTOM"
         | "DEFAULT";
     allItems: boolean;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     compulsory: boolean;
     created: string;
@@ -1451,31 +1499,9 @@ export type D2DataElementGroupSet = {
     lastUpdatedBy: D2User;
     legendSet: D2LegendSet;
     name: string;
+    programStage: D2ProgramStage;
     publicAccess: string;
     shortName: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2IndicatorType = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    factor: number;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    number: boolean;
-    publicAccess: string;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
@@ -1492,7 +1518,7 @@ export type D2AnalyticsTableHook = {
         | "EVENT"
         | "ENROLLMENT"
         | "VALIDATION_RESULT";
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     displayName: string;
@@ -1527,6 +1553,29 @@ export type D2AnalyticsTableHook = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
+export type D2IndicatorType = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    factor: number;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    number: boolean;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
 export type D2Indicator = {
     access: D2Access;
     aggregateExportAttributeOptionCombo: string;
@@ -1537,6 +1586,8 @@ export type D2Indicator = {
         | "AVERAGE_SUM_ORG_UNIT"
         | "LAST"
         | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
         | "COUNT"
         | "STDDEV"
         | "VARIANCE"
@@ -1546,7 +1597,7 @@ export type D2Indicator = {
         | "CUSTOM"
         | "DEFAULT";
     annualized: boolean;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     dataSets: D2DataSet[];
@@ -1603,7 +1654,7 @@ export type D2Indicator = {
 
 export type D2IndicatorGroup = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     displayName: string;
@@ -1626,7 +1677,7 @@ export type D2IndicatorGroup = {
 
 export type D2IndicatorGroupSet = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     compulsory: boolean;
     created: string;
@@ -1650,7 +1701,7 @@ export type D2IndicatorGroupSet = {
 
 export type D2DataEntryForm = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     displayName: string;
@@ -1680,6 +1731,8 @@ export type D2DataSet = {
         | "AVERAGE_SUM_ORG_UNIT"
         | "LAST"
         | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
         | "COUNT"
         | "STDDEV"
         | "VARIANCE"
@@ -1688,7 +1741,7 @@ export type D2DataSet = {
         | "NONE"
         | "CUSTOM"
         | "DEFAULT";
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     categoryCombo: D2CategoryCombo;
     code: Id;
     compulsoryDataElementOperands: D2DataElementOperand[];
@@ -1740,6 +1793,7 @@ export type D2DataSet = {
     notificationRecipients: D2UserGroup;
     notifyCompletingUser: boolean;
     openFuturePeriods: number;
+    openPeriodsAfterCoEndDate: number;
     organisationUnits: D2OrganisationUnit[];
     periodType: string;
     publicAccess: string;
@@ -1761,7 +1815,7 @@ export type D2DataSet = {
 
 export type D2DataSetNotificationTemplate = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     dataSetNotificationTrigger: "DATA_SET_COMPLETION" | "SCHEDULED_DAYS";
@@ -1793,7 +1847,7 @@ export type D2DataSetNotificationTemplate = {
 
 export type D2Section = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     categoryCombos: D2CategoryCombo[];
     code: Id;
     created: string;
@@ -1823,7 +1877,7 @@ export type D2Section = {
 
 export type D2DataApprovalLevel = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     categoryOptionGroupSet: D2CategoryOptionGroupSet;
     code: Id;
     created: string;
@@ -1848,7 +1902,7 @@ export type D2DataApprovalLevel = {
 
 export type D2DataApprovalWorkflow = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     categoryCombo: D2CategoryCombo;
     code: Id;
     created: string;
@@ -1881,6 +1935,8 @@ export type D2ValidationRule = {
         | "AVERAGE_SUM_ORG_UNIT"
         | "LAST"
         | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
         | "COUNT"
         | "STDDEV"
         | "VARIANCE"
@@ -1889,7 +1945,7 @@ export type D2ValidationRule = {
         | "NONE"
         | "CUSTOM"
         | "DEFAULT";
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     description: string;
@@ -1952,7 +2008,7 @@ export type D2ValidationRule = {
 
 export type D2ValidationRuleGroup = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     description: string;
@@ -1975,7 +2031,7 @@ export type D2ValidationRuleGroup = {
 
 export type D2ValidationNotificationTemplate = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     displayName: string;
@@ -2009,6 +2065,8 @@ export type D2TrackedEntityAttribute = {
         | "AVERAGE_SUM_ORG_UNIT"
         | "LAST"
         | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
         | "COUNT"
         | "STDDEV"
         | "VARIANCE"
@@ -2017,7 +2075,7 @@ export type D2TrackedEntityAttribute = {
         | "NONE"
         | "CUSTOM"
         | "DEFAULT";
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     confidential: boolean;
     created: string;
@@ -2063,7 +2121,6 @@ export type D2TrackedEntityAttribute = {
     optionSetValue: boolean;
     orgunitScope: boolean;
     pattern: string;
-    programScope: boolean;
     publicAccess: string;
     shortName: string;
     skipSynchronization: boolean;
@@ -2106,7 +2163,7 @@ export type D2TrackedEntityAttribute = {
 export type D2TrackedEntityType = {
     access: D2Access;
     allowAuditLog: boolean;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     description: string;
@@ -2138,7 +2195,7 @@ export type D2TrackedEntityType = {
 
 export type D2TrackedEntityTypeAttribute = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     displayInList: boolean;
@@ -2191,7 +2248,7 @@ export type D2TrackedEntityTypeAttribute = {
 
 export type D2ProgramTrackedEntityAttributeGroup = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     attributes: D2ProgramTrackedEntityAttribute[];
     code: Id;
     created: string;
@@ -2218,9 +2275,42 @@ export type D2ProgramTrackedEntityAttributeGroup = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
+export type D2ProgramStageSection = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    dataElements: D2DataElement[];
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    programIndicators: D2ProgramIndicator[];
+    programStage: D2ProgramStage;
+    publicAccess: string;
+    renderType: any;
+    shortName: string;
+    sortOrder: number;
+    style: D2Style;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
 export type D2ProgramNotificationTemplate = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     deliveryChannels: never[];
@@ -2262,42 +2352,9 @@ export type D2ProgramNotificationTemplate = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2ProgramStageSection = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    dataElements: D2DataElement[];
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    programIndicators: D2ProgramIndicator[];
-    programStage: D2ProgramStage;
-    publicAccess: string;
-    renderType: any;
-    shortName: string;
-    sortOrder: number;
-    style: D2Style;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
 export type D2SMSCommand = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     codeValueSeparator: string;
     completenessMethod: "ALL_DATAVALUE" | "AT_LEAST_ONE_DATAVALUE" | "DO_NOT_MARK_COMPLETE";
@@ -2343,7 +2400,7 @@ export type D2SMSCommand = {
 export type D2ProgramStage = {
     access: D2Access;
     allowGenerateNextVisit: boolean;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     autoGenerateEvent: boolean;
     blockEntryForm: boolean;
     code: Id;
@@ -2372,6 +2429,7 @@ export type D2ProgramStage = {
     lastUpdatedBy: D2User;
     minDaysFromStart: number;
     name: string;
+    nextScheduleDate: D2DataElement;
     notificationTemplates: D2ProgramNotificationTemplate[];
     openAfterEnrollment: boolean;
     periodType: string;
@@ -2397,7 +2455,7 @@ export type D2ProgramStage = {
 export type D2Program = {
     access: D2Access;
     accessLevel: "OPEN" | "AUDITED" | "PROTECTED" | "CLOSED";
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     categoryCombo: D2CategoryCombo;
     code: Id;
     completeEventsExpiryDays: number;
@@ -2455,7 +2513,7 @@ export type D2Program = {
     withoutRegistration: boolean;
 };
 
-export type D2EventChart = {
+export type D2EventReport = {
     access: D2Access;
     aggregationType:
         | "SUM"
@@ -2463,6 +2521,8 @@ export type D2EventChart = {
         | "AVERAGE_SUM_ORG_UNIT"
         | "LAST"
         | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
         | "COUNT"
         | "STDDEV"
         | "VARIANCE"
@@ -2473,7 +2533,109 @@ export type D2EventChart = {
         | "DEFAULT";
     attributeDimensions: any[];
     attributeValueDimension: D2TrackedEntityAttribute;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    categoryDimensions: D2CategoryDimension[];
+    categoryOptionGroupSetDimensions: D2CategoryOptionGroupSetDimension[];
+    code: Id;
+    colSubTotals: boolean;
+    colTotals: boolean;
+    collapseDataDimensions: boolean;
+    columnDimensions: string[];
+    columns: any[];
+    completedOnly: boolean;
+    created: string;
+    dataDimensionItems: any[];
+    dataElementDimensions: D2TrackedEntityDataElementDimension[];
+    dataElementGroupSetDimensions: D2DataElementGroupSetDimension[];
+    dataElementValueDimension: D2DataElement;
+    dataType: "AGGREGATED_VALUES" | "EVENTS";
+    description: string;
+    digitGroupSeparator: "COMMA" | "SPACE" | "NONE";
+    displayDensity: "COMFORTABLE" | "NORMAL" | "COMPACT" | "NONE";
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    endDate: string;
+    eventStatus: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    filterDimensions: string[];
+    filters: any[];
+    fontSize: "LARGE" | "NORMAL" | "SMALL";
+    formName: string;
+    hideEmptyRows: boolean;
+    hideNaData: boolean;
+    hideSubtitle: boolean;
+    hideTitle: boolean;
+    href: string;
+    id: Id;
+    interpretations: D2Interpretation[];
+    itemOrganisationUnitGroups: D2OrganisationUnitGroup[];
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    orgUnitField: string;
+    organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimension[];
+    organisationUnitLevels: number[];
+    organisationUnits: D2OrganisationUnit[];
+    outputType: "EVENT" | "ENROLLMENT" | "TRACKED_ENTITY_INSTANCE";
+    parentGraphMap: D2Map;
+    periods: any[];
+    program: D2Program;
+    programIndicatorDimensions: D2TrackedEntityProgramIndicatorDimension[];
+    programStage: D2ProgramStage;
+    programStatus: "ACTIVE" | "COMPLETED" | "CANCELLED";
+    publicAccess: string;
+    relativePeriods: any;
+    rowDimensions: string[];
+    rowSubTotals: boolean;
+    rowTotals: boolean;
+    rows: any[];
+    shortName: string;
+    showDimensionLabels: boolean;
+    showHierarchy: boolean;
+    sortOrder: number;
+    startDate: string;
+    subscribed: boolean;
+    subscribers: string[];
+    subtitle: string;
+    timeField: string;
+    title: string;
+    topLimit: number;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    userOrgUnitType: "DATA_CAPTURE" | "DATA_OUTPUT" | "TEI_SEARCH";
+    userOrganisationUnit: boolean;
+    userOrganisationUnitChildren: boolean;
+    userOrganisationUnitGrandChildren: boolean;
+    value: any;
+};
+
+export type D2EventChart = {
+    access: D2Access;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    attributeDimensions: any[];
+    attributeValueDimension: D2TrackedEntityAttribute;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     baseLineLabel: string;
     baseLineValue: number;
     categoryDimensions: D2CategoryDimension[];
@@ -2566,10 +2728,12 @@ export type D2EventChart = {
         | "RADAR"
         | "GAUGE"
         | "YEAR_OVER_YEAR_LINE"
-        | "YEAR_OVER_YEAR_COLUMN";
+        | "YEAR_OVER_YEAR_COLUMN"
+        | "SINGLE_VALUE";
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
+    userOrgUnitType: "DATA_CAPTURE" | "DATA_OUTPUT" | "TEI_SEARCH";
     userOrganisationUnit: boolean;
     userOrganisationUnitChildren: boolean;
     userOrganisationUnitGrandChildren: boolean;
@@ -2577,108 +2741,9 @@ export type D2EventChart = {
     yearlySeries: string[];
 };
 
-export type D2EventReport = {
-    access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    attributeDimensions: any[];
-    attributeValueDimension: D2TrackedEntityAttribute;
-    attributeValues: D2AttributeValue[];
-    categoryDimensions: D2CategoryDimension[];
-    categoryOptionGroupSetDimensions: D2CategoryOptionGroupSetDimension[];
-    code: Id;
-    colSubTotals: boolean;
-    colTotals: boolean;
-    collapseDataDimensions: boolean;
-    columnDimensions: string[];
-    columns: any[];
-    completedOnly: boolean;
-    created: string;
-    dataDimensionItems: any[];
-    dataElementDimensions: D2TrackedEntityDataElementDimension[];
-    dataElementGroupSetDimensions: D2DataElementGroupSetDimension[];
-    dataElementValueDimension: D2DataElement;
-    dataType: "AGGREGATED_VALUES" | "EVENTS";
-    description: string;
-    digitGroupSeparator: "COMMA" | "SPACE" | "NONE";
-    displayDensity: "COMFORTABLE" | "NORMAL" | "COMPACT" | "NONE";
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    endDate: string;
-    eventStatus: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    filterDimensions: string[];
-    filters: any[];
-    fontSize: "LARGE" | "NORMAL" | "SMALL";
-    formName: string;
-    hideEmptyRows: boolean;
-    hideNaData: boolean;
-    hideSubtitle: boolean;
-    hideTitle: boolean;
-    href: string;
-    id: Id;
-    interpretations: D2Interpretation[];
-    itemOrganisationUnitGroups: D2OrganisationUnitGroup[];
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    orgUnitField: string;
-    organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimension[];
-    organisationUnitLevels: number[];
-    organisationUnits: D2OrganisationUnit[];
-    outputType: "EVENT" | "ENROLLMENT" | "TRACKED_ENTITY_INSTANCE";
-    parentGraphMap: D2Map;
-    periods: any[];
-    program: D2Program;
-    programIndicatorDimensions: D2TrackedEntityProgramIndicatorDimension[];
-    programStage: D2ProgramStage;
-    programStatus: "ACTIVE" | "COMPLETED" | "CANCELLED";
-    publicAccess: string;
-    relativePeriods: any;
-    rowDimensions: string[];
-    rowSubTotals: boolean;
-    rowTotals: boolean;
-    rows: any[];
-    shortName: string;
-    showDimensionLabels: boolean;
-    showHierarchy: boolean;
-    sortOrder: number;
-    startDate: string;
-    subscribed: boolean;
-    subscribers: string[];
-    subtitle: string;
-    timeField: string;
-    title: string;
-    topLimit: number;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    userOrganisationUnit: boolean;
-    userOrganisationUnitChildren: boolean;
-    userOrganisationUnitGrandChildren: boolean;
-    value: any;
-};
-
 export type D2ProgramSection = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     description: string;
@@ -2696,12 +2761,12 @@ export type D2ProgramSection = {
     lastUpdatedBy: D2User;
     name: string;
     program: D2Program;
-    programTrackedEntityAttribute: D2TrackedEntityAttribute[];
     publicAccess: string;
     renderType: any;
     shortName: string;
     sortOrder: number;
     style: D2Style;
+    trackedEntityAttributes: D2TrackedEntityAttribute[];
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
@@ -2718,6 +2783,8 @@ export type D2ProgramIndicator = {
         | "AVERAGE_SUM_ORG_UNIT"
         | "LAST"
         | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
         | "COUNT"
         | "STDDEV"
         | "VARIANCE"
@@ -2728,7 +2795,7 @@ export type D2ProgramIndicator = {
         | "DEFAULT";
     analyticsPeriodBoundaries: D2AnalyticsPeriodBoundary[];
     analyticsType: "EVENT" | "ENROLLMENT";
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     decimals: number;
@@ -2780,7 +2847,7 @@ export type D2ProgramIndicator = {
 
 export type D2RelationshipType = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     bidirectional: boolean;
     code: Id;
     created: string;
@@ -2807,9 +2874,32 @@ export type D2RelationshipType = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
+export type D2ProgramIndicatorGroup = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    description: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    programIndicators: D2ProgramIndicator[];
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
 export type D2ProgramRuleVariable = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     dataElement: D2DataElement;
@@ -2840,38 +2930,17 @@ export type D2ProgramRuleVariable = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2ProgramIndicatorGroup = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    description: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    programIndicators: D2ProgramIndicator[];
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
 export type D2ProgramRuleAction = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     content: string;
     created: string;
     data: string;
     dataElement: D2DataElement;
     displayName: string;
+    evaluationEnvironments: never[];
+    evaluationTime: "ON_DATA_ENTRY" | "ON_COMPLETE" | "ALWAYS";
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
@@ -2916,7 +2985,7 @@ export type D2ProgramRuleAction = {
 
 export type D2ProgramRule = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     condition: string;
     created: string;
@@ -2949,6 +3018,8 @@ export type D2MapView = {
         | "AVERAGE_SUM_ORG_UNIT"
         | "LAST"
         | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
         | "COUNT"
         | "STDDEV"
         | "VARIANCE"
@@ -2959,7 +3030,7 @@ export type D2MapView = {
         | "DEFAULT";
     areaRadius: number;
     attributeDimensions: any[];
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     categoryDimensions: D2CategoryDimension[];
     categoryOptionGroupSetDimensions: D2CategoryOptionGroupSetDimension[];
     classes: number;
@@ -3036,6 +3107,7 @@ export type D2MapView = {
     radiusHigh: number;
     radiusLow: number;
     relativePeriods: any;
+    renderingStrategy: "SINGLE" | "SPLIT_BY_PERIOD" | "TIMELINE";
     rows: any[];
     shortName: string;
     sortOrder: number;
@@ -3052,14 +3124,113 @@ export type D2MapView = {
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
+    userOrgUnitType: "DATA_CAPTURE" | "DATA_OUTPUT" | "TEI_SEARCH";
     userOrganisationUnit: boolean;
     userOrganisationUnitChildren: boolean;
     userOrganisationUnitGrandChildren: boolean;
 };
 
+export type D2Report = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    cacheStrategy:
+        | "NO_CACHE"
+        | "CACHE_1_MINUTE"
+        | "CACHE_5_MINUTES"
+        | "CACHE_10_MINUTES"
+        | "CACHE_15_MINUTES"
+        | "CACHE_30_MINUTES"
+        | "CACHE_1_HOUR"
+        | "CACHE_6AM_TOMORROW"
+        | "CACHE_TWO_WEEKS"
+        | "RESPECT_SYSTEM_SETTING";
+    code: Id;
+    created: string;
+    designContent: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    relativePeriods: any;
+    reportParams: any;
+    translations: D2Translation[];
+    type: "JASPER_REPORT_TABLE" | "JASPER_JDBC" | "HTML";
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    visualization: D2Visualization;
+};
+
+export type D2Map = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    basemap: string;
+    code: Id;
+    created: string;
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    interpretations: D2Interpretation[];
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    latitude: number;
+    longitude: number;
+    mapViews: D2MapView[];
+    name: string;
+    publicAccess: string;
+    shortName: string;
+    subscribed: boolean;
+    subscribers: string[];
+    title: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    zoom: number;
+};
+
+export type D2Document = {
+    access: D2Access;
+    attachment: boolean;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    contentType: string;
+    created: string;
+    displayName: string;
+    external: boolean;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    translations: D2Translation[];
+    url: string;
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
 export type D2ExternalMapLayer = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     attribution: string;
     code: Id;
     created: string;
@@ -3086,7 +3257,7 @@ export type D2ExternalMapLayer = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2Chart = {
+export type D2ReportTable = {
     access: D2Access;
     aggregationType:
         | "SUM"
@@ -3094,6 +3265,8 @@ export type D2Chart = {
         | "AVERAGE_SUM_ORG_UNIT"
         | "LAST"
         | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
         | "COUNT"
         | "STDDEV"
         | "VARIANCE"
@@ -3103,7 +3276,108 @@ export type D2Chart = {
         | "CUSTOM"
         | "DEFAULT";
     attributeDimensions: any[];
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    categoryDimensions: D2CategoryDimension[];
+    categoryOptionGroupSetDimensions: D2CategoryOptionGroupSetDimension[];
+    code: Id;
+    colSubTotals: boolean;
+    colTotals: boolean;
+    columnDimensions: string[];
+    columns: any[];
+    completedOnly: boolean;
+    created: string;
+    cumulative: boolean;
+    dataDimensionItems: any[];
+    dataElementDimensions: D2TrackedEntityDataElementDimension[];
+    dataElementGroupSetDimensions: D2DataElementGroupSetDimension[];
+    description: string;
+    digitGroupSeparator: "COMMA" | "SPACE" | "NONE";
+    displayDensity: "COMFORTABLE" | "NORMAL" | "COMPACT" | "NONE";
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    endDate: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    filterDimensions: string[];
+    filters: any[];
+    fontSize: "LARGE" | "NORMAL" | "SMALL";
+    formName: string;
+    hideEmptyColumns: boolean;
+    hideEmptyRows: boolean;
+    hideSubtitle: boolean;
+    hideTitle: boolean;
+    href: string;
+    id: Id;
+    interpretations: D2Interpretation[];
+    itemOrganisationUnitGroups: D2OrganisationUnitGroup[];
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendDisplayStrategy: "FIXED" | "BY_DATA_ITEM";
+    legendDisplayStyle: "FILL" | "TEXT";
+    legendSet: D2LegendSet;
+    measureCriteria: string;
+    name: string;
+    numberType: "VALUE" | "ROW_PERCENTAGE" | "COLUMN_PERCENTAGE";
+    orgUnitField: string;
+    organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimension[];
+    organisationUnitLevels: number[];
+    organisationUnits: D2OrganisationUnit[];
+    parentGraphMap: D2Map;
+    periods: any[];
+    programIndicatorDimensions: D2TrackedEntityProgramIndicatorDimension[];
+    publicAccess: string;
+    regression: boolean;
+    relativePeriods: any;
+    reportParams: any;
+    rowDimensions: string[];
+    rowSubTotals: boolean;
+    rowTotals: boolean;
+    rows: any[];
+    shortName: string;
+    showDimensionLabels: boolean;
+    showHierarchy: boolean;
+    skipRounding: boolean;
+    sortOrder: number;
+    startDate: string;
+    subscribed: boolean;
+    subscribers: string[];
+    subtitle: string;
+    timeField: string;
+    title: string;
+    topLimit: number;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    userOrgUnitType: "DATA_CAPTURE" | "DATA_OUTPUT" | "TEI_SEARCH";
+    userOrganisationUnit: boolean;
+    userOrganisationUnitChildren: boolean;
+    userOrganisationUnitGrandChildren: boolean;
+};
+
+export type D2Chart = {
+    access: D2Access;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    attributeDimensions: any[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     baseLineLabel: string;
     baseLineValue: number;
     category: string;
@@ -3189,42 +3463,19 @@ export type D2Chart = {
         | "RADAR"
         | "GAUGE"
         | "YEAR_OVER_YEAR_LINE"
-        | "YEAR_OVER_YEAR_COLUMN";
+        | "YEAR_OVER_YEAR_COLUMN"
+        | "SINGLE_VALUE";
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
+    userOrgUnitType: "DATA_CAPTURE" | "DATA_OUTPUT" | "TEI_SEARCH";
     userOrganisationUnit: boolean;
     userOrganisationUnitChildren: boolean;
     userOrganisationUnitGrandChildren: boolean;
     yearlySeries: string[];
 };
 
-export type D2Document = {
-    access: D2Access;
-    attachment: boolean;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    contentType: string;
-    created: string;
-    displayName: string;
-    external: boolean;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    url: string;
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2ReportTable = {
+export type D2Visualization = {
     access: D2Access;
     aggregationType:
         | "SUM"
@@ -3232,6 +3483,8 @@ export type D2ReportTable = {
         | "AVERAGE_SUM_ORG_UNIT"
         | "LAST"
         | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
         | "COUNT"
         | "STDDEV"
         | "VARIANCE"
@@ -3241,17 +3494,20 @@ export type D2ReportTable = {
         | "CUSTOM"
         | "DEFAULT";
     attributeDimensions: any[];
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    baseLineLabel: string;
+    baseLineValue: number;
     categoryDimensions: D2CategoryDimension[];
     categoryOptionGroupSetDimensions: D2CategoryOptionGroupSetDimension[];
     code: Id;
     colSubTotals: boolean;
     colTotals: boolean;
+    colorSet: D2ColorSet;
     columnDimensions: string[];
     columns: any[];
     completedOnly: boolean;
     created: string;
-    cumulative: boolean;
+    cumulativeValues: boolean;
     dataDimensionItems: any[];
     dataElementDimensions: D2TrackedEntityDataElementDimension[];
     dataElementGroupSetDimensions: D2DataElementGroupSetDimension[];
@@ -3262,6 +3518,7 @@ export type D2ReportTable = {
     displayFormName: string;
     displayName: string;
     displayShortName: string;
+    domainAxisLabel: string;
     endDate: string;
     externalAccess: boolean;
     favorite: boolean;
@@ -3271,7 +3528,9 @@ export type D2ReportTable = {
     fontSize: "LARGE" | "NORMAL" | "SMALL";
     formName: string;
     hideEmptyColumns: boolean;
+    hideEmptyRowItems: "NONE" | "BEFORE_FIRST" | "AFTER_LAST" | "BEFORE_FIRST_AFTER_LAST" | "ALL";
     hideEmptyRows: boolean;
+    hideLegend: boolean;
     hideSubtitle: boolean;
     hideTitle: boolean;
     href: string;
@@ -3285,23 +3544,33 @@ export type D2ReportTable = {
     legendSet: D2LegendSet;
     measureCriteria: string;
     name: string;
+    noSpaceBetweenColumns: boolean;
     numberType: "VALUE" | "ROW_PERCENTAGE" | "COLUMN_PERCENTAGE";
+    optionalAxes: any[];
     orgUnitField: string;
     organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimension[];
     organisationUnitLevels: number[];
     organisationUnits: D2OrganisationUnit[];
     parentGraphMap: D2Map;
+    percentStackedValues: boolean;
     periods: any[];
     programIndicatorDimensions: D2TrackedEntityProgramIndicatorDimension[];
     publicAccess: string;
+    rangeAxisDecimals: number;
+    rangeAxisLabel: string;
+    rangeAxisMaxValue: number;
+    rangeAxisMinValue: number;
+    rangeAxisSteps: number;
     regression: boolean;
+    regressionType: "NONE" | "LINEAR" | "POLYNOMIAL" | "LOESS";
     relativePeriods: any;
-    reportParams: any;
+    reportingParams: any;
     rowDimensions: string[];
     rowSubTotals: boolean;
     rowTotals: boolean;
     rows: any[];
     shortName: string;
+    showData: boolean;
     showDimensionLabels: boolean;
     showHierarchy: boolean;
     skipRounding: boolean;
@@ -3310,50 +3579,35 @@ export type D2ReportTable = {
     subscribed: boolean;
     subscribers: string[];
     subtitle: string;
+    targetLineLabel: string;
+    targetLineValue: number;
     timeField: string;
     title: string;
     topLimit: number;
     translations: D2Translation[];
+    type:
+        | "COLUMN"
+        | "STACKED_COLUMN"
+        | "BAR"
+        | "STACKED_BAR"
+        | "LINE"
+        | "AREA"
+        | "PIE"
+        | "RADAR"
+        | "GAUGE"
+        | "YEAR_OVER_YEAR_LINE"
+        | "YEAR_OVER_YEAR_COLUMN"
+        | "SINGLE_VALUE"
+        | "PIVOT_TABLE";
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
+    userOrgUnitType: "DATA_CAPTURE" | "DATA_OUTPUT" | "TEI_SEARCH";
     userOrganisationUnit: boolean;
     userOrganisationUnitChildren: boolean;
     userOrganisationUnitGrandChildren: boolean;
-};
-
-export type D2Report = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    cacheStrategy:
-        | "NO_CACHE"
-        | "CACHE_15_MINUTES"
-        | "CACHE_30_MINUTES"
-        | "CACHE_1_HOUR"
-        | "CACHE_6AM_TOMORROW"
-        | "CACHE_TWO_WEEKS"
-        | "RESPECT_SYSTEM_SETTING";
-    code: Id;
-    created: string;
-    designContent: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    relativePeriods: any;
-    reportParams: any;
-    reportTable: D2ReportTable;
-    translations: D2Translation[];
-    type: "JASPER_REPORT_TABLE" | "JASPER_JDBC" | "HTML";
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
+    visualizationPeriodName: string;
+    yearlySeries: string[];
 };
 
 export type D2ValidationResult = {
@@ -3369,46 +3623,10 @@ export type D2ValidationResult = {
     validationRule: D2ValidationRule;
 };
 
-export type D2Map = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    basemap: string;
-    code: Id;
-    created: string;
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    interpretations: D2Interpretation[];
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    latitude: number;
-    longitude: number;
-    mapViews: D2MapView[];
-    name: string;
-    publicAccess: string;
-    shortName: string;
-    subscribed: boolean;
-    subscribers: string[];
-    title: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    zoom: number;
-};
-
 export type D2Predictor = {
     access: D2Access;
     annualSampleCount: number;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     description: string;
@@ -3444,7 +3662,7 @@ export type D2Predictor = {
 
 export type D2PredictorGroup = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     description: string;
@@ -3468,7 +3686,7 @@ export type D2PredictorGroup = {
 export type D2DashboardItem = {
     access: D2Access;
     appKey: string;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     chart: D2Chart;
     code: Id;
     contentCount: number;
@@ -3497,6 +3715,7 @@ export type D2DashboardItem = {
     text: string;
     translations: D2Translation[];
     type:
+        | "VISUALIZATION"
         | "CHART"
         | "EVENT_CHART"
         | "MAP"
@@ -3512,6 +3731,7 @@ export type D2DashboardItem = {
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
     users: D2User[];
+    visualization: D2Visualization;
     width: number;
     x: number;
     y: number;
@@ -3519,7 +3739,7 @@ export type D2DashboardItem = {
 
 export type D2Dashboard = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     dashboardItems: D2DashboardItem[];
@@ -3548,7 +3768,7 @@ export type D2Dashboard = {
 
 export type D2PushAnalysis = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     dashboard: D2Dashboard;
@@ -3573,7 +3793,7 @@ export type D2PushAnalysis = {
 
 export type D2KeyJsonValue = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     displayName: string;
@@ -3595,141 +3815,6 @@ export type D2KeyJsonValue = {
     value: string;
 };
 
-export type D2OrganisationUnitGroupSetDimension = {
-    organisationUnitGroupSet: D2OrganisationUnitGroupSet;
-    organisationUnitGroups: D2OrganisationUnitGroup[];
-};
-
-export type D2UserCredentials = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    catDimensionConstraints: D2Category[];
-    code: Id;
-    cogsDimensionConstraints: D2CategoryOptionGroupSet[];
-    created: string;
-    disabled: boolean;
-    displayName: string;
-    externalAccess: boolean;
-    externalAuth: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    invitation: boolean;
-    lastLogin: string;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    ldapId: string;
-    name: string;
-    openId: string;
-    password: string;
-    passwordLastUpdated: string;
-    publicAccess: string;
-    selfRegistered: boolean;
-    translations: D2Translation[];
-    twoFA: boolean;
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    userInfo: D2User;
-    userRoles: D2UserAuthorityGroup[];
-    username: string;
-};
-
-export type D2ProgramStageDataElement = {
-    access: D2Access;
-    allowFutureDate: boolean;
-    allowProvidedElsewhere: boolean;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    compulsory: boolean;
-    created: string;
-    dataElement: D2DataElement;
-    displayInReports: boolean;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    programStage: D2ProgramStage;
-    publicAccess: string;
-    renderOptionsAsRadio: boolean;
-    renderType: any;
-    skipSynchronization: boolean;
-    sortOrder: number;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2FileResource = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    contentLength: string;
-    contentMd5: string;
-    contentType: string;
-    created: string;
-    displayName: string;
-    domain: "DATA_VALUE" | "PUSH_ANALYSIS" | "DOCUMENT" | "MESSAGE_ATTACHMENT" | "USER_AVATAR";
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    storageStatus: "NONE" | "PENDING" | "FAILED" | "STORED";
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2ProgramInstance = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    createdAtClient: string;
-    deleted: boolean;
-    displayName: string;
-    endDate: string;
-    enrollmentDate: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    followup: boolean;
-    href: string;
-    id: Id;
-    incidentDate: string;
-    lastUpdated: string;
-    lastUpdatedAtClient: string;
-    lastUpdatedBy: D2User;
-    messageConversations: D2MessageConversation[];
-    name: string;
-    organisationUnit: D2OrganisationUnit;
-    program: D2Program;
-    programStageInstances: D2ProgramStageInstance[];
-    publicAccess: string;
-    relationshipItems: any[];
-    status: "ACTIVE" | "COMPLETED" | "CANCELLED";
-    storedBy: string;
-    trackedEntityComments: any[];
-    trackedEntityInstance: D2TrackedEntityInstance;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
 export type D2UserAccess = {
     access: string;
     displayName: string;
@@ -3737,13 +3822,106 @@ export type D2UserAccess = {
     userUid: string;
 };
 
-export type D2TrackedEntityDataElementDimension = {
-    dataElement: D2DataElement;
-    filter: string;
-    legendSet: D2LegendSet;
+export type D2AnalyticsPeriodBoundary = {
+    access: D2Access;
+    analyticsPeriodBoundaryType:
+        | "BEFORE_START_OF_REPORTING_PERIOD"
+        | "BEFORE_END_OF_REPORTING_PERIOD"
+        | "AFTER_START_OF_REPORTING_PERIOD"
+        | "AFTER_END_OF_REPORTING_PERIOD";
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    boundaryTarget: string;
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    offsetPeriodType: string;
+    offsetPeriods: number;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2Icon = {};
+export type D2DataSetElement = {
+    categoryCombo: D2CategoryCombo;
+    dataElement: D2DataElement;
+    dataSet: D2DataSet;
+};
+
+export type D2TrackedEntityInstance = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    createdAtClient: string;
+    deleted: boolean;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    geometry: D2Geometry;
+    href: string;
+    id: Id;
+    inactive: boolean;
+    lastUpdated: string;
+    lastUpdatedAtClient: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    organisationUnit: D2OrganisationUnit;
+    programInstances: D2ProgramInstance[];
+    programOwners: any[];
+    publicAccess: string;
+    relationshipItems: any[];
+    trackedEntityAttributeValues: D2TrackedEntityAttributeValue[];
+    trackedEntityType: D2TrackedEntityType;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2MinMaxDataElement = {
+    dataElement: D2DataElement;
+    generated: boolean;
+    max: number;
+    min: number;
+    optionCombo: D2CategoryOptionCombo;
+    source: D2OrganisationUnit;
+};
+
+export type D2ProgramStageInstanceFilter = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    description: string;
+    displayName: string;
+    eventQueryCriteria: any;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    program: Id;
+    programStage: Id;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
 
 export type D2DataElementGroupSetDimension = {
     dataElementGroupSet: D2DataElementGroupSet;
@@ -3753,7 +3931,7 @@ export type D2DataElementGroupSetDimension = {
 export type D2ProgramTrackedEntityAttribute = {
     access: D2Access;
     allowFutureDate: boolean;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     displayInList: boolean;
@@ -3808,136 +3986,10 @@ export type D2ProgramTrackedEntityAttribute = {
         | "IMAGE";
 };
 
-export type D2ReportingRate = {
-    access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    dataSet: D2DataSet;
-    description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
-    metric:
-        | "REPORTING_RATE"
-        | "REPORTING_RATE_ON_TIME"
-        | "ACTUAL_REPORTS"
-        | "ACTUAL_REPORTS_ON_TIME"
-        | "EXPECTED_REPORTS";
-    name: string;
-    publicAccess: string;
-    shortName: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2UserGroupAccess = {
-    access: string;
-    displayName: string;
-    id: string;
-    userGroupUid: string;
-};
-
-export type D2ProgramStageInstance = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2InterpretationComment = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    mentions: any[];
-    name: string;
-    publicAccess: string;
-    text: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2MinMaxDataElement = {
-    dataElement: D2DataElement;
-    generated: boolean;
-    max: number;
-    min: number;
-    optionCombo: D2CategoryOptionCombo;
-    source: D2OrganisationUnit;
-};
-
 export type D2MessageConversation = {
     access: D2Access;
     assignee: D2User;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     displayName: string;
@@ -3971,94 +4023,26 @@ export type D2MessageConversation = {
     userSurname: string;
 };
 
-export type D2AnalyticsPeriodBoundary = {
-    access: D2Access;
-    analyticsPeriodBoundaryType:
-        | "BEFORE_START_OF_REPORTING_PERIOD"
-        | "BEFORE_END_OF_REPORTING_PERIOD"
-        | "AFTER_START_OF_REPORTING_PERIOD"
-        | "AFTER_END_OF_REPORTING_PERIOD";
-    attributeValues: D2AttributeValue[];
-    boundaryTarget: string;
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    offsetPeriodType: string;
-    offsetPeriods: number;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
+export type D2OrganisationUnitGroupSetDimension = {
+    organisationUnitGroupSet: D2OrganisationUnitGroupSet;
+    organisationUnitGroups: D2OrganisationUnitGroup[];
 };
 
-export type D2MetadataVersion = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    hashCode: string;
-    href: string;
-    id: Id;
-    importDate: string;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    type: "BEST_EFFORT" | "ATOMIC";
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
+export type D2CategoryOptionGroupSetDimension = {
+    categoryOptionGroupSet: D2CategoryOptionGroupSet;
+    categoryOptionGroups: D2CategoryOptionGroup[];
 };
 
-export type D2TrackedEntityInstance = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    createdAtClient: string;
-    deleted: boolean;
+export type D2UserGroupAccess = {
+    access: string;
     displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    geometry: D2Geometry;
-    href: string;
-    id: Id;
-    inactive: boolean;
-    lastUpdated: string;
-    lastUpdatedAtClient: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    organisationUnit: D2OrganisationUnit;
-    programInstances: D2ProgramInstance[];
-    programOwners: any[];
-    publicAccess: string;
-    relationshipItems: any[];
-    trackedEntityAttributeValues: any[];
-    trackedEntityType: D2TrackedEntityType;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
+    id: string;
+    userGroupUid: string;
 };
 
 export type D2TrackedEntityInstanceFilter = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     description: string;
@@ -4085,134 +4069,6 @@ export type D2TrackedEntityInstanceFilter = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2ProgramStageInstanceFilter = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    code: Id;
-    created: string;
-    description: string;
-    displayName: string;
-    eventQueryCriteria: any;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    program: Id;
-    programStage: Id;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2DataElementOperand = {
-    access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    attributeOptionCombo: D2CategoryOptionCombo;
-    attributeValues: D2AttributeValue[];
-    categoryOptionCombo: D2CategoryOptionCombo;
-    code: Id;
-    created: string;
-    dataElement: D2DataElement;
-    description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
-    name: string;
-    publicAccess: string;
-    shortName: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2TrackedEntityProgramIndicatorDimension = {
-    filter: string;
-    legendSet: D2LegendSet;
-    programIndicator: D2ProgramIndicator;
-};
-
-export type D2Interpretation = {
-    access: D2Access;
-    attributeValues: D2AttributeValue[];
-    chart: D2Chart;
-    code: Id;
-    comments: D2InterpretationComment[];
-    created: string;
-    dataSet: D2DataSet;
-    displayName: string;
-    eventChart: D2EventChart;
-    eventReport: D2EventReport;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    likedBy: D2User[];
-    likes: number;
-    map: D2Map;
-    mentions: any[];
-    name: string;
-    organisationUnit: D2OrganisationUnit;
-    period: any;
-    publicAccess: string;
-    reportTable: D2ReportTable;
-    text: string;
-    translations: D2Translation[];
-    type: "REPORT_TABLE" | "CHART" | "MAP" | "EVENT_REPORT" | "EVENT_CHART" | "DATASET_REPORT";
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
 export type D2ProgramDataElementDimensionItem = {
     access: D2Access;
     aggregationType:
@@ -4221,6 +4077,8 @@ export type D2ProgramDataElementDimensionItem = {
         | "AVERAGE_SUM_ORG_UNIT"
         | "LAST"
         | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
         | "COUNT"
         | "STDDEV"
         | "VARIANCE"
@@ -4229,7 +4087,7 @@ export type D2ProgramDataElementDimensionItem = {
         | "NONE"
         | "CUSTOM"
         | "DEFAULT";
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     dataElement: D2DataElement;
@@ -4300,21 +4158,304 @@ export type D2ProgramDataElementDimensionItem = {
         | "IMAGE";
 };
 
+export type D2ReportingRate = {
+    access: D2Access;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    dataSet: D2DataSet;
+    description: string;
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
+    metric:
+        | "REPORTING_RATE"
+        | "REPORTING_RATE_ON_TIME"
+        | "ACTUAL_REPORTS"
+        | "ACTUAL_REPORTS_ON_TIME"
+        | "EXPECTED_REPORTS";
+    name: string;
+    publicAccess: string;
+    shortName: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2MetadataVersion = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    hashCode: string;
+    href: string;
+    id: Id;
+    importDate: string;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    translations: D2Translation[];
+    type: "BEST_EFFORT" | "ATOMIC";
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
 export type D2DataInputPeriod = {
     closingDate: string;
     openingDate: string;
     period: any;
 };
 
-export type D2DataSetElement = {
-    categoryCombo: D2CategoryCombo;
-    dataElement: D2DataElement;
+export type D2Icon = {};
+
+export type D2TrackedEntityAttributeValue = {
+    created: string;
+    lastUpdated: string;
+    storedBy: string;
+    trackedEntityAttribute: D2TrackedEntityAttribute;
+    trackedEntityInstance: D2TrackedEntityInstance;
+    value: string;
+};
+
+export type D2Interpretation = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    chart: D2Chart;
+    code: Id;
+    comments: D2InterpretationComment[];
+    created: string;
     dataSet: D2DataSet;
+    displayName: string;
+    eventChart: D2EventChart;
+    eventReport: D2EventReport;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    likedBy: D2User[];
+    likes: number;
+    map: D2Map;
+    mentions: any[];
+    name: string;
+    organisationUnit: D2OrganisationUnit;
+    period: any;
+    publicAccess: string;
+    reportTable: D2ReportTable;
+    text: string;
+    translations: D2Translation[];
+    type:
+        | "VISUALIZATION"
+        | "REPORT_TABLE"
+        | "CHART"
+        | "MAP"
+        | "EVENT_REPORT"
+        | "EVENT_CHART"
+        | "DATASET_REPORT";
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    visualization: D2Visualization;
+};
+
+export type D2ProgramStageDataElement = {
+    access: D2Access;
+    allowFutureDate: boolean;
+    allowProvidedElsewhere: boolean;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    compulsory: boolean;
+    created: string;
+    dataElement: D2DataElement;
+    displayInReports: boolean;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    programStage: D2ProgramStage;
+    publicAccess: string;
+    renderOptionsAsRadio: boolean;
+    renderType: any;
+    skipSynchronization: boolean;
+    sortOrder: number;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2InterpretationComment = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    mentions: any[];
+    name: string;
+    publicAccess: string;
+    text: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2TrackedEntityProgramIndicatorDimension = {
+    filter: string;
+    legendSet: D2LegendSet;
+    programIndicator: D2ProgramIndicator;
+};
+
+export type D2ProgramStageInstance = {
+    access: D2Access;
+    assignedUser: D2User;
+    attributeOptionCombo: D2CategoryOptionCombo;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    comments: any[];
+    completed: boolean;
+    completedBy: string;
+    completedDate: string;
+    creatableInSearchScope: boolean;
+    created: string;
+    createdAtClient: string;
+    deleted: boolean;
+    displayName: string;
+    dueDate: string;
+    eventDataValues: any[];
+    eventDate: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    geometry: D2Geometry;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedAtClient: string;
+    lastUpdatedBy: D2User;
+    messageConversations: D2MessageConversation[];
+    name: string;
+    organisationUnit: D2OrganisationUnit;
+    programInstance: D2ProgramInstance;
+    programStage: D2ProgramStage;
+    publicAccess: string;
+    relationshipItems: any[];
+    status: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";
+    storedBy: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2CategoryDimension = {
+    category: D2Category;
+    categoryOptions: D2CategoryOption[];
+};
+
+export type D2UserCredentials = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    catDimensionConstraints: D2Category[];
+    code: Id;
+    cogsDimensionConstraints: D2CategoryOptionGroupSet[];
+    created: string;
+    disabled: boolean;
+    displayName: string;
+    externalAccess: boolean;
+    externalAuth: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    invitation: boolean;
+    lastLogin: string;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    ldapId: string;
+    name: string;
+    openId: string;
+    password: string;
+    passwordLastUpdated: string;
+    publicAccess: string;
+    selfRegistered: boolean;
+    translations: D2Translation[];
+    twoFA: boolean;
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    userInfo: D2User;
+    userRoles: D2UserAuthorityGroup[];
+    username: string;
 };
 
 export type D2Color = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     color: string;
     created: string;
@@ -4334,14 +4475,75 @@ export type D2Color = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2CategoryOptionGroupSetDimension = {
-    categoryOptionGroupSet: D2CategoryOptionGroupSet;
-    categoryOptionGroups: D2CategoryOptionGroup[];
+export type D2ProgramInstance = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    completedBy: string;
+    created: string;
+    createdAtClient: string;
+    deleted: boolean;
+    displayName: string;
+    endDate: string;
+    enrollmentDate: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    followup: boolean;
+    geometry: D2Geometry;
+    href: string;
+    id: Id;
+    incidentDate: string;
+    lastUpdated: string;
+    lastUpdatedAtClient: string;
+    lastUpdatedBy: D2User;
+    messageConversations: D2MessageConversation[];
+    name: string;
+    organisationUnit: D2OrganisationUnit;
+    program: D2Program;
+    programStageInstances: D2ProgramStageInstance[];
+    publicAccess: string;
+    relationshipItems: any[];
+    status: "ACTIVE" | "COMPLETED" | "CANCELLED";
+    storedBy: string;
+    trackedEntityComments: any[];
+    trackedEntityInstance: D2TrackedEntityInstance;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2FileResource = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    contentLength: string;
+    contentMd5: string;
+    contentType: string;
+    created: string;
+    displayName: string;
+    domain: "DATA_VALUE" | "PUSH_ANALYSIS" | "DOCUMENT" | "MESSAGE_ATTACHMENT" | "USER_AVATAR";
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    hasMultipleStorageFiles: boolean;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    storageStatus: "NONE" | "PENDING" | "FAILED" | "STORED";
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
 };
 
 export type D2Legend = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     color: string;
     created: string;
@@ -4372,6 +4574,8 @@ export type D2ProgramTrackedEntityAttributeDimensionItem = {
         | "AVERAGE_SUM_ORG_UNIT"
         | "LAST"
         | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
         | "COUNT"
         | "STDDEV"
         | "VARIANCE"
@@ -4381,7 +4585,7 @@ export type D2ProgramTrackedEntityAttributeDimensionItem = {
         | "CUSTOM"
         | "DEFAULT";
     attribute: D2TrackedEntityAttribute;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     description: string;
@@ -4425,9 +4629,16 @@ export type D2ProgramTrackedEntityAttributeDimensionItem = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
+export type D2TrackedEntityDataElementDimension = {
+    dataElement: D2DataElement;
+    filter: string;
+    legendSet: D2LegendSet;
+    programStage: D2ProgramStage;
+};
+
 export type D2Relationship = {
     access: D2Access;
-    attributeValues: D2AttributeValue[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
     description: string;
@@ -4456,30 +4667,76 @@ export type D2Relationship = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2CategoryDimension = {
-    category: D2Category;
-    categoryOptions: D2CategoryOption[];
+export type D2DataElementOperand = {
+    access: D2Access;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    attributeOptionCombo: D2CategoryOptionCombo;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    categoryOptionCombo: D2CategoryOptionCombo;
+    code: Id;
+    created: string;
+    dataElement: D2DataElement;
+    description: string;
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
+    name: string;
+    publicAccess: string;
+    shortName: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
 };
-
-export interface D2AttributeValueSchema {
-    name: "D2AttributeValue";
-    model: D2AttributeValue;
-    fields: { attribute: D2AttributeSchema; created: string; lastUpdated: string; value: string };
-    fieldPresets: {
-        $all: Preset<D2AttributeValue, keyof D2AttributeValue>;
-        $identifiable: Preset<D2AttributeValue, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2AttributeValue, FieldPresets["nameable"]>;
-        $persisted: Preset<D2AttributeValue, "lastUpdated" | "attribute" | "value" | "created">;
-        $owner: Preset<D2AttributeValue, "lastUpdated" | "attribute" | "value" | "created">;
-    };
-}
 
 export interface D2UserAuthorityGroupSchema {
     name: "D2UserAuthorityGroup";
     model: D2UserAuthorityGroup;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         authorities: string[];
         code: Id;
         created: string;
@@ -4544,7 +4801,7 @@ export interface D2AttributeSchema {
     model: D2Attribute;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         categoryAttribute: boolean;
         categoryOptionAttribute: boolean;
         categoryOptionComboAttribute: boolean;
@@ -4742,7 +4999,7 @@ export interface D2UserSchema {
     model: D2User;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         avatar: D2FileResourceSchema;
         birthday: string;
         code: Id;
@@ -4865,7 +5122,7 @@ export interface D2UserGroupSchema {
     model: D2UserGroup;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         displayName: string;
@@ -4960,7 +5217,7 @@ export interface D2ExternalFileResourceSchema {
     model: D2ExternalFileResource;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         displayName: string;
@@ -4998,9 +5255,12 @@ export interface D2SqlViewSchema {
     model: D2SqlView;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         cacheStrategy:
             | "NO_CACHE"
+            | "CACHE_1_MINUTE"
+            | "CACHE_5_MINUTES"
+            | "CACHE_10_MINUTES"
             | "CACHE_15_MINUTES"
             | "CACHE_30_MINUTES"
             | "CACHE_1_HOUR"
@@ -5072,72 +5332,12 @@ export interface D2SqlViewSchema {
     };
 }
 
-export interface D2OAuth2ClientSchema {
-    name: "D2OAuth2Client";
-    model: D2OAuth2Client;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        cid: Id;
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        grantTypes: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        redirectUris: string[];
-        secret: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2OAuth2Client, keyof D2OAuth2Client>;
-        $identifiable: Preset<D2OAuth2Client, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OAuth2Client, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2OAuth2Client,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "secret"
-            | "redirectUris"
-            | "lastUpdated"
-            | "grantTypes"
-            | "name"
-            | "id"
-            | "cid"
-        >;
-        $owner: Preset<
-            D2OAuth2Client,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "secret"
-            | "redirectUris"
-            | "lastUpdated"
-            | "grantTypes"
-            | "name"
-            | "id"
-            | "cid"
-        >;
-    };
-}
-
 export interface D2ConstantSchema {
     name: "D2Constant";
     model: D2Constant;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         description: string;
@@ -5205,121 +5405,62 @@ export interface D2ConstantSchema {
     };
 }
 
-export interface D2JobConfigurationSchema {
-    name: "D2JobConfiguration";
-    model: D2JobConfiguration;
+export interface D2OAuth2ClientSchema {
+    name: "D2OAuth2Client";
+    model: D2OAuth2Client;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        cid: Id;
         code: Id;
-        configurable: boolean;
-        continuousExecution: boolean;
         created: string;
-        cronExpression: string;
         displayName: string;
-        enabled: boolean;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
+        grantTypes: string[];
         href: string;
         id: Id;
-        jobParameters: string;
-        jobStatus: "RUNNING" | "COMPLETED" | "STOPPED" | "SCHEDULED" | "DISABLED" | "FAILED";
-        jobType:
-            | "DATA_STATISTICS"
-            | "DATA_INTEGRITY"
-            | "RESOURCE_TABLE"
-            | "ANALYTICS_TABLE"
-            | "DATA_SYNC"
-            | "PROGRAM_DATA_SYNC"
-            | "FILE_RESOURCE_CLEANUP"
-            | "META_DATA_SYNC"
-            | "SMS_SEND"
-            | "SEND_SCHEDULED_MESSAGE"
-            | "PROGRAM_NOTIFICATIONS"
-            | "VALIDATION_RESULTS_NOTIFICATION"
-            | "CREDENTIALS_EXPIRY_ALERT"
-            | "MONITORING"
-            | "PUSH_ANALYSIS"
-            | "PREDICTOR"
-            | "DATA_SET_NOTIFICATION"
-            | "REMOVE_EXPIRED_RESERVED_VALUES"
-            | "MOCK"
-            | "DATAVALUE_IMPORT"
-            | "ANALYTICSTABLE_UPDATE"
-            | "METADATA_IMPORT"
-            | "GML_IMPORT"
-            | "DATAVALUE_IMPORT_INTERNAL"
-            | "EVENT_IMPORT"
-            | "ENROLLMENT_IMPORT"
-            | "TEI_IMPORT"
-            | "LEADER_ELECTION"
-            | "LEADER_RENEWAL"
-            | "COMPLETE_DATA_SET_REGISTRATION_IMPORT";
-        lastExecuted: string;
-        lastExecutedStatus:
-            | "RUNNING"
-            | "COMPLETED"
-            | "STOPPED"
-            | "SCHEDULED"
-            | "DISABLED"
-            | "FAILED";
-        lastRuntimeExecution: string;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
-        leaderOnlyJob: boolean;
         name: string;
-        nextExecutionTime: string;
         publicAccess: string;
+        redirectUris: string[];
+        secret: string;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
-        userUid: string;
     };
     fieldPresets: {
-        $all: Preset<D2JobConfiguration, keyof D2JobConfiguration>;
-        $identifiable: Preset<D2JobConfiguration, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2JobConfiguration, FieldPresets["nameable"]>;
+        $all: Preset<D2OAuth2Client, keyof D2OAuth2Client>;
+        $identifiable: Preset<D2OAuth2Client, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OAuth2Client, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2JobConfiguration,
-            | "jobStatus"
-            | "code"
-            | "enabled"
-            | "leaderOnlyJob"
-            | "lastUpdated"
-            | "continuousExecution"
-            | "id"
-            | "jobType"
+            D2OAuth2Client,
             | "lastUpdatedBy"
-            | "nextExecutionTime"
+            | "code"
             | "created"
-            | "cronExpression"
-            | "lastRuntimeExecution"
-            | "lastExecutedStatus"
+            | "secret"
+            | "redirectUris"
+            | "lastUpdated"
+            | "grantTypes"
             | "name"
-            | "jobParameters"
-            | "lastExecuted"
+            | "id"
+            | "cid"
         >;
         $owner: Preset<
-            D2JobConfiguration,
-            | "jobStatus"
-            | "code"
-            | "enabled"
-            | "leaderOnlyJob"
-            | "lastUpdated"
-            | "continuousExecution"
-            | "id"
-            | "jobType"
+            D2OAuth2Client,
             | "lastUpdatedBy"
-            | "nextExecutionTime"
+            | "code"
             | "created"
-            | "cronExpression"
-            | "lastRuntimeExecution"
-            | "lastExecutedStatus"
+            | "secret"
+            | "redirectUris"
+            | "lastUpdated"
+            | "grantTypes"
             | "name"
-            | "jobParameters"
-            | "lastExecuted"
+            | "id"
+            | "cid"
         >;
     };
 }
@@ -5329,7 +5470,7 @@ export interface D2OptionSchema {
     model: D2Option;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: string;
         created: string;
         description: string;
@@ -5393,12 +5534,147 @@ export interface D2OptionSchema {
     };
 }
 
+export interface D2JobConfigurationSchema {
+    name: "D2JobConfiguration";
+    model: D2JobConfiguration;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        configurable: boolean;
+        created: string;
+        cronExpression: string;
+        delay: number;
+        displayName: string;
+        enabled: boolean;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        jobParameters: string;
+        jobStatus:
+            | "RUNNING"
+            | "COMPLETED"
+            | "STOPPED"
+            | "SCHEDULED"
+            | "DISABLED"
+            | "FAILED"
+            | "NOT_STARTED";
+        jobType:
+            | "DATA_STATISTICS"
+            | "DATA_INTEGRITY"
+            | "RESOURCE_TABLE"
+            | "ANALYTICS_TABLE"
+            | "CONTINUOUS_ANALYTICS_TABLE"
+            | "DATA_SYNC"
+            | "TRACKER_PROGRAMS_DATA_SYNC"
+            | "EVENT_PROGRAMS_DATA_SYNC"
+            | "FILE_RESOURCE_CLEANUP"
+            | "IMAGE_PROCESSING"
+            | "META_DATA_SYNC"
+            | "SMS_SEND"
+            | "SEND_SCHEDULED_MESSAGE"
+            | "PROGRAM_NOTIFICATIONS"
+            | "VALIDATION_RESULTS_NOTIFICATION"
+            | "CREDENTIALS_EXPIRY_ALERT"
+            | "MONITORING"
+            | "PUSH_ANALYSIS"
+            | "PREDICTOR"
+            | "DATA_SET_NOTIFICATION"
+            | "REMOVE_EXPIRED_RESERVED_VALUES"
+            | "TRACKER_IMPORT_JOB"
+            | "TRACKER_IMPORT_NOTIFICATION_JOB"
+            | "TRACKER_IMPORT_RULE_ENGINE_JOB"
+            | "MOCK"
+            | "DATAVALUE_IMPORT"
+            | "ANALYTICSTABLE_UPDATE"
+            | "METADATA_IMPORT"
+            | "GML_IMPORT"
+            | "DATAVALUE_IMPORT_INTERNAL"
+            | "EVENT_IMPORT"
+            | "ENROLLMENT_IMPORT"
+            | "TEI_IMPORT"
+            | "LEADER_ELECTION"
+            | "LEADER_RENEWAL"
+            | "COMPLETE_DATA_SET_REGISTRATION_IMPORT"
+            | "PROGRAM_DATA_SYNC";
+        lastExecuted: string;
+        lastExecutedStatus:
+            | "RUNNING"
+            | "COMPLETED"
+            | "STOPPED"
+            | "SCHEDULED"
+            | "DISABLED"
+            | "FAILED"
+            | "NOT_STARTED";
+        lastRuntimeExecution: string;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        leaderOnlyJob: boolean;
+        name: string;
+        nextExecutionTime: string;
+        publicAccess: string;
+        schedulingType: "CRON" | "FIXED_DELAY";
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        userUid: string;
+    };
+    fieldPresets: {
+        $all: Preset<D2JobConfiguration, keyof D2JobConfiguration>;
+        $identifiable: Preset<D2JobConfiguration, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2JobConfiguration, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2JobConfiguration,
+            | "jobStatus"
+            | "code"
+            | "enabled"
+            | "leaderOnlyJob"
+            | "lastUpdated"
+            | "id"
+            | "jobType"
+            | "lastUpdatedBy"
+            | "nextExecutionTime"
+            | "created"
+            | "cronExpression"
+            | "lastRuntimeExecution"
+            | "delay"
+            | "lastExecutedStatus"
+            | "name"
+            | "jobParameters"
+            | "lastExecuted"
+        >;
+        $owner: Preset<
+            D2JobConfiguration,
+            | "jobStatus"
+            | "code"
+            | "enabled"
+            | "leaderOnlyJob"
+            | "lastUpdated"
+            | "id"
+            | "jobType"
+            | "lastUpdatedBy"
+            | "nextExecutionTime"
+            | "created"
+            | "cronExpression"
+            | "lastRuntimeExecution"
+            | "delay"
+            | "lastExecutedStatus"
+            | "name"
+            | "jobParameters"
+            | "lastExecuted"
+        >;
+    };
+}
+
 export interface D2OptionSetSchema {
     name: "D2OptionSet";
     model: D2OptionSet;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         displayName: string;
@@ -5498,6 +5774,8 @@ export interface D2OptionGroupSetSchema {
             | "AVERAGE_SUM_ORG_UNIT"
             | "LAST"
             | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
             | "COUNT"
             | "STDDEV"
             | "VARIANCE"
@@ -5507,7 +5785,7 @@ export interface D2OptionGroupSetSchema {
             | "CUSTOM"
             | "DEFAULT";
         allItems: boolean;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         dataDimension: boolean;
@@ -5552,6 +5830,7 @@ export interface D2OptionGroupSetSchema {
         name: string;
         optionGroups: D2OptionGroupSchema[];
         optionSet: D2OptionSetSchema;
+        programStage: D2ProgramStageSchema;
         publicAccess: string;
         shortName: string;
         translations: D2Translation[];
@@ -5613,6 +5892,8 @@ export interface D2OptionGroupSchema {
             | "AVERAGE_SUM_ORG_UNIT"
             | "LAST"
             | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
             | "COUNT"
             | "STDDEV"
             | "VARIANCE"
@@ -5621,7 +5902,7 @@ export interface D2OptionGroupSchema {
             | "NONE"
             | "CUSTOM"
             | "DEFAULT";
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         description: string;
@@ -5681,7 +5962,6 @@ export interface D2OptionGroupSchema {
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "created"
-            | "attributeValues"
             | "userAccesses"
             | "name"
             | "shortName"
@@ -5699,64 +5979,10 @@ export interface D2OptionGroupSchema {
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "created"
-            | "attributeValues"
             | "userAccesses"
             | "name"
             | "shortName"
             | "user"
-        >;
-    };
-}
-
-export interface D2ColorSetSchema {
-    name: "D2ColorSet";
-    model: D2ColorSet;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        colors: D2ColorSchema[];
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ColorSet, keyof D2ColorSet>;
-        $identifiable: Preset<D2ColorSet, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ColorSet, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ColorSet,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "colors"
-            | "lastUpdated"
-            | "translations"
-            | "name"
-            | "id"
-        >;
-        $owner: Preset<
-            D2ColorSet,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "colors"
-            | "lastUpdated"
-            | "translations"
-            | "name"
-            | "id"
         >;
     };
 }
@@ -5766,7 +5992,7 @@ export interface D2LegendSetSchema {
     model: D2LegendSet;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         displayName: string;
@@ -5827,6 +6053,59 @@ export interface D2LegendSetSchema {
     };
 }
 
+export interface D2ColorSetSchema {
+    name: "D2ColorSet";
+    model: D2ColorSet;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        colors: D2ColorSchema[];
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ColorSet, keyof D2ColorSet>;
+        $identifiable: Preset<D2ColorSet, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ColorSet, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ColorSet,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "colors"
+            | "lastUpdated"
+            | "translations"
+            | "name"
+            | "id"
+        >;
+        $owner: Preset<
+            D2ColorSet,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "colors"
+            | "lastUpdated"
+            | "translations"
+            | "name"
+            | "id"
+        >;
+    };
+}
+
 export interface D2OrganisationUnitSchema {
     name: "D2OrganisationUnit";
     model: D2OrganisationUnit;
@@ -5839,6 +6118,8 @@ export interface D2OrganisationUnitSchema {
             | "AVERAGE_SUM_ORG_UNIT"
             | "LAST"
             | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
             | "COUNT"
             | "STDDEV"
             | "VARIANCE"
@@ -5848,7 +6129,7 @@ export interface D2OrganisationUnitSchema {
             | "CUSTOM"
             | "DEFAULT";
         ancestors: D2OrganisationUnitSchema[];
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         children: D2OrganisationUnitSchema[];
         closedDate: string;
         code: Id;
@@ -5923,6 +6204,7 @@ export interface D2OrganisationUnitSchema {
             | "id"
             | "organisationUnitGroups"
             | "lastUpdatedBy"
+            | "level"
             | "created"
             | "attributeValues"
             | "users"
@@ -5951,6 +6233,7 @@ export interface D2OrganisationUnitSchema {
             | "translations"
             | "id"
             | "lastUpdatedBy"
+            | "level"
             | "created"
             | "attributeValues"
             | "phoneNumber"
@@ -5976,7 +6259,7 @@ export interface D2OrganisationUnitLevelSchema {
     model: D2OrganisationUnitLevel;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         displayName: string;
@@ -6038,6 +6321,8 @@ export interface D2OrganisationUnitGroupSchema {
             | "AVERAGE_SUM_ORG_UNIT"
             | "LAST"
             | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
             | "COUNT"
             | "STDDEV"
             | "VARIANCE"
@@ -6046,7 +6331,7 @@ export interface D2OrganisationUnitGroupSchema {
             | "NONE"
             | "CUSTOM"
             | "DEFAULT";
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         color: string;
         created: string;
@@ -6153,6 +6438,8 @@ export interface D2OrganisationUnitGroupSetSchema {
             | "AVERAGE_SUM_ORG_UNIT"
             | "LAST"
             | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
             | "COUNT"
             | "STDDEV"
             | "VARIANCE"
@@ -6162,7 +6449,7 @@ export interface D2OrganisationUnitGroupSetSchema {
             | "CUSTOM"
             | "DEFAULT";
         allItems: boolean;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         compulsory: boolean;
         created: string;
@@ -6208,6 +6495,7 @@ export interface D2OrganisationUnitGroupSetSchema {
         legendSet: D2LegendSetSchema;
         name: string;
         organisationUnitGroups: D2OrganisationUnitGroupSchema[];
+        programStage: D2ProgramStageSchema;
         publicAccess: string;
         shortName: string;
         translations: D2Translation[];
@@ -6273,6 +6561,8 @@ export interface D2CategoryOptionSchema {
             | "AVERAGE_SUM_ORG_UNIT"
             | "LAST"
             | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
             | "COUNT"
             | "STDDEV"
             | "VARIANCE"
@@ -6281,7 +6571,7 @@ export interface D2CategoryOptionSchema {
             | "NONE"
             | "CUSTOM"
             | "DEFAULT";
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         categories: D2CategorySchema[];
         categoryOptionCombos: D2CategoryOptionComboSchema[];
         categoryOptionGroups: D2CategoryOptionGroupSchema[];
@@ -6342,6 +6632,7 @@ export interface D2CategoryOptionSchema {
             | "publicAccess"
             | "lastUpdated"
             | "translations"
+            | "formName"
             | "id"
             | "categories"
             | "organisationUnits"
@@ -6365,6 +6656,7 @@ export interface D2CategoryOptionSchema {
             | "publicAccess"
             | "lastUpdated"
             | "translations"
+            | "formName"
             | "id"
             | "organisationUnits"
             | "lastUpdatedBy"
@@ -6392,6 +6684,8 @@ export interface D2CategoryOptionGroupSchema {
             | "AVERAGE_SUM_ORG_UNIT"
             | "LAST"
             | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
             | "COUNT"
             | "STDDEV"
             | "VARIANCE"
@@ -6400,7 +6694,7 @@ export interface D2CategoryOptionGroupSchema {
             | "NONE"
             | "CUSTOM"
             | "DEFAULT";
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         categoryOptions: D2CategoryOptionSchema[];
         code: Id;
         created: string;
@@ -6500,6 +6794,8 @@ export interface D2CategoryOptionGroupSetSchema {
             | "AVERAGE_SUM_ORG_UNIT"
             | "LAST"
             | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
             | "COUNT"
             | "STDDEV"
             | "VARIANCE"
@@ -6509,7 +6805,7 @@ export interface D2CategoryOptionGroupSetSchema {
             | "CUSTOM"
             | "DEFAULT";
         allItems: boolean;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         categoryOptionGroups: D2CategoryOptionGroupSchema[];
         code: Id;
         created: string;
@@ -6553,6 +6849,7 @@ export interface D2CategoryOptionGroupSetSchema {
         lastUpdatedBy: D2UserSchema;
         legendSet: D2LegendSetSchema;
         name: string;
+        programStage: D2ProgramStageSchema;
         publicAccess: string;
         shortName: string;
         translations: D2Translation[];
@@ -6616,6 +6913,8 @@ export interface D2CategorySchema {
             | "AVERAGE_SUM_ORG_UNIT"
             | "LAST"
             | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
             | "COUNT"
             | "STDDEV"
             | "VARIANCE"
@@ -6625,7 +6924,7 @@ export interface D2CategorySchema {
             | "CUSTOM"
             | "DEFAULT";
         allItems: boolean;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         categoryCombos: D2CategoryComboSchema[];
         categoryOptions: D2CategoryOptionSchema[];
         code: Id;
@@ -6670,6 +6969,7 @@ export interface D2CategorySchema {
         lastUpdatedBy: D2UserSchema;
         legendSet: D2LegendSetSchema;
         name: string;
+        programStage: D2ProgramStageSchema;
         publicAccess: string;
         shortName: string;
         translations: D2Translation[];
@@ -6726,7 +7026,7 @@ export interface D2CategoryComboSchema {
     model: D2CategoryCombo;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         categories: D2CategorySchema[];
         categoryOptionCombos: D2CategoryOptionComboSchema[];
         code: Id;
@@ -6802,6 +7102,8 @@ export interface D2CategoryOptionComboSchema {
             | "AVERAGE_SUM_ORG_UNIT"
             | "LAST"
             | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
             | "COUNT"
             | "STDDEV"
             | "VARIANCE"
@@ -6810,7 +7112,7 @@ export interface D2CategoryOptionComboSchema {
             | "NONE"
             | "CUSTOM"
             | "DEFAULT";
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         categoryCombo: D2CategoryComboSchema;
         categoryOptions: D2CategoryOptionSchema[];
         code: Id;
@@ -6902,6 +7204,8 @@ export interface D2DataElementSchema {
             | "AVERAGE_SUM_ORG_UNIT"
             | "LAST"
             | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
             | "COUNT"
             | "STDDEV"
             | "VARIANCE"
@@ -6910,7 +7214,7 @@ export interface D2DataElementSchema {
             | "NONE"
             | "CUSTOM"
             | "DEFAULT";
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         categoryCombo: D2CategoryComboSchema;
         code: Id;
         commentOptionSet: D2OptionSetSchema;
@@ -7069,6 +7373,8 @@ export interface D2DataElementGroupSchema {
             | "AVERAGE_SUM_ORG_UNIT"
             | "LAST"
             | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
             | "COUNT"
             | "STDDEV"
             | "VARIANCE"
@@ -7077,7 +7383,7 @@ export interface D2DataElementGroupSchema {
             | "NONE"
             | "CUSTOM"
             | "DEFAULT";
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         dataElements: D2DataElementSchema[];
@@ -7174,6 +7480,8 @@ export interface D2DataElementGroupSetSchema {
             | "AVERAGE_SUM_ORG_UNIT"
             | "LAST"
             | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
             | "COUNT"
             | "STDDEV"
             | "VARIANCE"
@@ -7183,7 +7491,7 @@ export interface D2DataElementGroupSetSchema {
             | "CUSTOM"
             | "DEFAULT";
         allItems: boolean;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         compulsory: boolean;
         created: string;
@@ -7228,6 +7536,7 @@ export interface D2DataElementGroupSetSchema {
         lastUpdatedBy: D2UserSchema;
         legendSet: D2LegendSetSchema;
         name: string;
+        programStage: D2ProgramStageSchema;
         publicAccess: string;
         shortName: string;
         translations: D2Translation[];
@@ -7280,62 +7589,6 @@ export interface D2DataElementGroupSetSchema {
     };
 }
 
-export interface D2IndicatorTypeSchema {
-    name: "D2IndicatorType";
-    model: D2IndicatorType;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        factor: number;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        number: boolean;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2IndicatorType, keyof D2IndicatorType>;
-        $identifiable: Preset<D2IndicatorType, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2IndicatorType, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2IndicatorType,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "lastUpdated"
-            | "number"
-            | "translations"
-            | "name"
-            | "id"
-            | "factor"
-        >;
-        $owner: Preset<
-            D2IndicatorType,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "lastUpdated"
-            | "number"
-            | "translations"
-            | "name"
-            | "id"
-            | "factor"
-        >;
-    };
-}
-
 export interface D2AnalyticsTableHookSchema {
     name: "D2AnalyticsTableHook";
     model: D2AnalyticsTableHook;
@@ -7349,7 +7602,7 @@ export interface D2AnalyticsTableHookSchema {
             | "EVENT"
             | "ENROLLMENT"
             | "VALIDATION_RESULT";
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         displayName: string;
@@ -7416,6 +7669,62 @@ export interface D2AnalyticsTableHookSchema {
     };
 }
 
+export interface D2IndicatorTypeSchema {
+    name: "D2IndicatorType";
+    model: D2IndicatorType;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        factor: number;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        number: boolean;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2IndicatorType, keyof D2IndicatorType>;
+        $identifiable: Preset<D2IndicatorType, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2IndicatorType, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2IndicatorType,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "lastUpdated"
+            | "number"
+            | "translations"
+            | "name"
+            | "id"
+            | "factor"
+        >;
+        $owner: Preset<
+            D2IndicatorType,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "lastUpdated"
+            | "number"
+            | "translations"
+            | "name"
+            | "id"
+            | "factor"
+        >;
+    };
+}
+
 export interface D2IndicatorSchema {
     name: "D2Indicator";
     model: D2Indicator;
@@ -7429,6 +7738,8 @@ export interface D2IndicatorSchema {
             | "AVERAGE_SUM_ORG_UNIT"
             | "LAST"
             | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
             | "COUNT"
             | "STDDEV"
             | "VARIANCE"
@@ -7438,7 +7749,7 @@ export interface D2IndicatorSchema {
             | "CUSTOM"
             | "DEFAULT";
         annualized: boolean;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         dataSets: D2DataSetSchema[];
@@ -7566,7 +7877,7 @@ export interface D2IndicatorGroupSchema {
     model: D2IndicatorGroup;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         displayName: string;
@@ -7632,7 +7943,7 @@ export interface D2IndicatorGroupSetSchema {
     model: D2IndicatorGroupSet;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         compulsory: boolean;
         created: string;
@@ -7699,7 +8010,7 @@ export interface D2DataEntryFormSchema {
     model: D2DataEntryForm;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         displayName: string;
@@ -7764,6 +8075,8 @@ export interface D2DataSetSchema {
             | "AVERAGE_SUM_ORG_UNIT"
             | "LAST"
             | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
             | "COUNT"
             | "STDDEV"
             | "VARIANCE"
@@ -7772,7 +8085,7 @@ export interface D2DataSetSchema {
             | "NONE"
             | "CUSTOM"
             | "DEFAULT";
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         categoryCombo: D2CategoryComboSchema;
         code: Id;
         compulsoryDataElementOperands: D2DataElementOperandSchema[];
@@ -7824,6 +8137,7 @@ export interface D2DataSetSchema {
         notificationRecipients: D2UserGroupSchema;
         notifyCompletingUser: boolean;
         openFuturePeriods: number;
+        openPeriodsAfterCoEndDate: number;
         organisationUnits: D2OrganisationUnitSchema[];
         periodType: string;
         publicAccess: string;
@@ -7887,6 +8201,7 @@ export interface D2DataSetSchema {
             | "renderHorizontally"
             | "renderAsTabs"
             | "mobile"
+            | "openPeriodsAfterCoEndDate"
             | "periodType"
             | "openFuturePeriods"
             | "expiryDays"
@@ -7931,6 +8246,7 @@ export interface D2DataSetSchema {
             | "renderHorizontally"
             | "renderAsTabs"
             | "mobile"
+            | "openPeriodsAfterCoEndDate"
             | "periodType"
             | "openFuturePeriods"
             | "expiryDays"
@@ -7944,7 +8260,7 @@ export interface D2DataSetNotificationTemplateSchema {
     model: D2DataSetNotificationTemplate;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         dataSetNotificationTrigger: "DATA_SET_COMPLETION" | "SCHEDULED_DAYS";
@@ -8025,7 +8341,7 @@ export interface D2SectionSchema {
     model: D2Section;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         categoryCombos: D2CategoryComboSchema[];
         code: Id;
         created: string;
@@ -8102,7 +8418,7 @@ export interface D2DataApprovalLevelSchema {
     model: D2DataApprovalLevel;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         categoryOptionGroupSet: D2CategoryOptionGroupSetSchema;
         code: Id;
         created: string;
@@ -8170,7 +8486,7 @@ export interface D2DataApprovalWorkflowSchema {
     model: D2DataApprovalWorkflow;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         categoryCombo: D2CategoryComboSchema;
         code: Id;
         created: string;
@@ -8247,6 +8563,8 @@ export interface D2ValidationRuleSchema {
             | "AVERAGE_SUM_ORG_UNIT"
             | "LAST"
             | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
             | "COUNT"
             | "STDDEV"
             | "VARIANCE"
@@ -8255,7 +8573,7 @@ export interface D2ValidationRuleSchema {
             | "NONE"
             | "CUSTOM"
             | "DEFAULT";
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         description: string;
@@ -8377,7 +8695,7 @@ export interface D2ValidationRuleGroupSchema {
     model: D2ValidationRuleGroup;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         description: string;
@@ -8443,7 +8761,7 @@ export interface D2ValidationNotificationTemplateSchema {
     model: D2ValidationNotificationTemplate;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         displayName: string;
@@ -8516,6 +8834,8 @@ export interface D2TrackedEntityAttributeSchema {
             | "AVERAGE_SUM_ORG_UNIT"
             | "LAST"
             | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
             | "COUNT"
             | "STDDEV"
             | "VARIANCE"
@@ -8524,7 +8844,7 @@ export interface D2TrackedEntityAttributeSchema {
             | "NONE"
             | "CUSTOM"
             | "DEFAULT";
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         confidential: boolean;
         created: string;
@@ -8570,7 +8890,6 @@ export interface D2TrackedEntityAttributeSchema {
         optionSetValue: boolean;
         orgunitScope: boolean;
         pattern: string;
-        programScope: boolean;
         publicAccess: string;
         shortName: string;
         skipSynchronization: boolean;
@@ -8615,76 +8934,74 @@ export interface D2TrackedEntityAttributeSchema {
         $nameable: Preset<D2TrackedEntityAttribute, FieldPresets["nameable"]>;
         $persisted: Preset<
             D2TrackedEntityAttribute,
-            | "programScope"
-            | "publicAccess"
-            | "lastUpdated"
-            | "generated"
-            | "translations"
-            | "valueType"
-            | "id"
-            | "confidential"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "unique"
-            | "userAccesses"
-            | "name"
-            | "legendSets"
-            | "style"
-            | "shortName"
             | "aggregationType"
             | "code"
             | "displayInListNoProgram"
+            | "publicAccess"
             | "pattern"
             | "description"
             | "skipSynchronization"
             | "sortOrderInListNoProgram"
+            | "lastUpdated"
             | "optionSet"
+            | "generated"
             | "displayOnVisitSchedule"
+            | "translations"
+            | "valueType"
             | "formName"
             | "sortOrderInVisitSchedule"
+            | "id"
             | "orgunitScope"
+            | "confidential"
             | "fieldMask"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
             | "expression"
+            | "created"
+            | "attributeValues"
+            | "unique"
+            | "userAccesses"
             | "inherit"
+            | "name"
+            | "legendSets"
+            | "style"
+            | "shortName"
             | "user"
         >;
         $owner: Preset<
             D2TrackedEntityAttribute,
-            | "programScope"
-            | "publicAccess"
-            | "lastUpdated"
-            | "generated"
-            | "translations"
-            | "valueType"
-            | "id"
-            | "confidential"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "unique"
-            | "userAccesses"
-            | "name"
-            | "legendSets"
-            | "style"
-            | "shortName"
             | "aggregationType"
             | "code"
             | "displayInListNoProgram"
+            | "publicAccess"
             | "pattern"
             | "description"
             | "skipSynchronization"
             | "sortOrderInListNoProgram"
+            | "lastUpdated"
             | "optionSet"
+            | "generated"
             | "displayOnVisitSchedule"
+            | "translations"
+            | "valueType"
             | "formName"
             | "sortOrderInVisitSchedule"
+            | "id"
             | "orgunitScope"
+            | "confidential"
             | "fieldMask"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
             | "expression"
+            | "created"
+            | "attributeValues"
+            | "unique"
+            | "userAccesses"
             | "inherit"
+            | "name"
+            | "legendSets"
+            | "style"
+            | "shortName"
             | "user"
         >;
     };
@@ -8696,7 +9013,7 @@ export interface D2TrackedEntityTypeSchema {
     fields: {
         access: D2Access;
         allowAuditLog: boolean;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         description: string;
@@ -8783,7 +9100,7 @@ export interface D2TrackedEntityTypeAttributeSchema {
     model: D2TrackedEntityTypeAttribute;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         displayInList: boolean;
@@ -8871,7 +9188,7 @@ export interface D2ProgramTrackedEntityAttributeGroupSchema {
     model: D2ProgramTrackedEntityAttributeGroup;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         attributes: D2ProgramTrackedEntityAttributeSchema[];
         code: Id;
         created: string;
@@ -8934,12 +9251,90 @@ export interface D2ProgramTrackedEntityAttributeGroupSchema {
     };
 }
 
+export interface D2ProgramStageSectionSchema {
+    name: "D2ProgramStageSection";
+    model: D2ProgramStageSection;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        dataElements: D2DataElementSchema[];
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        programIndicators: D2ProgramIndicatorSchema[];
+        programStage: D2ProgramStageSchema;
+        publicAccess: string;
+        renderType: any;
+        shortName: string;
+        sortOrder: number;
+        style: D2Style;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramStageSection, keyof D2ProgramStageSection>;
+        $identifiable: Preset<D2ProgramStageSection, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramStageSection, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramStageSection,
+            | "code"
+            | "description"
+            | "programIndicators"
+            | "lastUpdated"
+            | "translations"
+            | "formName"
+            | "id"
+            | "renderType"
+            | "dataElements"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "sortOrder"
+            | "name"
+            | "style"
+        >;
+        $owner: Preset<
+            D2ProgramStageSection,
+            | "code"
+            | "description"
+            | "programIndicators"
+            | "lastUpdated"
+            | "translations"
+            | "formName"
+            | "id"
+            | "renderType"
+            | "dataElements"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "sortOrder"
+            | "name"
+            | "style"
+        >;
+    };
+}
+
 export interface D2ProgramNotificationTemplateSchema {
     name: "D2ProgramNotificationTemplate";
     model: D2ProgramNotificationTemplate;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         deliveryChannels: never[];
@@ -9027,90 +9422,12 @@ export interface D2ProgramNotificationTemplateSchema {
     };
 }
 
-export interface D2ProgramStageSectionSchema {
-    name: "D2ProgramStageSection";
-    model: D2ProgramStageSection;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        dataElements: D2DataElementSchema[];
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        programIndicators: D2ProgramIndicatorSchema[];
-        programStage: D2ProgramStageSchema;
-        publicAccess: string;
-        renderType: any;
-        shortName: string;
-        sortOrder: number;
-        style: D2Style;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramStageSection, keyof D2ProgramStageSection>;
-        $identifiable: Preset<D2ProgramStageSection, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramStageSection, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramStageSection,
-            | "code"
-            | "description"
-            | "programIndicators"
-            | "lastUpdated"
-            | "translations"
-            | "formName"
-            | "id"
-            | "renderType"
-            | "dataElements"
-            | "lastUpdatedBy"
-            | "programStage"
-            | "created"
-            | "sortOrder"
-            | "name"
-            | "style"
-        >;
-        $owner: Preset<
-            D2ProgramStageSection,
-            | "code"
-            | "description"
-            | "programIndicators"
-            | "lastUpdated"
-            | "translations"
-            | "formName"
-            | "id"
-            | "renderType"
-            | "dataElements"
-            | "lastUpdatedBy"
-            | "programStage"
-            | "created"
-            | "sortOrder"
-            | "name"
-            | "style"
-        >;
-    };
-}
-
 export interface D2SMSCommandSchema {
     name: "D2SMSCommand";
     model: D2SMSCommand;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         codeValueSeparator: string;
         completenessMethod: "ALL_DATAVALUE" | "AT_LEAST_ONE_DATAVALUE" | "DO_NOT_MARK_COMPLETE";
@@ -9213,7 +9530,7 @@ export interface D2ProgramStageSchema {
     fields: {
         access: D2Access;
         allowGenerateNextVisit: boolean;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         autoGenerateEvent: boolean;
         blockEntryForm: boolean;
         code: Id;
@@ -9242,6 +9559,7 @@ export interface D2ProgramStageSchema {
         lastUpdatedBy: D2UserSchema;
         minDaysFromStart: number;
         name: string;
+        nextScheduleDate: D2DataElementSchema;
         notificationTemplates: D2ProgramNotificationTemplateSchema[];
         openAfterEnrollment: boolean;
         periodType: string;
@@ -9303,6 +9621,7 @@ export interface D2ProgramStageSchema {
             | "featureType"
             | "remindCompleted"
             | "displayGenerateEventBox"
+            | "nextScheduleDate"
             | "validationStrategy"
             | "autoGenerateEvent"
             | "periodType"
@@ -9346,6 +9665,7 @@ export interface D2ProgramStageSchema {
             | "featureType"
             | "remindCompleted"
             | "displayGenerateEventBox"
+            | "nextScheduleDate"
             | "validationStrategy"
             | "autoGenerateEvent"
             | "periodType"
@@ -9362,7 +9682,7 @@ export interface D2ProgramSchema {
     fields: {
         access: D2Access;
         accessLevel: "OPEN" | "AUDITED" | "PROTECTED" | "CLOSED";
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         categoryCombo: D2CategoryComboSchema;
         code: Id;
         completeEventsExpiryDays: number;
@@ -9523,6 +9843,254 @@ export interface D2ProgramSchema {
     };
 }
 
+export interface D2EventReportSchema {
+    name: "D2EventReport";
+    model: D2EventReport;
+    fields: {
+        access: D2Access;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        attributeDimensions: any[];
+        attributeValueDimension: D2TrackedEntityAttributeSchema;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        categoryDimensions: D2CategoryDimensionSchema[];
+        categoryOptionGroupSetDimensions: D2CategoryOptionGroupSetDimensionSchema[];
+        code: Id;
+        colSubTotals: boolean;
+        colTotals: boolean;
+        collapseDataDimensions: boolean;
+        columnDimensions: string[];
+        columns: any[];
+        completedOnly: boolean;
+        created: string;
+        dataDimensionItems: any[];
+        dataElementDimensions: D2TrackedEntityDataElementDimensionSchema[];
+        dataElementGroupSetDimensions: D2DataElementGroupSetDimensionSchema[];
+        dataElementValueDimension: D2DataElementSchema;
+        dataType: "AGGREGATED_VALUES" | "EVENTS";
+        description: string;
+        digitGroupSeparator: "COMMA" | "SPACE" | "NONE";
+        displayDensity: "COMFORTABLE" | "NORMAL" | "COMPACT" | "NONE";
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        endDate: string;
+        eventStatus: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        filterDimensions: string[];
+        filters: any[];
+        fontSize: "LARGE" | "NORMAL" | "SMALL";
+        formName: string;
+        hideEmptyRows: boolean;
+        hideNaData: boolean;
+        hideSubtitle: boolean;
+        hideTitle: boolean;
+        href: string;
+        id: Id;
+        interpretations: D2InterpretationSchema[];
+        itemOrganisationUnitGroups: D2OrganisationUnitGroupSchema[];
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        orgUnitField: string;
+        organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimensionSchema[];
+        organisationUnitLevels: number[];
+        organisationUnits: D2OrganisationUnitSchema[];
+        outputType: "EVENT" | "ENROLLMENT" | "TRACKED_ENTITY_INSTANCE";
+        parentGraphMap: D2MapSchema;
+        periods: any[];
+        program: D2ProgramSchema;
+        programIndicatorDimensions: D2TrackedEntityProgramIndicatorDimensionSchema[];
+        programStage: D2ProgramStageSchema;
+        programStatus: "ACTIVE" | "COMPLETED" | "CANCELLED";
+        publicAccess: string;
+        relativePeriods: any;
+        rowDimensions: string[];
+        rowSubTotals: boolean;
+        rowTotals: boolean;
+        rows: any[];
+        shortName: string;
+        showDimensionLabels: boolean;
+        showHierarchy: boolean;
+        sortOrder: number;
+        startDate: string;
+        subscribed: boolean;
+        subscribers: string[];
+        subtitle: string;
+        timeField: string;
+        title: string;
+        topLimit: number;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        userOrgUnitType: "DATA_CAPTURE" | "DATA_OUTPUT" | "TEI_SEARCH";
+        userOrganisationUnit: boolean;
+        userOrganisationUnitChildren: boolean;
+        userOrganisationUnitGrandChildren: boolean;
+        value: any;
+    };
+    fieldPresets: {
+        $all: Preset<D2EventReport, keyof D2EventReport>;
+        $identifiable: Preset<D2EventReport, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2EventReport, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2EventReport,
+            | "orgUnitField"
+            | "endDate"
+            | "publicAccess"
+            | "userOrganisationUnitChildren"
+            | "program"
+            | "lastUpdated"
+            | "hideEmptyRows"
+            | "attributeDimensions"
+            | "translations"
+            | "userOrganisationUnit"
+            | "filterDimensions"
+            | "id"
+            | "rowSubTotals"
+            | "hideNaData"
+            | "interpretations"
+            | "itemOrganisationUnitGroups"
+            | "displayDensity"
+            | "attributeValueDimension"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "programIndicatorDimensions"
+            | "created"
+            | "subscribers"
+            | "dataType"
+            | "columnDimensions"
+            | "completedOnly"
+            | "colTotals"
+            | "showDimensionLabels"
+            | "subtitle"
+            | "sortOrder"
+            | "userAccesses"
+            | "name"
+            | "fontSize"
+            | "topLimit"
+            | "startDate"
+            | "collapseDataDimensions"
+            | "programStatus"
+            | "favorites"
+            | "aggregationType"
+            | "code"
+            | "categoryOptionGroupSetDimensions"
+            | "userOrganisationUnitGrandChildren"
+            | "hideSubtitle"
+            | "outputType"
+            | "description"
+            | "organisationUnitGroupSetDimensions"
+            | "title"
+            | "organisationUnitLevels"
+            | "externalAccess"
+            | "colSubTotals"
+            | "dataElementValueDimension"
+            | "relativePeriods"
+            | "dataElementDimensions"
+            | "periods"
+            | "organisationUnits"
+            | "categoryDimensions"
+            | "showHierarchy"
+            | "programStage"
+            | "rowTotals"
+            | "timeField"
+            | "digitGroupSeparator"
+            | "hideTitle"
+            | "rowDimensions"
+            | "eventStatus"
+            | "userOrgUnitType"
+            | "user"
+        >;
+        $owner: Preset<
+            D2EventReport,
+            | "orgUnitField"
+            | "endDate"
+            | "publicAccess"
+            | "userOrganisationUnitChildren"
+            | "program"
+            | "lastUpdated"
+            | "hideEmptyRows"
+            | "attributeDimensions"
+            | "translations"
+            | "userOrganisationUnit"
+            | "filterDimensions"
+            | "id"
+            | "rowSubTotals"
+            | "hideNaData"
+            | "itemOrganisationUnitGroups"
+            | "displayDensity"
+            | "attributeValueDimension"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "programIndicatorDimensions"
+            | "created"
+            | "subscribers"
+            | "dataType"
+            | "columnDimensions"
+            | "completedOnly"
+            | "colTotals"
+            | "showDimensionLabels"
+            | "subtitle"
+            | "sortOrder"
+            | "userAccesses"
+            | "name"
+            | "fontSize"
+            | "topLimit"
+            | "startDate"
+            | "collapseDataDimensions"
+            | "programStatus"
+            | "favorites"
+            | "aggregationType"
+            | "code"
+            | "categoryOptionGroupSetDimensions"
+            | "userOrganisationUnitGrandChildren"
+            | "hideSubtitle"
+            | "outputType"
+            | "description"
+            | "organisationUnitGroupSetDimensions"
+            | "title"
+            | "organisationUnitLevels"
+            | "externalAccess"
+            | "colSubTotals"
+            | "dataElementValueDimension"
+            | "relativePeriods"
+            | "dataElementDimensions"
+            | "periods"
+            | "organisationUnits"
+            | "categoryDimensions"
+            | "showHierarchy"
+            | "programStage"
+            | "rowTotals"
+            | "timeField"
+            | "digitGroupSeparator"
+            | "hideTitle"
+            | "rowDimensions"
+            | "eventStatus"
+            | "userOrgUnitType"
+            | "user"
+        >;
+    };
+}
+
 export interface D2EventChartSchema {
     name: "D2EventChart";
     model: D2EventChart;
@@ -9534,6 +10102,8 @@ export interface D2EventChartSchema {
             | "AVERAGE_SUM_ORG_UNIT"
             | "LAST"
             | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
             | "COUNT"
             | "STDDEV"
             | "VARIANCE"
@@ -9544,7 +10114,7 @@ export interface D2EventChartSchema {
             | "DEFAULT";
         attributeDimensions: any[];
         attributeValueDimension: D2TrackedEntityAttributeSchema;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         baseLineLabel: string;
         baseLineValue: number;
         categoryDimensions: D2CategoryDimensionSchema[];
@@ -9642,10 +10212,12 @@ export interface D2EventChartSchema {
             | "RADAR"
             | "GAUGE"
             | "YEAR_OVER_YEAR_LINE"
-            | "YEAR_OVER_YEAR_COLUMN";
+            | "YEAR_OVER_YEAR_COLUMN"
+            | "SINGLE_VALUE";
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
+        userOrgUnitType: "DATA_CAPTURE" | "DATA_OUTPUT" | "TEI_SEARCH";
         userOrganisationUnit: boolean;
         userOrganisationUnitChildren: boolean;
         userOrganisationUnitGrandChildren: boolean;
@@ -9727,6 +10299,7 @@ export interface D2EventChartSchema {
             | "timeField"
             | "targetLineValue"
             | "baseLineLabel"
+            | "userOrgUnitType"
             | "rangeAxisMaxValue"
             | "user"
         >;
@@ -9800,250 +10373,8 @@ export interface D2EventChartSchema {
             | "timeField"
             | "targetLineValue"
             | "baseLineLabel"
+            | "userOrgUnitType"
             | "rangeAxisMaxValue"
-            | "user"
-        >;
-    };
-}
-
-export interface D2EventReportSchema {
-    name: "D2EventReport";
-    model: D2EventReport;
-    fields: {
-        access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
-        attributeDimensions: any[];
-        attributeValueDimension: D2TrackedEntityAttributeSchema;
-        attributeValues: D2AttributeValueSchema[];
-        categoryDimensions: D2CategoryDimensionSchema[];
-        categoryOptionGroupSetDimensions: D2CategoryOptionGroupSetDimensionSchema[];
-        code: Id;
-        colSubTotals: boolean;
-        colTotals: boolean;
-        collapseDataDimensions: boolean;
-        columnDimensions: string[];
-        columns: any[];
-        completedOnly: boolean;
-        created: string;
-        dataDimensionItems: any[];
-        dataElementDimensions: D2TrackedEntityDataElementDimensionSchema[];
-        dataElementGroupSetDimensions: D2DataElementGroupSetDimensionSchema[];
-        dataElementValueDimension: D2DataElementSchema;
-        dataType: "AGGREGATED_VALUES" | "EVENTS";
-        description: string;
-        digitGroupSeparator: "COMMA" | "SPACE" | "NONE";
-        displayDensity: "COMFORTABLE" | "NORMAL" | "COMPACT" | "NONE";
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        endDate: string;
-        eventStatus: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        filterDimensions: string[];
-        filters: any[];
-        fontSize: "LARGE" | "NORMAL" | "SMALL";
-        formName: string;
-        hideEmptyRows: boolean;
-        hideNaData: boolean;
-        hideSubtitle: boolean;
-        hideTitle: boolean;
-        href: string;
-        id: Id;
-        interpretations: D2InterpretationSchema[];
-        itemOrganisationUnitGroups: D2OrganisationUnitGroupSchema[];
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        orgUnitField: string;
-        organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimensionSchema[];
-        organisationUnitLevels: number[];
-        organisationUnits: D2OrganisationUnitSchema[];
-        outputType: "EVENT" | "ENROLLMENT" | "TRACKED_ENTITY_INSTANCE";
-        parentGraphMap: D2MapSchema;
-        periods: any[];
-        program: D2ProgramSchema;
-        programIndicatorDimensions: D2TrackedEntityProgramIndicatorDimensionSchema[];
-        programStage: D2ProgramStageSchema;
-        programStatus: "ACTIVE" | "COMPLETED" | "CANCELLED";
-        publicAccess: string;
-        relativePeriods: any;
-        rowDimensions: string[];
-        rowSubTotals: boolean;
-        rowTotals: boolean;
-        rows: any[];
-        shortName: string;
-        showDimensionLabels: boolean;
-        showHierarchy: boolean;
-        sortOrder: number;
-        startDate: string;
-        subscribed: boolean;
-        subscribers: string[];
-        subtitle: string;
-        timeField: string;
-        title: string;
-        topLimit: number;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        userOrganisationUnit: boolean;
-        userOrganisationUnitChildren: boolean;
-        userOrganisationUnitGrandChildren: boolean;
-        value: any;
-    };
-    fieldPresets: {
-        $all: Preset<D2EventReport, keyof D2EventReport>;
-        $identifiable: Preset<D2EventReport, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2EventReport, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2EventReport,
-            | "orgUnitField"
-            | "endDate"
-            | "publicAccess"
-            | "userOrganisationUnitChildren"
-            | "program"
-            | "lastUpdated"
-            | "hideEmptyRows"
-            | "attributeDimensions"
-            | "translations"
-            | "userOrganisationUnit"
-            | "filterDimensions"
-            | "id"
-            | "rowSubTotals"
-            | "hideNaData"
-            | "interpretations"
-            | "itemOrganisationUnitGroups"
-            | "displayDensity"
-            | "attributeValueDimension"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "programIndicatorDimensions"
-            | "created"
-            | "subscribers"
-            | "dataType"
-            | "columnDimensions"
-            | "completedOnly"
-            | "colTotals"
-            | "showDimensionLabels"
-            | "subtitle"
-            | "sortOrder"
-            | "userAccesses"
-            | "name"
-            | "fontSize"
-            | "topLimit"
-            | "startDate"
-            | "collapseDataDimensions"
-            | "programStatus"
-            | "favorites"
-            | "aggregationType"
-            | "code"
-            | "categoryOptionGroupSetDimensions"
-            | "userOrganisationUnitGrandChildren"
-            | "hideSubtitle"
-            | "outputType"
-            | "description"
-            | "organisationUnitGroupSetDimensions"
-            | "title"
-            | "organisationUnitLevels"
-            | "externalAccess"
-            | "colSubTotals"
-            | "dataElementValueDimension"
-            | "relativePeriods"
-            | "dataElementDimensions"
-            | "periods"
-            | "organisationUnits"
-            | "categoryDimensions"
-            | "showHierarchy"
-            | "programStage"
-            | "rowTotals"
-            | "timeField"
-            | "digitGroupSeparator"
-            | "hideTitle"
-            | "rowDimensions"
-            | "eventStatus"
-            | "user"
-        >;
-        $owner: Preset<
-            D2EventReport,
-            | "orgUnitField"
-            | "endDate"
-            | "publicAccess"
-            | "userOrganisationUnitChildren"
-            | "program"
-            | "lastUpdated"
-            | "hideEmptyRows"
-            | "attributeDimensions"
-            | "translations"
-            | "userOrganisationUnit"
-            | "filterDimensions"
-            | "id"
-            | "rowSubTotals"
-            | "hideNaData"
-            | "itemOrganisationUnitGroups"
-            | "displayDensity"
-            | "attributeValueDimension"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "programIndicatorDimensions"
-            | "created"
-            | "subscribers"
-            | "dataType"
-            | "columnDimensions"
-            | "completedOnly"
-            | "colTotals"
-            | "showDimensionLabels"
-            | "subtitle"
-            | "sortOrder"
-            | "userAccesses"
-            | "name"
-            | "fontSize"
-            | "topLimit"
-            | "startDate"
-            | "collapseDataDimensions"
-            | "programStatus"
-            | "favorites"
-            | "aggregationType"
-            | "code"
-            | "categoryOptionGroupSetDimensions"
-            | "userOrganisationUnitGrandChildren"
-            | "hideSubtitle"
-            | "outputType"
-            | "description"
-            | "organisationUnitGroupSetDimensions"
-            | "title"
-            | "organisationUnitLevels"
-            | "externalAccess"
-            | "colSubTotals"
-            | "dataElementValueDimension"
-            | "relativePeriods"
-            | "dataElementDimensions"
-            | "periods"
-            | "organisationUnits"
-            | "categoryDimensions"
-            | "showHierarchy"
-            | "programStage"
-            | "rowTotals"
-            | "timeField"
-            | "digitGroupSeparator"
-            | "hideTitle"
-            | "rowDimensions"
-            | "eventStatus"
             | "user"
         >;
     };
@@ -10054,7 +10385,7 @@ export interface D2ProgramSectionSchema {
     model: D2ProgramSection;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         description: string;
@@ -10072,12 +10403,12 @@ export interface D2ProgramSectionSchema {
         lastUpdatedBy: D2UserSchema;
         name: string;
         program: D2ProgramSchema;
-        programTrackedEntityAttribute: D2TrackedEntityAttributeSchema[];
         publicAccess: string;
         renderType: any;
         shortName: string;
         sortOrder: number;
         style: D2Style;
+        trackedEntityAttributes: D2TrackedEntityAttributeSchema[];
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
@@ -10092,7 +10423,6 @@ export interface D2ProgramSectionSchema {
             | "code"
             | "description"
             | "program"
-            | "programTrackedEntityAttribute"
             | "lastUpdated"
             | "translations"
             | "formName"
@@ -10102,6 +10432,7 @@ export interface D2ProgramSectionSchema {
             | "created"
             | "sortOrder"
             | "name"
+            | "trackedEntityAttributes"
             | "style"
         >;
         $owner: Preset<
@@ -10109,7 +10440,6 @@ export interface D2ProgramSectionSchema {
             | "code"
             | "description"
             | "program"
-            | "programTrackedEntityAttribute"
             | "lastUpdated"
             | "translations"
             | "formName"
@@ -10119,6 +10449,7 @@ export interface D2ProgramSectionSchema {
             | "created"
             | "sortOrder"
             | "name"
+            | "trackedEntityAttributes"
             | "style"
         >;
     };
@@ -10137,6 +10468,8 @@ export interface D2ProgramIndicatorSchema {
             | "AVERAGE_SUM_ORG_UNIT"
             | "LAST"
             | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
             | "COUNT"
             | "STDDEV"
             | "VARIANCE"
@@ -10147,7 +10480,7 @@ export interface D2ProgramIndicatorSchema {
             | "DEFAULT";
         analyticsPeriodBoundaries: D2AnalyticsPeriodBoundarySchema[];
         analyticsType: "EVENT" | "ENROLLMENT";
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         decimals: number;
@@ -10269,7 +10602,7 @@ export interface D2RelationshipTypeSchema {
     model: D2RelationshipType;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         bidirectional: boolean;
         code: Id;
         created: string;
@@ -10342,12 +10675,76 @@ export interface D2RelationshipTypeSchema {
     };
 }
 
+export interface D2ProgramIndicatorGroupSchema {
+    name: "D2ProgramIndicatorGroup";
+    model: D2ProgramIndicatorGroup;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        description: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        programIndicators: D2ProgramIndicatorSchema[];
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramIndicatorGroup, keyof D2ProgramIndicatorGroup>;
+        $identifiable: Preset<D2ProgramIndicatorGroup, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramIndicatorGroup, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramIndicatorGroup,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "description"
+            | "programIndicators"
+            | "lastUpdated"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+        >;
+        $owner: Preset<
+            D2ProgramIndicatorGroup,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "description"
+            | "programIndicators"
+            | "lastUpdated"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+        >;
+    };
+}
+
 export interface D2ProgramRuleVariableSchema {
     name: "D2ProgramRuleVariable";
     model: D2ProgramRuleVariable;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         dataElement: D2DataElementSchema;
@@ -10414,84 +10811,20 @@ export interface D2ProgramRuleVariableSchema {
     };
 }
 
-export interface D2ProgramIndicatorGroupSchema {
-    name: "D2ProgramIndicatorGroup";
-    model: D2ProgramIndicatorGroup;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        description: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        programIndicators: D2ProgramIndicatorSchema[];
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramIndicatorGroup, keyof D2ProgramIndicatorGroup>;
-        $identifiable: Preset<D2ProgramIndicatorGroup, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramIndicatorGroup, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramIndicatorGroup,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "description"
-            | "programIndicators"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2ProgramIndicatorGroup,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "description"
-            | "programIndicators"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
 export interface D2ProgramRuleActionSchema {
     name: "D2ProgramRuleAction";
     model: D2ProgramRuleAction;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         content: string;
         created: string;
         data: string;
         dataElement: D2DataElementSchema;
         displayName: string;
+        evaluationEnvironments: never[];
+        evaluationTime: "ON_DATA_ENTRY" | "ON_COMPLETE" | "ALWAYS";
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
@@ -10539,6 +10872,7 @@ export interface D2ProgramRuleActionSchema {
         $nameable: Preset<D2ProgramRuleAction, FieldPresets["nameable"]>;
         $persisted: Preset<
             D2ProgramRuleAction,
+            | "evaluationEnvironments"
             | "code"
             | "data"
             | "optionGroup"
@@ -10555,11 +10889,13 @@ export interface D2ProgramRuleActionSchema {
             | "programStage"
             | "created"
             | "dataElement"
+            | "evaluationTime"
             | "location"
             | "option"
         >;
         $owner: Preset<
             D2ProgramRuleAction,
+            | "evaluationEnvironments"
             | "code"
             | "data"
             | "optionGroup"
@@ -10576,6 +10912,7 @@ export interface D2ProgramRuleActionSchema {
             | "programStage"
             | "created"
             | "dataElement"
+            | "evaluationTime"
             | "location"
             | "option"
         >;
@@ -10587,7 +10924,7 @@ export interface D2ProgramRuleSchema {
     model: D2ProgramRule;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         condition: string;
         created: string;
@@ -10661,6 +10998,8 @@ export interface D2MapViewSchema {
             | "AVERAGE_SUM_ORG_UNIT"
             | "LAST"
             | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
             | "COUNT"
             | "STDDEV"
             | "VARIANCE"
@@ -10671,7 +11010,7 @@ export interface D2MapViewSchema {
             | "DEFAULT";
         areaRadius: number;
         attributeDimensions: any[];
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         categoryDimensions: D2CategoryDimensionSchema[];
         categoryOptionGroupSetDimensions: D2CategoryOptionGroupSetDimensionSchema[];
         classes: number;
@@ -10748,6 +11087,7 @@ export interface D2MapViewSchema {
         radiusHigh: number;
         radiusLow: number;
         relativePeriods: any;
+        renderingStrategy: "SINGLE" | "SPLIT_BY_PERIOD" | "TIMELINE";
         rows: any[];
         shortName: string;
         sortOrder: number;
@@ -10764,6 +11104,7 @@ export interface D2MapViewSchema {
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
+        userOrgUnitType: "DATA_CAPTURE" | "DATA_OUTPUT" | "TEI_SEARCH";
         userOrganisationUnit: boolean;
         userOrganisationUnitChildren: boolean;
         userOrganisationUnitGrandChildren: boolean;
@@ -10776,7 +11117,6 @@ export interface D2MapViewSchema {
             D2MapView,
             | "endDate"
             | "userOrganisationUnitChildren"
-            | "colorScale"
             | "program"
             | "lastUpdated"
             | "attributeDimensions"
@@ -10786,56 +11126,58 @@ export interface D2MapViewSchema {
             | "filterDimensions"
             | "id"
             | "organisationUnitSelectionMode"
+            | "method"
+            | "renderingStrategy"
+            | "labels"
+            | "startDate"
+            | "userOrganisationUnitGrandChildren"
+            | "styleDataItem"
+            | "labelFontColor"
+            | "layer"
+            | "dataElementDimensions"
+            | "periods"
+            | "categoryDimensions"
+            | "labelFontStyle"
+            | "radiusHigh"
+            | "eventClustering"
+            | "colorLow"
+            | "opacity"
+            | "config"
+            | "colorScale"
             | "itemOrganisationUnitGroups"
             | "lastUpdatedBy"
-            | "method"
             | "labelFontSize"
             | "created"
             | "colorHigh"
             | "columnDimensions"
             | "eventPointRadius"
             | "areaRadius"
-            | "labels"
-            | "startDate"
             | "programStatus"
             | "dataDimensionItems"
             | "aggregationType"
             | "code"
             | "categoryOptionGroupSetDimensions"
-            | "userOrganisationUnitGrandChildren"
             | "hidden"
             | "classes"
-            | "styleDataItem"
             | "description"
-            | "labelFontColor"
             | "organisationUnitGroupSetDimensions"
-            | "layer"
             | "organisationUnitLevels"
             | "organisationUnitGroupSet"
             | "followUp"
             | "relativePeriods"
-            | "dataElementDimensions"
-            | "periods"
             | "organisationUnits"
-            | "categoryDimensions"
             | "eventPointColor"
-            | "labelFontStyle"
             | "programStage"
             | "labelFontWeight"
             | "radiusLow"
-            | "radiusHigh"
-            | "eventClustering"
-            | "colorLow"
             | "trackedEntityType"
             | "legendSet"
-            | "opacity"
-            | "config"
+            | "userOrgUnitType"
         >;
         $owner: Preset<
             D2MapView,
             | "endDate"
             | "userOrganisationUnitChildren"
-            | "colorScale"
             | "program"
             | "lastUpdated"
             | "attributeDimensions"
@@ -10845,50 +11187,309 @@ export interface D2MapViewSchema {
             | "filterDimensions"
             | "id"
             | "organisationUnitSelectionMode"
+            | "method"
+            | "renderingStrategy"
+            | "labels"
+            | "startDate"
+            | "userOrganisationUnitGrandChildren"
+            | "styleDataItem"
+            | "labelFontColor"
+            | "layer"
+            | "dataElementDimensions"
+            | "periods"
+            | "categoryDimensions"
+            | "labelFontStyle"
+            | "radiusHigh"
+            | "eventClustering"
+            | "colorLow"
+            | "opacity"
+            | "config"
+            | "colorScale"
             | "itemOrganisationUnitGroups"
             | "lastUpdatedBy"
-            | "method"
             | "labelFontSize"
             | "created"
             | "colorHigh"
             | "columnDimensions"
             | "eventPointRadius"
             | "areaRadius"
-            | "labels"
-            | "startDate"
             | "programStatus"
             | "dataDimensionItems"
             | "aggregationType"
             | "code"
             | "categoryOptionGroupSetDimensions"
-            | "userOrganisationUnitGrandChildren"
             | "hidden"
             | "classes"
-            | "styleDataItem"
             | "description"
-            | "labelFontColor"
             | "organisationUnitGroupSetDimensions"
-            | "layer"
             | "organisationUnitLevels"
             | "organisationUnitGroupSet"
             | "followUp"
             | "relativePeriods"
-            | "dataElementDimensions"
-            | "periods"
             | "organisationUnits"
-            | "categoryDimensions"
             | "eventPointColor"
-            | "labelFontStyle"
             | "programStage"
             | "labelFontWeight"
             | "radiusLow"
-            | "radiusHigh"
-            | "eventClustering"
-            | "colorLow"
             | "trackedEntityType"
             | "legendSet"
-            | "opacity"
-            | "config"
+            | "userOrgUnitType"
+        >;
+    };
+}
+
+export interface D2ReportSchema {
+    name: "D2Report";
+    model: D2Report;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        cacheStrategy:
+            | "NO_CACHE"
+            | "CACHE_1_MINUTE"
+            | "CACHE_5_MINUTES"
+            | "CACHE_10_MINUTES"
+            | "CACHE_15_MINUTES"
+            | "CACHE_30_MINUTES"
+            | "CACHE_1_HOUR"
+            | "CACHE_6AM_TOMORROW"
+            | "CACHE_TWO_WEEKS"
+            | "RESPECT_SYSTEM_SETTING";
+        code: Id;
+        created: string;
+        designContent: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        relativePeriods: any;
+        reportParams: any;
+        translations: D2Translation[];
+        type: "JASPER_REPORT_TABLE" | "JASPER_JDBC" | "HTML";
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        visualization: D2VisualizationSchema;
+    };
+    fieldPresets: {
+        $all: Preset<D2Report, keyof D2Report>;
+        $identifiable: Preset<D2Report, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Report, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Report,
+            | "designContent"
+            | "visualization"
+            | "code"
+            | "publicAccess"
+            | "type"
+            | "externalAccess"
+            | "lastUpdated"
+            | "relativePeriods"
+            | "reportParams"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "userAccesses"
+            | "name"
+            | "cacheStrategy"
+            | "user"
+        >;
+        $owner: Preset<
+            D2Report,
+            | "designContent"
+            | "visualization"
+            | "code"
+            | "publicAccess"
+            | "type"
+            | "externalAccess"
+            | "lastUpdated"
+            | "relativePeriods"
+            | "reportParams"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "userAccesses"
+            | "name"
+            | "cacheStrategy"
+            | "user"
+        >;
+    };
+}
+
+export interface D2MapSchema {
+    name: "D2Map";
+    model: D2Map;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        basemap: string;
+        code: Id;
+        created: string;
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        interpretations: D2InterpretationSchema[];
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        latitude: number;
+        longitude: number;
+        mapViews: D2MapViewSchema[];
+        name: string;
+        publicAccess: string;
+        shortName: string;
+        subscribed: boolean;
+        subscribers: string[];
+        title: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        zoom: number;
+    };
+    fieldPresets: {
+        $all: Preset<D2Map, keyof D2Map>;
+        $identifiable: Preset<D2Map, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Map, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Map,
+            | "favorites"
+            | "code"
+            | "publicAccess"
+            | "basemap"
+            | "latitude"
+            | "description"
+            | "title"
+            | "externalAccess"
+            | "lastUpdated"
+            | "translations"
+            | "mapViews"
+            | "id"
+            | "interpretations"
+            | "longitude"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "subscribers"
+            | "created"
+            | "zoom"
+            | "userAccesses"
+            | "name"
+            | "user"
+        >;
+        $owner: Preset<
+            D2Map,
+            | "favorites"
+            | "code"
+            | "publicAccess"
+            | "basemap"
+            | "latitude"
+            | "description"
+            | "title"
+            | "externalAccess"
+            | "lastUpdated"
+            | "translations"
+            | "mapViews"
+            | "id"
+            | "longitude"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "subscribers"
+            | "created"
+            | "zoom"
+            | "userAccesses"
+            | "name"
+            | "user"
+        >;
+    };
+}
+
+export interface D2DocumentSchema {
+    name: "D2Document";
+    model: D2Document;
+    fields: {
+        access: D2Access;
+        attachment: boolean;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        contentType: string;
+        created: string;
+        displayName: string;
+        external: boolean;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        translations: D2Translation[];
+        url: string;
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2Document, keyof D2Document>;
+        $identifiable: Preset<D2Document, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Document, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Document,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "attributeValues"
+            | "url"
+            | "externalAccess"
+            | "lastUpdated"
+            | "external"
+            | "attachment"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+            | "contentType"
+        >;
+        $owner: Preset<
+            D2Document,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "attributeValues"
+            | "url"
+            | "externalAccess"
+            | "lastUpdated"
+            | "external"
+            | "attachment"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+            | "contentType"
         >;
     };
 }
@@ -10898,7 +11499,7 @@ export interface D2ExternalMapLayerSchema {
     model: D2ExternalMapLayer;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         attribution: string;
         code: Id;
         created: string;
@@ -10973,6 +11574,118 @@ export interface D2ExternalMapLayerSchema {
     };
 }
 
+export interface D2ReportTableSchema {
+    name: "D2ReportTable";
+    model: D2ReportTable;
+    fields: {
+        access: D2Access;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        attributeDimensions: any[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        categoryDimensions: D2CategoryDimensionSchema[];
+        categoryOptionGroupSetDimensions: D2CategoryOptionGroupSetDimensionSchema[];
+        code: Id;
+        colSubTotals: boolean;
+        colTotals: boolean;
+        columnDimensions: string[];
+        columns: any[];
+        completedOnly: boolean;
+        created: string;
+        cumulative: boolean;
+        dataDimensionItems: any[];
+        dataElementDimensions: D2TrackedEntityDataElementDimensionSchema[];
+        dataElementGroupSetDimensions: D2DataElementGroupSetDimensionSchema[];
+        description: string;
+        digitGroupSeparator: "COMMA" | "SPACE" | "NONE";
+        displayDensity: "COMFORTABLE" | "NORMAL" | "COMPACT" | "NONE";
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        endDate: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        filterDimensions: string[];
+        filters: any[];
+        fontSize: "LARGE" | "NORMAL" | "SMALL";
+        formName: string;
+        hideEmptyColumns: boolean;
+        hideEmptyRows: boolean;
+        hideSubtitle: boolean;
+        hideTitle: boolean;
+        href: string;
+        id: Id;
+        interpretations: D2InterpretationSchema[];
+        itemOrganisationUnitGroups: D2OrganisationUnitGroupSchema[];
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendDisplayStrategy: "FIXED" | "BY_DATA_ITEM";
+        legendDisplayStyle: "FILL" | "TEXT";
+        legendSet: D2LegendSetSchema;
+        measureCriteria: string;
+        name: string;
+        numberType: "VALUE" | "ROW_PERCENTAGE" | "COLUMN_PERCENTAGE";
+        orgUnitField: string;
+        organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimensionSchema[];
+        organisationUnitLevels: number[];
+        organisationUnits: D2OrganisationUnitSchema[];
+        parentGraphMap: D2MapSchema;
+        periods: any[];
+        programIndicatorDimensions: D2TrackedEntityProgramIndicatorDimensionSchema[];
+        publicAccess: string;
+        regression: boolean;
+        relativePeriods: any;
+        reportParams: any;
+        rowDimensions: string[];
+        rowSubTotals: boolean;
+        rowTotals: boolean;
+        rows: any[];
+        shortName: string;
+        showDimensionLabels: boolean;
+        showHierarchy: boolean;
+        skipRounding: boolean;
+        sortOrder: number;
+        startDate: string;
+        subscribed: boolean;
+        subscribers: string[];
+        subtitle: string;
+        timeField: string;
+        title: string;
+        topLimit: number;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        userOrgUnitType: "DATA_CAPTURE" | "DATA_OUTPUT" | "TEI_SEARCH";
+        userOrganisationUnit: boolean;
+        userOrganisationUnitChildren: boolean;
+        userOrganisationUnitGrandChildren: boolean;
+    };
+    fieldPresets: {
+        $all: Preset<D2ReportTable, keyof D2ReportTable>;
+        $identifiable: Preset<D2ReportTable, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ReportTable, FieldPresets["nameable"]>;
+        $persisted: Preset<D2ReportTable, never>;
+        $owner: Preset<D2ReportTable, never>;
+    };
+}
+
 export interface D2ChartSchema {
     name: "D2Chart";
     model: D2Chart;
@@ -10984,6 +11697,8 @@ export interface D2ChartSchema {
             | "AVERAGE_SUM_ORG_UNIT"
             | "LAST"
             | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
             | "COUNT"
             | "STDDEV"
             | "VARIANCE"
@@ -10993,7 +11708,7 @@ export interface D2ChartSchema {
             | "CUSTOM"
             | "DEFAULT";
         attributeDimensions: any[];
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         baseLineLabel: string;
         baseLineValue: number;
         category: string;
@@ -11084,10 +11799,12 @@ export interface D2ChartSchema {
             | "RADAR"
             | "GAUGE"
             | "YEAR_OVER_YEAR_LINE"
-            | "YEAR_OVER_YEAR_COLUMN";
+            | "YEAR_OVER_YEAR_COLUMN"
+            | "SINGLE_VALUE";
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
+        userOrgUnitType: "DATA_CAPTURE" | "DATA_OUTPUT" | "TEI_SEARCH";
         userOrganisationUnit: boolean;
         userOrganisationUnitChildren: boolean;
         userOrganisationUnitGrandChildren: boolean;
@@ -11097,219 +11814,14 @@ export interface D2ChartSchema {
         $all: Preset<D2Chart, keyof D2Chart>;
         $identifiable: Preset<D2Chart, FieldPresets["identifiable"]>;
         $nameable: Preset<D2Chart, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Chart,
-            | "dataElementGroupSetDimensions"
-            | "showData"
-            | "endDate"
-            | "baseLineValue"
-            | "publicAccess"
-            | "userOrganisationUnitChildren"
-            | "type"
-            | "lastUpdated"
-            | "translations"
-            | "yearlySeries"
-            | "userOrganisationUnit"
-            | "filterDimensions"
-            | "id"
-            | "interpretations"
-            | "itemOrganisationUnitGroups"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "domainAxisLabel"
-            | "created"
-            | "subscribers"
-            | "rangeAxisLabel"
-            | "regressionType"
-            | "completedOnly"
-            | "cumulativeValues"
-            | "subtitle"
-            | "sortOrder"
-            | "userAccesses"
-            | "name"
-            | "rangeAxisDecimals"
-            | "startDate"
-            | "hideEmptyRowItems"
-            | "favorites"
-            | "dataDimensionItems"
-            | "aggregationType"
-            | "code"
-            | "categoryOptionGroupSetDimensions"
-            | "userOrganisationUnitGrandChildren"
-            | "hideSubtitle"
-            | "description"
-            | "organisationUnitGroupSetDimensions"
-            | "title"
-            | "hideLegend"
-            | "organisationUnitLevels"
-            | "externalAccess"
-            | "rangeAxisMinValue"
-            | "percentStackedValues"
-            | "seriesItems"
-            | "legendDisplayStrategy"
-            | "noSpaceBetweenColumns"
-            | "relativePeriods"
-            | "rangeAxisSteps"
-            | "targetLineLabel"
-            | "periods"
-            | "organisationUnits"
-            | "categoryDimensions"
-            | "targetLineValue"
-            | "baseLineLabel"
-            | "hideTitle"
-            | "series"
-            | "legendSet"
-            | "rangeAxisMaxValue"
-            | "colorSet"
-            | "category"
-            | "user"
-        >;
-        $owner: Preset<
-            D2Chart,
-            | "dataElementGroupSetDimensions"
-            | "showData"
-            | "endDate"
-            | "baseLineValue"
-            | "publicAccess"
-            | "userOrganisationUnitChildren"
-            | "type"
-            | "lastUpdated"
-            | "translations"
-            | "yearlySeries"
-            | "userOrganisationUnit"
-            | "filterDimensions"
-            | "id"
-            | "itemOrganisationUnitGroups"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "domainAxisLabel"
-            | "created"
-            | "subscribers"
-            | "rangeAxisLabel"
-            | "regressionType"
-            | "completedOnly"
-            | "cumulativeValues"
-            | "subtitle"
-            | "sortOrder"
-            | "userAccesses"
-            | "name"
-            | "rangeAxisDecimals"
-            | "startDate"
-            | "hideEmptyRowItems"
-            | "favorites"
-            | "dataDimensionItems"
-            | "aggregationType"
-            | "code"
-            | "categoryOptionGroupSetDimensions"
-            | "userOrganisationUnitGrandChildren"
-            | "hideSubtitle"
-            | "description"
-            | "organisationUnitGroupSetDimensions"
-            | "title"
-            | "hideLegend"
-            | "organisationUnitLevels"
-            | "externalAccess"
-            | "rangeAxisMinValue"
-            | "percentStackedValues"
-            | "seriesItems"
-            | "legendDisplayStrategy"
-            | "noSpaceBetweenColumns"
-            | "relativePeriods"
-            | "rangeAxisSteps"
-            | "targetLineLabel"
-            | "periods"
-            | "organisationUnits"
-            | "categoryDimensions"
-            | "targetLineValue"
-            | "baseLineLabel"
-            | "hideTitle"
-            | "series"
-            | "legendSet"
-            | "rangeAxisMaxValue"
-            | "colorSet"
-            | "category"
-            | "user"
-        >;
+        $persisted: Preset<D2Chart, never>;
+        $owner: Preset<D2Chart, never>;
     };
 }
 
-export interface D2DocumentSchema {
-    name: "D2Document";
-    model: D2Document;
-    fields: {
-        access: D2Access;
-        attachment: boolean;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        contentType: string;
-        created: string;
-        displayName: string;
-        external: boolean;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        url: string;
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Document, keyof D2Document>;
-        $identifiable: Preset<D2Document, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Document, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Document,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "url"
-            | "externalAccess"
-            | "lastUpdated"
-            | "external"
-            | "attachment"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-            | "contentType"
-        >;
-        $owner: Preset<
-            D2Document,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "url"
-            | "externalAccess"
-            | "lastUpdated"
-            | "external"
-            | "attachment"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-            | "contentType"
-        >;
-    };
-}
-
-export interface D2ReportTableSchema {
-    name: "D2ReportTable";
-    model: D2ReportTable;
+export interface D2VisualizationSchema {
+    name: "D2Visualization";
+    model: D2Visualization;
     fields: {
         access: D2Access;
         aggregationType:
@@ -11318,6 +11830,8 @@ export interface D2ReportTableSchema {
             | "AVERAGE_SUM_ORG_UNIT"
             | "LAST"
             | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
             | "COUNT"
             | "STDDEV"
             | "VARIANCE"
@@ -11327,17 +11841,20 @@ export interface D2ReportTableSchema {
             | "CUSTOM"
             | "DEFAULT";
         attributeDimensions: any[];
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        baseLineLabel: string;
+        baseLineValue: number;
         categoryDimensions: D2CategoryDimensionSchema[];
         categoryOptionGroupSetDimensions: D2CategoryOptionGroupSetDimensionSchema[];
         code: Id;
         colSubTotals: boolean;
         colTotals: boolean;
+        colorSet: D2ColorSetSchema;
         columnDimensions: string[];
         columns: any[];
         completedOnly: boolean;
         created: string;
-        cumulative: boolean;
+        cumulativeValues: boolean;
         dataDimensionItems: any[];
         dataElementDimensions: D2TrackedEntityDataElementDimensionSchema[];
         dataElementGroupSetDimensions: D2DataElementGroupSetDimensionSchema[];
@@ -11348,6 +11865,7 @@ export interface D2ReportTableSchema {
         displayFormName: string;
         displayName: string;
         displayShortName: string;
+        domainAxisLabel: string;
         endDate: string;
         externalAccess: boolean;
         favorite: boolean;
@@ -11357,7 +11875,14 @@ export interface D2ReportTableSchema {
         fontSize: "LARGE" | "NORMAL" | "SMALL";
         formName: string;
         hideEmptyColumns: boolean;
+        hideEmptyRowItems:
+            | "NONE"
+            | "BEFORE_FIRST"
+            | "AFTER_LAST"
+            | "BEFORE_FIRST_AFTER_LAST"
+            | "ALL";
         hideEmptyRows: boolean;
+        hideLegend: boolean;
         hideSubtitle: boolean;
         hideTitle: boolean;
         href: string;
@@ -11371,23 +11896,33 @@ export interface D2ReportTableSchema {
         legendSet: D2LegendSetSchema;
         measureCriteria: string;
         name: string;
+        noSpaceBetweenColumns: boolean;
         numberType: "VALUE" | "ROW_PERCENTAGE" | "COLUMN_PERCENTAGE";
+        optionalAxes: any[];
         orgUnitField: string;
         organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimensionSchema[];
         organisationUnitLevels: number[];
         organisationUnits: D2OrganisationUnitSchema[];
         parentGraphMap: D2MapSchema;
+        percentStackedValues: boolean;
         periods: any[];
         programIndicatorDimensions: D2TrackedEntityProgramIndicatorDimensionSchema[];
         publicAccess: string;
+        rangeAxisDecimals: number;
+        rangeAxisLabel: string;
+        rangeAxisMaxValue: number;
+        rangeAxisMinValue: number;
+        rangeAxisSteps: number;
         regression: boolean;
+        regressionType: "NONE" | "LINEAR" | "POLYNOMIAL" | "LOESS";
         relativePeriods: any;
-        reportParams: any;
+        reportingParams: any;
         rowDimensions: string[];
         rowSubTotals: boolean;
         rowTotals: boolean;
         rows: any[];
         shortName: string;
+        showData: boolean;
         showDimensionLabels: boolean;
         showHierarchy: boolean;
         skipRounding: boolean;
@@ -11396,233 +11931,209 @@ export interface D2ReportTableSchema {
         subscribed: boolean;
         subscribers: string[];
         subtitle: string;
+        targetLineLabel: string;
+        targetLineValue: number;
         timeField: string;
         title: string;
         topLimit: number;
         translations: D2Translation[];
+        type:
+            | "COLUMN"
+            | "STACKED_COLUMN"
+            | "BAR"
+            | "STACKED_BAR"
+            | "LINE"
+            | "AREA"
+            | "PIE"
+            | "RADAR"
+            | "GAUGE"
+            | "YEAR_OVER_YEAR_LINE"
+            | "YEAR_OVER_YEAR_COLUMN"
+            | "SINGLE_VALUE"
+            | "PIVOT_TABLE";
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
+        userOrgUnitType: "DATA_CAPTURE" | "DATA_OUTPUT" | "TEI_SEARCH";
         userOrganisationUnit: boolean;
         userOrganisationUnitChildren: boolean;
         userOrganisationUnitGrandChildren: boolean;
+        visualizationPeriodName: string;
+        yearlySeries: string[];
     };
     fieldPresets: {
-        $all: Preset<D2ReportTable, keyof D2ReportTable>;
-        $identifiable: Preset<D2ReportTable, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ReportTable, FieldPresets["nameable"]>;
+        $all: Preset<D2Visualization, keyof D2Visualization>;
+        $identifiable: Preset<D2Visualization, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Visualization, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2ReportTable,
+            D2Visualization,
             | "dataElementGroupSetDimensions"
-            | "numberType"
             | "endDate"
+            | "baseLineValue"
             | "publicAccess"
             | "userOrganisationUnitChildren"
             | "legendDisplayStyle"
+            | "type"
             | "hideEmptyColumns"
             | "measureCriteria"
             | "lastUpdated"
-            | "hideEmptyRows"
             | "translations"
-            | "reportParams"
+            | "yearlySeries"
             | "userOrganisationUnit"
+            | "rowSubTotals"
             | "filterDimensions"
             | "id"
-            | "rowSubTotals"
             | "interpretations"
+            | "userGroupAccesses"
+            | "domainAxisLabel"
+            | "subscribers"
+            | "cumulativeValues"
+            | "optionalAxes"
+            | "showDimensionLabels"
+            | "sortOrder"
+            | "subtitle"
+            | "fontSize"
+            | "rangeAxisDecimals"
+            | "topLimit"
+            | "startDate"
+            | "userOrganisationUnitGrandChildren"
+            | "percentStackedValues"
+            | "noSpaceBetweenColumns"
+            | "rangeAxisSteps"
+            | "periods"
+            | "categoryDimensions"
+            | "showHierarchy"
+            | "reportingParams"
+            | "hideTitle"
+            | "rowDimensions"
+            | "colorSet"
+            | "skipRounding"
+            | "showData"
+            | "numberType"
+            | "hideEmptyRows"
             | "itemOrganisationUnitGroups"
             | "displayDensity"
             | "lastUpdatedBy"
-            | "userGroupAccesses"
             | "created"
-            | "subscribers"
+            | "rangeAxisLabel"
+            | "regressionType"
             | "columnDimensions"
             | "completedOnly"
             | "colTotals"
-            | "showDimensionLabels"
-            | "subtitle"
-            | "sortOrder"
             | "userAccesses"
             | "name"
-            | "fontSize"
-            | "topLimit"
-            | "startDate"
+            | "hideEmptyRowItems"
             | "favorites"
-            | "dataDimensionItems"
             | "aggregationType"
+            | "dataDimensionItems"
             | "code"
             | "categoryOptionGroupSetDimensions"
-            | "userOrganisationUnitGrandChildren"
             | "hideSubtitle"
             | "description"
             | "organisationUnitGroupSetDimensions"
             | "title"
-            | "organisationUnitLevels"
+            | "hideLegend"
             | "externalAccess"
+            | "rangeAxisMinValue"
+            | "organisationUnitLevels"
             | "legendDisplayStrategy"
             | "colSubTotals"
             | "relativePeriods"
-            | "periods"
+            | "targetLineLabel"
             | "organisationUnits"
-            | "categoryDimensions"
-            | "showHierarchy"
             | "rowTotals"
-            | "cumulative"
+            | "targetLineValue"
+            | "baseLineLabel"
             | "digitGroupSeparator"
-            | "hideTitle"
-            | "rowDimensions"
             | "regression"
             | "legendSet"
+            | "userOrgUnitType"
+            | "rangeAxisMaxValue"
             | "user"
-            | "skipRounding"
         >;
         $owner: Preset<
-            D2ReportTable,
+            D2Visualization,
             | "dataElementGroupSetDimensions"
-            | "numberType"
             | "endDate"
+            | "baseLineValue"
             | "publicAccess"
             | "userOrganisationUnitChildren"
             | "legendDisplayStyle"
+            | "type"
             | "hideEmptyColumns"
             | "measureCriteria"
             | "lastUpdated"
-            | "hideEmptyRows"
             | "translations"
-            | "reportParams"
+            | "yearlySeries"
             | "userOrganisationUnit"
+            | "rowSubTotals"
             | "filterDimensions"
             | "id"
-            | "rowSubTotals"
+            | "userGroupAccesses"
+            | "domainAxisLabel"
+            | "subscribers"
+            | "cumulativeValues"
+            | "optionalAxes"
+            | "showDimensionLabels"
+            | "sortOrder"
+            | "subtitle"
+            | "fontSize"
+            | "rangeAxisDecimals"
+            | "topLimit"
+            | "startDate"
+            | "userOrganisationUnitGrandChildren"
+            | "percentStackedValues"
+            | "noSpaceBetweenColumns"
+            | "rangeAxisSteps"
+            | "periods"
+            | "categoryDimensions"
+            | "showHierarchy"
+            | "reportingParams"
+            | "hideTitle"
+            | "rowDimensions"
+            | "colorSet"
+            | "skipRounding"
+            | "showData"
+            | "numberType"
+            | "hideEmptyRows"
             | "itemOrganisationUnitGroups"
             | "displayDensity"
             | "lastUpdatedBy"
-            | "userGroupAccesses"
             | "created"
-            | "subscribers"
+            | "rangeAxisLabel"
+            | "regressionType"
             | "columnDimensions"
             | "completedOnly"
             | "colTotals"
-            | "showDimensionLabels"
-            | "subtitle"
-            | "sortOrder"
             | "userAccesses"
             | "name"
-            | "fontSize"
-            | "topLimit"
-            | "startDate"
+            | "hideEmptyRowItems"
             | "favorites"
-            | "dataDimensionItems"
             | "aggregationType"
+            | "dataDimensionItems"
             | "code"
             | "categoryOptionGroupSetDimensions"
-            | "userOrganisationUnitGrandChildren"
             | "hideSubtitle"
             | "description"
             | "organisationUnitGroupSetDimensions"
             | "title"
-            | "organisationUnitLevels"
+            | "hideLegend"
             | "externalAccess"
+            | "rangeAxisMinValue"
+            | "organisationUnitLevels"
             | "legendDisplayStrategy"
             | "colSubTotals"
             | "relativePeriods"
-            | "periods"
+            | "targetLineLabel"
             | "organisationUnits"
-            | "categoryDimensions"
-            | "showHierarchy"
             | "rowTotals"
-            | "cumulative"
+            | "targetLineValue"
+            | "baseLineLabel"
             | "digitGroupSeparator"
-            | "hideTitle"
-            | "rowDimensions"
             | "regression"
             | "legendSet"
-            | "user"
-            | "skipRounding"
-        >;
-    };
-}
-
-export interface D2ReportSchema {
-    name: "D2Report";
-    model: D2Report;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        cacheStrategy:
-            | "NO_CACHE"
-            | "CACHE_15_MINUTES"
-            | "CACHE_30_MINUTES"
-            | "CACHE_1_HOUR"
-            | "CACHE_6AM_TOMORROW"
-            | "CACHE_TWO_WEEKS"
-            | "RESPECT_SYSTEM_SETTING";
-        code: Id;
-        created: string;
-        designContent: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        relativePeriods: any;
-        reportParams: any;
-        reportTable: D2ReportTableSchema;
-        translations: D2Translation[];
-        type: "JASPER_REPORT_TABLE" | "JASPER_JDBC" | "HTML";
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Report, keyof D2Report>;
-        $identifiable: Preset<D2Report, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Report, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Report,
-            | "designContent"
-            | "code"
-            | "publicAccess"
-            | "type"
-            | "externalAccess"
-            | "reportTable"
-            | "lastUpdated"
-            | "relativePeriods"
-            | "reportParams"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "userAccesses"
-            | "name"
-            | "cacheStrategy"
-            | "user"
-        >;
-        $owner: Preset<
-            D2Report,
-            | "designContent"
-            | "code"
-            | "publicAccess"
-            | "type"
-            | "externalAccess"
-            | "reportTable"
-            | "lastUpdated"
-            | "relativePeriods"
-            | "reportParams"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "userAccesses"
-            | "name"
-            | "cacheStrategy"
+            | "userOrgUnitType"
+            | "rangeAxisMaxValue"
             | "user"
         >;
     };
@@ -11658,107 +12169,13 @@ export interface D2ValidationResultSchema {
     };
 }
 
-export interface D2MapSchema {
-    name: "D2Map";
-    model: D2Map;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        basemap: string;
-        code: Id;
-        created: string;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        interpretations: D2InterpretationSchema[];
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        latitude: number;
-        longitude: number;
-        mapViews: D2MapViewSchema[];
-        name: string;
-        publicAccess: string;
-        shortName: string;
-        subscribed: boolean;
-        subscribers: string[];
-        title: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        zoom: number;
-    };
-    fieldPresets: {
-        $all: Preset<D2Map, keyof D2Map>;
-        $identifiable: Preset<D2Map, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Map, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Map,
-            | "favorites"
-            | "code"
-            | "publicAccess"
-            | "basemap"
-            | "latitude"
-            | "description"
-            | "title"
-            | "externalAccess"
-            | "lastUpdated"
-            | "translations"
-            | "mapViews"
-            | "id"
-            | "interpretations"
-            | "longitude"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "subscribers"
-            | "created"
-            | "zoom"
-            | "userAccesses"
-            | "name"
-            | "user"
-        >;
-        $owner: Preset<
-            D2Map,
-            | "favorites"
-            | "code"
-            | "publicAccess"
-            | "basemap"
-            | "latitude"
-            | "description"
-            | "title"
-            | "externalAccess"
-            | "lastUpdated"
-            | "translations"
-            | "mapViews"
-            | "id"
-            | "longitude"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "subscribers"
-            | "created"
-            | "zoom"
-            | "userAccesses"
-            | "name"
-            | "user"
-        >;
-    };
-}
-
 export interface D2PredictorSchema {
     name: "D2Predictor";
     model: D2Predictor;
     fields: {
         access: D2Access;
         annualSampleCount: number;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         description: string;
@@ -11842,7 +12259,7 @@ export interface D2PredictorGroupSchema {
     model: D2PredictorGroup;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         description: string;
@@ -11907,7 +12324,7 @@ export interface D2DashboardItemSchema {
     fields: {
         access: D2Access;
         appKey: string;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         chart: D2ChartSchema;
         code: Id;
         contentCount: number;
@@ -11936,6 +12353,7 @@ export interface D2DashboardItemSchema {
         text: string;
         translations: D2Translation[];
         type:
+            | "VISUALIZATION"
             | "CHART"
             | "EVENT_CHART"
             | "MAP"
@@ -11951,6 +12369,7 @@ export interface D2DashboardItemSchema {
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
         users: D2UserSchema[];
+        visualization: D2VisualizationSchema;
         width: number;
         x: number;
         y: number;
@@ -11962,8 +12381,8 @@ export interface D2DashboardItemSchema {
         $persisted: Preset<
             D2DashboardItem,
             | "reports"
+            | "visualization"
             | "code"
-            | "reportTable"
             | "lastUpdated"
             | "translations"
             | "appKey"
@@ -11982,13 +12401,12 @@ export interface D2DashboardItemSchema {
             | "x"
             | "messages"
             | "y"
-            | "chart"
         >;
         $owner: Preset<
             D2DashboardItem,
             | "reports"
+            | "visualization"
             | "code"
-            | "reportTable"
             | "lastUpdated"
             | "translations"
             | "appKey"
@@ -12007,7 +12425,6 @@ export interface D2DashboardItemSchema {
             | "x"
             | "messages"
             | "y"
-            | "chart"
         >;
     };
 }
@@ -12017,7 +12434,7 @@ export interface D2DashboardSchema {
     model: D2Dashboard;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         dashboardItems: D2DashboardItemSchema[];
@@ -12091,7 +12508,7 @@ export interface D2PushAnalysisSchema {
     model: D2PushAnalysis;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         dashboard: D2DashboardSchema;
@@ -12151,7 +12568,7 @@ export interface D2KeyJsonValueSchema {
     model: D2KeyJsonValue;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         displayName: string;
@@ -12207,352 +12624,6 @@ export interface D2KeyJsonValueSchema {
     };
 }
 
-export interface D2OrganisationUnitGroupSetDimensionSchema {
-    name: "D2OrganisationUnitGroupSetDimension";
-    model: D2OrganisationUnitGroupSetDimension;
-    fields: {
-        organisationUnitGroupSet: D2OrganisationUnitGroupSetSchema;
-        organisationUnitGroups: D2OrganisationUnitGroupSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<
-            D2OrganisationUnitGroupSetDimension,
-            keyof D2OrganisationUnitGroupSetDimension
-        >;
-        $identifiable: Preset<D2OrganisationUnitGroupSetDimension, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OrganisationUnitGroupSetDimension, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2OrganisationUnitGroupSetDimension,
-            "organisationUnitGroupSet" | "organisationUnitGroups"
-        >;
-        $owner: Preset<
-            D2OrganisationUnitGroupSetDimension,
-            "organisationUnitGroupSet" | "organisationUnitGroups"
-        >;
-    };
-}
-
-export interface D2UserCredentialsSchema {
-    name: "D2UserCredentials";
-    model: D2UserCredentials;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        catDimensionConstraints: D2CategorySchema[];
-        code: Id;
-        cogsDimensionConstraints: D2CategoryOptionGroupSetSchema[];
-        created: string;
-        disabled: boolean;
-        displayName: string;
-        externalAccess: boolean;
-        externalAuth: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        invitation: boolean;
-        lastLogin: string;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        ldapId: string;
-        name: string;
-        openId: string;
-        password: string;
-        passwordLastUpdated: string;
-        publicAccess: string;
-        selfRegistered: boolean;
-        translations: D2Translation[];
-        twoFA: boolean;
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        userInfo: D2UserSchema;
-        userRoles: D2UserAuthorityGroupSchema[];
-        username: string;
-    };
-    fieldPresets: {
-        $all: Preset<D2UserCredentials, keyof D2UserCredentials>;
-        $identifiable: Preset<D2UserCredentials, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2UserCredentials, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2UserCredentials,
-            | "lastLogin"
-            | "userInfo"
-            | "code"
-            | "openId"
-            | "externalAuth"
-            | "cogsDimensionConstraints"
-            | "catDimensionConstraints"
-            | "lastUpdated"
-            | "password"
-            | "ldapId"
-            | "disabled"
-            | "id"
-            | "twoFA"
-            | "passwordLastUpdated"
-            | "lastUpdatedBy"
-            | "invitation"
-            | "created"
-            | "selfRegistered"
-            | "userRoles"
-            | "user"
-            | "username"
-        >;
-        $owner: Preset<
-            D2UserCredentials,
-            | "lastLogin"
-            | "userInfo"
-            | "code"
-            | "openId"
-            | "externalAuth"
-            | "cogsDimensionConstraints"
-            | "catDimensionConstraints"
-            | "lastUpdated"
-            | "password"
-            | "ldapId"
-            | "disabled"
-            | "id"
-            | "twoFA"
-            | "passwordLastUpdated"
-            | "lastUpdatedBy"
-            | "invitation"
-            | "created"
-            | "selfRegistered"
-            | "userRoles"
-            | "user"
-            | "username"
-        >;
-    };
-}
-
-export interface D2ProgramStageDataElementSchema {
-    name: "D2ProgramStageDataElement";
-    model: D2ProgramStageDataElement;
-    fields: {
-        access: D2Access;
-        allowFutureDate: boolean;
-        allowProvidedElsewhere: boolean;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        compulsory: boolean;
-        created: string;
-        dataElement: D2DataElementSchema;
-        displayInReports: boolean;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        programStage: D2ProgramStageSchema;
-        publicAccess: string;
-        renderOptionsAsRadio: boolean;
-        renderType: any;
-        skipSynchronization: boolean;
-        sortOrder: number;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramStageDataElement, keyof D2ProgramStageDataElement>;
-        $identifiable: Preset<D2ProgramStageDataElement, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramStageDataElement, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramStageDataElement,
-            | "displayInReports"
-            | "code"
-            | "skipSynchronization"
-            | "lastUpdated"
-            | "renderOptionsAsRadio"
-            | "id"
-            | "allowFutureDate"
-            | "renderType"
-            | "lastUpdatedBy"
-            | "programStage"
-            | "created"
-            | "dataElement"
-            | "compulsory"
-            | "allowProvidedElsewhere"
-            | "sortOrder"
-        >;
-        $owner: Preset<
-            D2ProgramStageDataElement,
-            | "displayInReports"
-            | "code"
-            | "skipSynchronization"
-            | "lastUpdated"
-            | "renderOptionsAsRadio"
-            | "id"
-            | "allowFutureDate"
-            | "renderType"
-            | "lastUpdatedBy"
-            | "programStage"
-            | "created"
-            | "dataElement"
-            | "compulsory"
-            | "allowProvidedElsewhere"
-            | "sortOrder"
-        >;
-    };
-}
-
-export interface D2FileResourceSchema {
-    name: "D2FileResource";
-    model: D2FileResource;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        contentLength: string;
-        contentMd5: string;
-        contentType: string;
-        created: string;
-        displayName: string;
-        domain: "DATA_VALUE" | "PUSH_ANALYSIS" | "DOCUMENT" | "MESSAGE_ATTACHMENT" | "USER_AVATAR";
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        storageStatus: "NONE" | "PENDING" | "FAILED" | "STORED";
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2FileResource, keyof D2FileResource>;
-        $identifiable: Preset<D2FileResource, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2FileResource, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2FileResource,
-            | "contentMd5"
-            | "code"
-            | "lastUpdated"
-            | "id"
-            | "contentType"
-            | "lastUpdatedBy"
-            | "created"
-            | "domain"
-            | "name"
-            | "contentLength"
-            | "user"
-        >;
-        $owner: Preset<
-            D2FileResource,
-            | "contentMd5"
-            | "code"
-            | "lastUpdated"
-            | "id"
-            | "contentType"
-            | "lastUpdatedBy"
-            | "created"
-            | "domain"
-            | "name"
-            | "contentLength"
-            | "user"
-        >;
-    };
-}
-
-export interface D2ProgramInstanceSchema {
-    name: "D2ProgramInstance";
-    model: D2ProgramInstance;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        createdAtClient: string;
-        deleted: boolean;
-        displayName: string;
-        endDate: string;
-        enrollmentDate: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        followup: boolean;
-        href: string;
-        id: Id;
-        incidentDate: string;
-        lastUpdated: string;
-        lastUpdatedAtClient: string;
-        lastUpdatedBy: D2UserSchema;
-        messageConversations: D2MessageConversationSchema[];
-        name: string;
-        organisationUnit: D2OrganisationUnitSchema;
-        program: D2ProgramSchema;
-        programStageInstances: D2ProgramStageInstanceSchema[];
-        publicAccess: string;
-        relationshipItems: any[];
-        status: "ACTIVE" | "COMPLETED" | "CANCELLED";
-        storedBy: string;
-        trackedEntityComments: any[];
-        trackedEntityInstance: D2TrackedEntityInstanceSchema;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramInstance, keyof D2ProgramInstance>;
-        $identifiable: Preset<D2ProgramInstance, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramInstance, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramInstance,
-            | "storedBy"
-            | "endDate"
-            | "organisationUnit"
-            | "enrollmentDate"
-            | "createdAtClient"
-            | "program"
-            | "messageConversations"
-            | "trackedEntityComments"
-            | "lastUpdated"
-            | "relationshipItems"
-            | "id"
-            | "created"
-            | "programStageInstances"
-            | "trackedEntityInstance"
-            | "followup"
-            | "deleted"
-            | "incidentDate"
-            | "status"
-            | "lastUpdatedAtClient"
-        >;
-        $owner: Preset<
-            D2ProgramInstance,
-            | "storedBy"
-            | "endDate"
-            | "organisationUnit"
-            | "enrollmentDate"
-            | "createdAtClient"
-            | "program"
-            | "messageConversations"
-            | "trackedEntityComments"
-            | "lastUpdated"
-            | "id"
-            | "created"
-            | "programStageInstances"
-            | "trackedEntityInstance"
-            | "followup"
-            | "deleted"
-            | "incidentDate"
-            | "status"
-            | "lastUpdatedAtClient"
-        >;
-    };
-}
-
 export interface D2UserAccessSchema {
     name: "D2UserAccess";
     model: D2UserAccess;
@@ -12566,35 +12637,249 @@ export interface D2UserAccessSchema {
     };
 }
 
-export interface D2TrackedEntityDataElementDimensionSchema {
-    name: "D2TrackedEntityDataElementDimension";
-    model: D2TrackedEntityDataElementDimension;
-    fields: { dataElement: D2DataElementSchema; filter: string; legendSet: D2LegendSetSchema };
+export interface D2AnalyticsPeriodBoundarySchema {
+    name: "D2AnalyticsPeriodBoundary";
+    model: D2AnalyticsPeriodBoundary;
+    fields: {
+        access: D2Access;
+        analyticsPeriodBoundaryType:
+            | "BEFORE_START_OF_REPORTING_PERIOD"
+            | "BEFORE_END_OF_REPORTING_PERIOD"
+            | "AFTER_START_OF_REPORTING_PERIOD"
+            | "AFTER_END_OF_REPORTING_PERIOD";
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        boundaryTarget: string;
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        offsetPeriodType: string;
+        offsetPeriods: number;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
     fieldPresets: {
-        $all: Preset<
-            D2TrackedEntityDataElementDimension,
-            keyof D2TrackedEntityDataElementDimension
-        >;
-        $identifiable: Preset<D2TrackedEntityDataElementDimension, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2TrackedEntityDataElementDimension, FieldPresets["nameable"]>;
+        $all: Preset<D2AnalyticsPeriodBoundary, keyof D2AnalyticsPeriodBoundary>;
+        $identifiable: Preset<D2AnalyticsPeriodBoundary, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2AnalyticsPeriodBoundary, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2TrackedEntityDataElementDimension,
-            "filter" | "legendSet" | "dataElement"
+            D2AnalyticsPeriodBoundary,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "lastUpdated"
+            | "offsetPeriodType"
+            | "id"
+            | "analyticsPeriodBoundaryType"
+            | "boundaryTarget"
+            | "offsetPeriods"
         >;
-        $owner: Preset<D2TrackedEntityDataElementDimension, "filter" | "legendSet" | "dataElement">;
+        $owner: Preset<
+            D2AnalyticsPeriodBoundary,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "lastUpdated"
+            | "offsetPeriodType"
+            | "id"
+            | "analyticsPeriodBoundaryType"
+            | "boundaryTarget"
+            | "offsetPeriods"
+        >;
     };
 }
 
-export interface D2IconSchema {
-    name: "D2Icon";
-    model: D2Icon;
-    fields: {};
+export interface D2DataSetElementSchema {
+    name: "D2DataSetElement";
+    model: D2DataSetElement;
+    fields: {
+        categoryCombo: D2CategoryComboSchema;
+        dataElement: D2DataElementSchema;
+        dataSet: D2DataSetSchema;
+    };
     fieldPresets: {
-        $all: Preset<D2Icon, keyof D2Icon>;
-        $identifiable: Preset<D2Icon, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Icon, FieldPresets["nameable"]>;
-        $persisted: Preset<D2Icon, never>;
-        $owner: Preset<D2Icon, never>;
+        $all: Preset<D2DataSetElement, keyof D2DataSetElement>;
+        $identifiable: Preset<D2DataSetElement, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2DataSetElement, FieldPresets["nameable"]>;
+        $persisted: Preset<D2DataSetElement, "dataElement" | "categoryCombo" | "dataSet">;
+        $owner: Preset<D2DataSetElement, "dataElement" | "categoryCombo" | "dataSet">;
+    };
+}
+
+export interface D2TrackedEntityInstanceSchema {
+    name: "D2TrackedEntityInstance";
+    model: D2TrackedEntityInstance;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        createdAtClient: string;
+        deleted: boolean;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        geometry: D2Geometry;
+        href: string;
+        id: Id;
+        inactive: boolean;
+        lastUpdated: string;
+        lastUpdatedAtClient: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        organisationUnit: D2OrganisationUnitSchema;
+        programInstances: D2ProgramInstanceSchema[];
+        programOwners: any[];
+        publicAccess: string;
+        relationshipItems: any[];
+        trackedEntityAttributeValues: D2TrackedEntityAttributeValueSchema[];
+        trackedEntityType: D2TrackedEntityTypeSchema;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2TrackedEntityInstance, keyof D2TrackedEntityInstance>;
+        $identifiable: Preset<D2TrackedEntityInstance, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2TrackedEntityInstance, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2TrackedEntityInstance,
+            | "programOwners"
+            | "code"
+            | "programInstances"
+            | "organisationUnit"
+            | "createdAtClient"
+            | "lastUpdated"
+            | "inactive"
+            | "relationshipItems"
+            | "id"
+            | "lastUpdatedBy"
+            | "created"
+            | "deleted"
+            | "trackedEntityType"
+            | "geometry"
+            | "trackedEntityAttributeValues"
+            | "lastUpdatedAtClient"
+        >;
+        $owner: Preset<
+            D2TrackedEntityInstance,
+            | "code"
+            | "organisationUnit"
+            | "createdAtClient"
+            | "lastUpdated"
+            | "inactive"
+            | "id"
+            | "lastUpdatedBy"
+            | "created"
+            | "deleted"
+            | "trackedEntityType"
+            | "geometry"
+            | "lastUpdatedAtClient"
+        >;
+    };
+}
+
+export interface D2MinMaxDataElementSchema {
+    name: "D2MinMaxDataElement";
+    model: D2MinMaxDataElement;
+    fields: {
+        dataElement: D2DataElementSchema;
+        generated: boolean;
+        max: number;
+        min: number;
+        optionCombo: D2CategoryOptionComboSchema;
+        source: D2OrganisationUnitSchema;
+    };
+    fieldPresets: {
+        $all: Preset<D2MinMaxDataElement, keyof D2MinMaxDataElement>;
+        $identifiable: Preset<D2MinMaxDataElement, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2MinMaxDataElement, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2MinMaxDataElement,
+            "min" | "generated" | "max" | "dataElement" | "source" | "optionCombo"
+        >;
+        $owner: Preset<
+            D2MinMaxDataElement,
+            "min" | "generated" | "max" | "dataElement" | "source" | "optionCombo"
+        >;
+    };
+}
+
+export interface D2ProgramStageInstanceFilterSchema {
+    name: "D2ProgramStageInstanceFilter";
+    model: D2ProgramStageInstanceFilter;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        description: string;
+        displayName: string;
+        eventQueryCriteria: any;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        program: Id;
+        programStage: Id;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramStageInstanceFilter, keyof D2ProgramStageInstanceFilter>;
+        $identifiable: Preset<D2ProgramStageInstanceFilter, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramStageInstanceFilter, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramStageInstanceFilter,
+            | "lastUpdatedBy"
+            | "programStage"
+            | "eventQueryCriteria"
+            | "userGroupAccesses"
+            | "created"
+            | "publicAccess"
+            | "description"
+            | "program"
+            | "lastUpdated"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+        >;
+        $owner: Preset<
+            D2ProgramStageInstanceFilter,
+            | "lastUpdatedBy"
+            | "programStage"
+            | "eventQueryCriteria"
+            | "userGroupAccesses"
+            | "created"
+            | "publicAccess"
+            | "description"
+            | "program"
+            | "lastUpdated"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+        >;
     };
 }
 
@@ -12623,7 +12908,7 @@ export interface D2ProgramTrackedEntityAttributeSchema {
     fields: {
         access: D2Access;
         allowFutureDate: boolean;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         displayInList: boolean;
@@ -12720,201 +13005,13 @@ export interface D2ProgramTrackedEntityAttributeSchema {
     };
 }
 
-export interface D2ReportingRateSchema {
-    name: "D2ReportingRate";
-    model: D2ReportingRate;
-    fields: {
-        access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        dataSet: D2DataSetSchema;
-        description: string;
-        dimensionItem: string;
-        dimensionItemType:
-            | "DATA_ELEMENT"
-            | "DATA_ELEMENT_OPERAND"
-            | "INDICATOR"
-            | "REPORTING_RATE"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION"
-            | "OPTION_GROUP"
-            | "DATA_ELEMENT_GROUP"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY_OPTION_GROUP";
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        legendSet: D2LegendSetSchema;
-        legendSets: D2LegendSetSchema[];
-        metric:
-            | "REPORTING_RATE"
-            | "REPORTING_RATE_ON_TIME"
-            | "ACTUAL_REPORTS"
-            | "ACTUAL_REPORTS_ON_TIME"
-            | "EXPECTED_REPORTS";
-        name: string;
-        publicAccess: string;
-        shortName: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ReportingRate, keyof D2ReportingRate>;
-        $identifiable: Preset<D2ReportingRate, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ReportingRate, FieldPresets["nameable"]>;
-        $persisted: Preset<D2ReportingRate, never>;
-        $owner: Preset<D2ReportingRate, never>;
-    };
-}
-
-export interface D2UserGroupAccessSchema {
-    name: "D2UserGroupAccess";
-    model: D2UserGroupAccess;
-    fields: { access: string; displayName: string; id: string; userGroupUid: string };
-    fieldPresets: {
-        $all: Preset<D2UserGroupAccess, keyof D2UserGroupAccess>;
-        $identifiable: Preset<D2UserGroupAccess, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2UserGroupAccess, FieldPresets["nameable"]>;
-        $persisted: Preset<D2UserGroupAccess, "access">;
-        $owner: Preset<D2UserGroupAccess, "access">;
-    };
-}
-
-export interface D2ProgramStageInstanceSchema {
-    name: "D2ProgramStageInstance";
-    model: D2ProgramStageInstance;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramStageInstance, keyof D2ProgramStageInstance>;
-        $identifiable: Preset<D2ProgramStageInstance, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramStageInstance, FieldPresets["nameable"]>;
-        $persisted: Preset<D2ProgramStageInstance, "code" | "created" | "lastUpdated" | "id">;
-        $owner: Preset<D2ProgramStageInstance, "code" | "created" | "lastUpdated" | "id">;
-    };
-}
-
-export interface D2InterpretationCommentSchema {
-    name: "D2InterpretationComment";
-    model: D2InterpretationComment;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        mentions: any[];
-        name: string;
-        publicAccess: string;
-        text: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2InterpretationComment, keyof D2InterpretationComment>;
-        $identifiable: Preset<D2InterpretationComment, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2InterpretationComment, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2InterpretationComment,
-            "created" | "lastUpdated" | "mentions" | "text" | "id" | "user"
-        >;
-        $owner: Preset<
-            D2InterpretationComment,
-            "created" | "lastUpdated" | "mentions" | "text" | "id" | "user"
-        >;
-    };
-}
-
-export interface D2MinMaxDataElementSchema {
-    name: "D2MinMaxDataElement";
-    model: D2MinMaxDataElement;
-    fields: {
-        dataElement: D2DataElementSchema;
-        generated: boolean;
-        max: number;
-        min: number;
-        optionCombo: D2CategoryOptionComboSchema;
-        source: D2OrganisationUnitSchema;
-    };
-    fieldPresets: {
-        $all: Preset<D2MinMaxDataElement, keyof D2MinMaxDataElement>;
-        $identifiable: Preset<D2MinMaxDataElement, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2MinMaxDataElement, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2MinMaxDataElement,
-            "min" | "generated" | "max" | "dataElement" | "source" | "optionCombo"
-        >;
-        $owner: Preset<
-            D2MinMaxDataElement,
-            "min" | "generated" | "max" | "dataElement" | "source" | "optionCombo"
-        >;
-    };
-}
-
 export interface D2MessageConversationSchema {
     name: "D2MessageConversation";
     model: D2MessageConversation;
     fields: {
         access: D2Access;
         assignee: D2UserSchema;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         displayName: string;
@@ -12988,197 +13085,63 @@ export interface D2MessageConversationSchema {
     };
 }
 
-export interface D2AnalyticsPeriodBoundarySchema {
-    name: "D2AnalyticsPeriodBoundary";
-    model: D2AnalyticsPeriodBoundary;
+export interface D2OrganisationUnitGroupSetDimensionSchema {
+    name: "D2OrganisationUnitGroupSetDimension";
+    model: D2OrganisationUnitGroupSetDimension;
     fields: {
-        access: D2Access;
-        analyticsPeriodBoundaryType:
-            | "BEFORE_START_OF_REPORTING_PERIOD"
-            | "BEFORE_END_OF_REPORTING_PERIOD"
-            | "AFTER_START_OF_REPORTING_PERIOD"
-            | "AFTER_END_OF_REPORTING_PERIOD";
-        attributeValues: D2AttributeValueSchema[];
-        boundaryTarget: string;
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        offsetPeriodType: string;
-        offsetPeriods: number;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
+        organisationUnitGroupSet: D2OrganisationUnitGroupSetSchema;
+        organisationUnitGroups: D2OrganisationUnitGroupSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2AnalyticsPeriodBoundary, keyof D2AnalyticsPeriodBoundary>;
-        $identifiable: Preset<D2AnalyticsPeriodBoundary, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2AnalyticsPeriodBoundary, FieldPresets["nameable"]>;
+        $all: Preset<
+            D2OrganisationUnitGroupSetDimension,
+            keyof D2OrganisationUnitGroupSetDimension
+        >;
+        $identifiable: Preset<D2OrganisationUnitGroupSetDimension, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OrganisationUnitGroupSetDimension, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2AnalyticsPeriodBoundary,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "lastUpdated"
-            | "offsetPeriodType"
-            | "id"
-            | "analyticsPeriodBoundaryType"
-            | "boundaryTarget"
-            | "offsetPeriods"
+            D2OrganisationUnitGroupSetDimension,
+            "organisationUnitGroupSet" | "organisationUnitGroups"
         >;
         $owner: Preset<
-            D2AnalyticsPeriodBoundary,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "lastUpdated"
-            | "offsetPeriodType"
-            | "id"
-            | "analyticsPeriodBoundaryType"
-            | "boundaryTarget"
-            | "offsetPeriods"
+            D2OrganisationUnitGroupSetDimension,
+            "organisationUnitGroupSet" | "organisationUnitGroups"
         >;
     };
 }
 
-export interface D2MetadataVersionSchema {
-    name: "D2MetadataVersion";
-    model: D2MetadataVersion;
+export interface D2CategoryOptionGroupSetDimensionSchema {
+    name: "D2CategoryOptionGroupSetDimension";
+    model: D2CategoryOptionGroupSetDimension;
     fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        hashCode: string;
-        href: string;
-        id: Id;
-        importDate: string;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        type: "BEST_EFFORT" | "ATOMIC";
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
+        categoryOptionGroupSet: D2CategoryOptionGroupSetSchema;
+        categoryOptionGroups: D2CategoryOptionGroupSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2MetadataVersion, keyof D2MetadataVersion>;
-        $identifiable: Preset<D2MetadataVersion, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2MetadataVersion, FieldPresets["nameable"]>;
+        $all: Preset<D2CategoryOptionGroupSetDimension, keyof D2CategoryOptionGroupSetDimension>;
+        $identifiable: Preset<D2CategoryOptionGroupSetDimension, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2CategoryOptionGroupSetDimension, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2MetadataVersion,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "type"
-            | "lastUpdated"
-            | "importDate"
-            | "hashCode"
-            | "name"
-            | "id"
+            D2CategoryOptionGroupSetDimension,
+            "categoryOptionGroups" | "categoryOptionGroupSet"
         >;
         $owner: Preset<
-            D2MetadataVersion,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "type"
-            | "lastUpdated"
-            | "importDate"
-            | "hashCode"
-            | "name"
-            | "id"
+            D2CategoryOptionGroupSetDimension,
+            "categoryOptionGroups" | "categoryOptionGroupSet"
         >;
     };
 }
 
-export interface D2TrackedEntityInstanceSchema {
-    name: "D2TrackedEntityInstance";
-    model: D2TrackedEntityInstance;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        createdAtClient: string;
-        deleted: boolean;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        geometry: D2Geometry;
-        href: string;
-        id: Id;
-        inactive: boolean;
-        lastUpdated: string;
-        lastUpdatedAtClient: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        organisationUnit: D2OrganisationUnitSchema;
-        programInstances: D2ProgramInstanceSchema[];
-        programOwners: any[];
-        publicAccess: string;
-        relationshipItems: any[];
-        trackedEntityAttributeValues: any[];
-        trackedEntityType: D2TrackedEntityTypeSchema;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
+export interface D2UserGroupAccessSchema {
+    name: "D2UserGroupAccess";
+    model: D2UserGroupAccess;
+    fields: { access: string; displayName: string; id: string; userGroupUid: string };
     fieldPresets: {
-        $all: Preset<D2TrackedEntityInstance, keyof D2TrackedEntityInstance>;
-        $identifiable: Preset<D2TrackedEntityInstance, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2TrackedEntityInstance, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2TrackedEntityInstance,
-            | "programOwners"
-            | "code"
-            | "programInstances"
-            | "organisationUnit"
-            | "createdAtClient"
-            | "lastUpdated"
-            | "inactive"
-            | "relationshipItems"
-            | "id"
-            | "lastUpdatedBy"
-            | "created"
-            | "deleted"
-            | "trackedEntityType"
-            | "geometry"
-            | "trackedEntityAttributeValues"
-            | "lastUpdatedAtClient"
-        >;
-        $owner: Preset<
-            D2TrackedEntityInstance,
-            | "code"
-            | "organisationUnit"
-            | "createdAtClient"
-            | "lastUpdated"
-            | "inactive"
-            | "id"
-            | "lastUpdatedBy"
-            | "created"
-            | "deleted"
-            | "trackedEntityType"
-            | "geometry"
-            | "lastUpdatedAtClient"
-        >;
+        $all: Preset<D2UserGroupAccess, keyof D2UserGroupAccess>;
+        $identifiable: Preset<D2UserGroupAccess, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2UserGroupAccess, FieldPresets["nameable"]>;
+        $persisted: Preset<D2UserGroupAccess, "access">;
+        $owner: Preset<D2UserGroupAccess, "access">;
     };
 }
 
@@ -13187,7 +13150,7 @@ export interface D2TrackedEntityInstanceFilterSchema {
     model: D2TrackedEntityInstanceFilter;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         description: string;
@@ -13254,264 +13217,6 @@ export interface D2TrackedEntityInstanceFilterSchema {
     };
 }
 
-export interface D2ProgramStageInstanceFilterSchema {
-    name: "D2ProgramStageInstanceFilter";
-    model: D2ProgramStageInstanceFilter;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        code: Id;
-        created: string;
-        description: string;
-        displayName: string;
-        eventQueryCriteria: any;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        program: Id;
-        programStage: Id;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramStageInstanceFilter, keyof D2ProgramStageInstanceFilter>;
-        $identifiable: Preset<D2ProgramStageInstanceFilter, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramStageInstanceFilter, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramStageInstanceFilter,
-            | "lastUpdatedBy"
-            | "programStage"
-            | "eventQueryCriteria"
-            | "userGroupAccesses"
-            | "created"
-            | "publicAccess"
-            | "description"
-            | "program"
-            | "lastUpdated"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2ProgramStageInstanceFilter,
-            | "lastUpdatedBy"
-            | "programStage"
-            | "eventQueryCriteria"
-            | "userGroupAccesses"
-            | "created"
-            | "publicAccess"
-            | "description"
-            | "program"
-            | "lastUpdated"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
-export interface D2DataElementOperandSchema {
-    name: "D2DataElementOperand";
-    model: D2DataElementOperand;
-    fields: {
-        access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
-        attributeOptionCombo: D2CategoryOptionComboSchema;
-        attributeValues: D2AttributeValueSchema[];
-        categoryOptionCombo: D2CategoryOptionComboSchema;
-        code: Id;
-        created: string;
-        dataElement: D2DataElementSchema;
-        description: string;
-        dimensionItem: string;
-        dimensionItemType:
-            | "DATA_ELEMENT"
-            | "DATA_ELEMENT_OPERAND"
-            | "INDICATOR"
-            | "REPORTING_RATE"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION"
-            | "OPTION_GROUP"
-            | "DATA_ELEMENT_GROUP"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY_OPTION_GROUP";
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        legendSet: D2LegendSetSchema;
-        legendSets: D2LegendSetSchema[];
-        name: string;
-        publicAccess: string;
-        shortName: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2DataElementOperand, keyof D2DataElementOperand>;
-        $identifiable: Preset<D2DataElementOperand, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2DataElementOperand, FieldPresets["nameable"]>;
-        $persisted: Preset<D2DataElementOperand, "categoryOptionCombo" | "dataElement">;
-        $owner: Preset<D2DataElementOperand, "categoryOptionCombo" | "dataElement">;
-    };
-}
-
-export interface D2TrackedEntityProgramIndicatorDimensionSchema {
-    name: "D2TrackedEntityProgramIndicatorDimension";
-    model: D2TrackedEntityProgramIndicatorDimension;
-    fields: {
-        filter: string;
-        legendSet: D2LegendSetSchema;
-        programIndicator: D2ProgramIndicatorSchema;
-    };
-    fieldPresets: {
-        $all: Preset<
-            D2TrackedEntityProgramIndicatorDimension,
-            keyof D2TrackedEntityProgramIndicatorDimension
-        >;
-        $identifiable: Preset<
-            D2TrackedEntityProgramIndicatorDimension,
-            FieldPresets["identifiable"]
-        >;
-        $nameable: Preset<D2TrackedEntityProgramIndicatorDimension, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2TrackedEntityProgramIndicatorDimension,
-            "filter" | "legendSet" | "programIndicator"
-        >;
-        $owner: Preset<
-            D2TrackedEntityProgramIndicatorDimension,
-            "filter" | "legendSet" | "programIndicator"
-        >;
-    };
-}
-
-export interface D2InterpretationSchema {
-    name: "D2Interpretation";
-    model: D2Interpretation;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
-        chart: D2ChartSchema;
-        code: Id;
-        comments: D2InterpretationCommentSchema[];
-        created: string;
-        dataSet: D2DataSetSchema;
-        displayName: string;
-        eventChart: D2EventChartSchema;
-        eventReport: D2EventReportSchema;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        likedBy: D2UserSchema[];
-        likes: number;
-        map: D2MapSchema;
-        mentions: any[];
-        name: string;
-        organisationUnit: D2OrganisationUnitSchema;
-        period: any;
-        publicAccess: string;
-        reportTable: D2ReportTableSchema;
-        text: string;
-        translations: D2Translation[];
-        type: "REPORT_TABLE" | "CHART" | "MAP" | "EVENT_REPORT" | "EVENT_CHART" | "DATASET_REPORT";
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Interpretation, keyof D2Interpretation>;
-        $identifiable: Preset<D2Interpretation, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Interpretation, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Interpretation,
-            | "likedBy"
-            | "organisationUnit"
-            | "publicAccess"
-            | "reportTable"
-            | "lastUpdated"
-            | "id"
-            | "text"
-            | "map"
-            | "dataSet"
-            | "likes"
-            | "period"
-            | "userGroupAccesses"
-            | "comments"
-            | "created"
-            | "eventReport"
-            | "userAccesses"
-            | "mentions"
-            | "eventChart"
-            | "user"
-            | "chart"
-        >;
-        $owner: Preset<
-            D2Interpretation,
-            | "likedBy"
-            | "organisationUnit"
-            | "publicAccess"
-            | "reportTable"
-            | "lastUpdated"
-            | "id"
-            | "text"
-            | "map"
-            | "dataSet"
-            | "likes"
-            | "period"
-            | "userGroupAccesses"
-            | "comments"
-            | "created"
-            | "eventReport"
-            | "userAccesses"
-            | "mentions"
-            | "eventChart"
-            | "user"
-            | "chart"
-        >;
-    };
-}
-
 export interface D2ProgramDataElementDimensionItemSchema {
     name: "D2ProgramDataElementDimensionItem";
     model: D2ProgramDataElementDimensionItem;
@@ -13523,6 +13228,8 @@ export interface D2ProgramDataElementDimensionItemSchema {
             | "AVERAGE_SUM_ORG_UNIT"
             | "LAST"
             | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
             | "COUNT"
             | "STDDEV"
             | "VARIANCE"
@@ -13531,7 +13238,7 @@ export interface D2ProgramDataElementDimensionItemSchema {
             | "NONE"
             | "CUSTOM"
             | "DEFAULT";
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         dataElement: D2DataElementSchema;
@@ -13610,6 +13317,142 @@ export interface D2ProgramDataElementDimensionItemSchema {
     };
 }
 
+export interface D2ReportingRateSchema {
+    name: "D2ReportingRate";
+    model: D2ReportingRate;
+    fields: {
+        access: D2Access;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        dataSet: D2DataSetSchema;
+        description: string;
+        dimensionItem: string;
+        dimensionItemType:
+            | "DATA_ELEMENT"
+            | "DATA_ELEMENT_OPERAND"
+            | "INDICATOR"
+            | "REPORTING_RATE"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION"
+            | "OPTION_GROUP"
+            | "DATA_ELEMENT_GROUP"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY_OPTION_GROUP";
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendSet: D2LegendSetSchema;
+        legendSets: D2LegendSetSchema[];
+        metric:
+            | "REPORTING_RATE"
+            | "REPORTING_RATE_ON_TIME"
+            | "ACTUAL_REPORTS"
+            | "ACTUAL_REPORTS_ON_TIME"
+            | "EXPECTED_REPORTS";
+        name: string;
+        publicAccess: string;
+        shortName: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ReportingRate, keyof D2ReportingRate>;
+        $identifiable: Preset<D2ReportingRate, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ReportingRate, FieldPresets["nameable"]>;
+        $persisted: Preset<D2ReportingRate, never>;
+        $owner: Preset<D2ReportingRate, never>;
+    };
+}
+
+export interface D2MetadataVersionSchema {
+    name: "D2MetadataVersion";
+    model: D2MetadataVersion;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        hashCode: string;
+        href: string;
+        id: Id;
+        importDate: string;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        translations: D2Translation[];
+        type: "BEST_EFFORT" | "ATOMIC";
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2MetadataVersion, keyof D2MetadataVersion>;
+        $identifiable: Preset<D2MetadataVersion, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2MetadataVersion, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2MetadataVersion,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "type"
+            | "lastUpdated"
+            | "importDate"
+            | "hashCode"
+            | "name"
+            | "id"
+        >;
+        $owner: Preset<
+            D2MetadataVersion,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "type"
+            | "lastUpdated"
+            | "importDate"
+            | "hashCode"
+            | "name"
+            | "id"
+        >;
+    };
+}
+
 export interface D2DataInputPeriodSchema {
     name: "D2DataInputPeriod";
     model: D2DataInputPeriod;
@@ -13623,20 +13466,485 @@ export interface D2DataInputPeriodSchema {
     };
 }
 
-export interface D2DataSetElementSchema {
-    name: "D2DataSetElement";
-    model: D2DataSetElement;
+export interface D2IconSchema {
+    name: "D2Icon";
+    model: D2Icon;
+    fields: {};
+    fieldPresets: {
+        $all: Preset<D2Icon, keyof D2Icon>;
+        $identifiable: Preset<D2Icon, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Icon, FieldPresets["nameable"]>;
+        $persisted: Preset<D2Icon, never>;
+        $owner: Preset<D2Icon, never>;
+    };
+}
+
+export interface D2TrackedEntityAttributeValueSchema {
+    name: "D2TrackedEntityAttributeValue";
+    model: D2TrackedEntityAttributeValue;
     fields: {
-        categoryCombo: D2CategoryComboSchema;
-        dataElement: D2DataElementSchema;
-        dataSet: D2DataSetSchema;
+        created: string;
+        lastUpdated: string;
+        storedBy: string;
+        trackedEntityAttribute: D2TrackedEntityAttributeSchema;
+        trackedEntityInstance: D2TrackedEntityInstanceSchema;
+        value: string;
     };
     fieldPresets: {
-        $all: Preset<D2DataSetElement, keyof D2DataSetElement>;
-        $identifiable: Preset<D2DataSetElement, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2DataSetElement, FieldPresets["nameable"]>;
-        $persisted: Preset<D2DataSetElement, "dataElement" | "categoryCombo" | "dataSet">;
-        $owner: Preset<D2DataSetElement, "dataElement" | "categoryCombo" | "dataSet">;
+        $all: Preset<D2TrackedEntityAttributeValue, keyof D2TrackedEntityAttributeValue>;
+        $identifiable: Preset<D2TrackedEntityAttributeValue, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2TrackedEntityAttributeValue, FieldPresets["nameable"]>;
+        $persisted: Preset<D2TrackedEntityAttributeValue, "lastUpdated" | "storedBy" | "created">;
+        $owner: Preset<D2TrackedEntityAttributeValue, "lastUpdated" | "storedBy" | "created">;
+    };
+}
+
+export interface D2InterpretationSchema {
+    name: "D2Interpretation";
+    model: D2Interpretation;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        chart: D2ChartSchema;
+        code: Id;
+        comments: D2InterpretationCommentSchema[];
+        created: string;
+        dataSet: D2DataSetSchema;
+        displayName: string;
+        eventChart: D2EventChartSchema;
+        eventReport: D2EventReportSchema;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        likedBy: D2UserSchema[];
+        likes: number;
+        map: D2MapSchema;
+        mentions: any[];
+        name: string;
+        organisationUnit: D2OrganisationUnitSchema;
+        period: any;
+        publicAccess: string;
+        reportTable: D2ReportTableSchema;
+        text: string;
+        translations: D2Translation[];
+        type:
+            | "VISUALIZATION"
+            | "REPORT_TABLE"
+            | "CHART"
+            | "MAP"
+            | "EVENT_REPORT"
+            | "EVENT_CHART"
+            | "DATASET_REPORT";
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        visualization: D2VisualizationSchema;
+    };
+    fieldPresets: {
+        $all: Preset<D2Interpretation, keyof D2Interpretation>;
+        $identifiable: Preset<D2Interpretation, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Interpretation, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Interpretation,
+            | "visualization"
+            | "likedBy"
+            | "organisationUnit"
+            | "publicAccess"
+            | "lastUpdated"
+            | "id"
+            | "text"
+            | "map"
+            | "dataSet"
+            | "likes"
+            | "period"
+            | "userGroupAccesses"
+            | "comments"
+            | "created"
+            | "eventReport"
+            | "userAccesses"
+            | "mentions"
+            | "eventChart"
+            | "user"
+        >;
+        $owner: Preset<
+            D2Interpretation,
+            | "visualization"
+            | "likedBy"
+            | "organisationUnit"
+            | "publicAccess"
+            | "lastUpdated"
+            | "id"
+            | "text"
+            | "map"
+            | "dataSet"
+            | "likes"
+            | "period"
+            | "userGroupAccesses"
+            | "comments"
+            | "created"
+            | "eventReport"
+            | "userAccesses"
+            | "mentions"
+            | "eventChart"
+            | "user"
+        >;
+    };
+}
+
+export interface D2ProgramStageDataElementSchema {
+    name: "D2ProgramStageDataElement";
+    model: D2ProgramStageDataElement;
+    fields: {
+        access: D2Access;
+        allowFutureDate: boolean;
+        allowProvidedElsewhere: boolean;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        compulsory: boolean;
+        created: string;
+        dataElement: D2DataElementSchema;
+        displayInReports: boolean;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        programStage: D2ProgramStageSchema;
+        publicAccess: string;
+        renderOptionsAsRadio: boolean;
+        renderType: any;
+        skipSynchronization: boolean;
+        sortOrder: number;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramStageDataElement, keyof D2ProgramStageDataElement>;
+        $identifiable: Preset<D2ProgramStageDataElement, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramStageDataElement, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramStageDataElement,
+            | "displayInReports"
+            | "code"
+            | "skipSynchronization"
+            | "lastUpdated"
+            | "renderOptionsAsRadio"
+            | "id"
+            | "allowFutureDate"
+            | "renderType"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "dataElement"
+            | "compulsory"
+            | "allowProvidedElsewhere"
+            | "sortOrder"
+        >;
+        $owner: Preset<
+            D2ProgramStageDataElement,
+            | "displayInReports"
+            | "code"
+            | "skipSynchronization"
+            | "lastUpdated"
+            | "renderOptionsAsRadio"
+            | "id"
+            | "allowFutureDate"
+            | "renderType"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "dataElement"
+            | "compulsory"
+            | "allowProvidedElsewhere"
+            | "sortOrder"
+        >;
+    };
+}
+
+export interface D2InterpretationCommentSchema {
+    name: "D2InterpretationComment";
+    model: D2InterpretationComment;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        mentions: any[];
+        name: string;
+        publicAccess: string;
+        text: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2InterpretationComment, keyof D2InterpretationComment>;
+        $identifiable: Preset<D2InterpretationComment, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2InterpretationComment, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2InterpretationComment,
+            "created" | "lastUpdated" | "mentions" | "text" | "id" | "user"
+        >;
+        $owner: Preset<
+            D2InterpretationComment,
+            "created" | "lastUpdated" | "mentions" | "text" | "id" | "user"
+        >;
+    };
+}
+
+export interface D2TrackedEntityProgramIndicatorDimensionSchema {
+    name: "D2TrackedEntityProgramIndicatorDimension";
+    model: D2TrackedEntityProgramIndicatorDimension;
+    fields: {
+        filter: string;
+        legendSet: D2LegendSetSchema;
+        programIndicator: D2ProgramIndicatorSchema;
+    };
+    fieldPresets: {
+        $all: Preset<
+            D2TrackedEntityProgramIndicatorDimension,
+            keyof D2TrackedEntityProgramIndicatorDimension
+        >;
+        $identifiable: Preset<
+            D2TrackedEntityProgramIndicatorDimension,
+            FieldPresets["identifiable"]
+        >;
+        $nameable: Preset<D2TrackedEntityProgramIndicatorDimension, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2TrackedEntityProgramIndicatorDimension,
+            "filter" | "legendSet" | "programIndicator"
+        >;
+        $owner: Preset<
+            D2TrackedEntityProgramIndicatorDimension,
+            "filter" | "legendSet" | "programIndicator"
+        >;
+    };
+}
+
+export interface D2ProgramStageInstanceSchema {
+    name: "D2ProgramStageInstance";
+    model: D2ProgramStageInstance;
+    fields: {
+        access: D2Access;
+        assignedUser: D2UserSchema;
+        attributeOptionCombo: D2CategoryOptionComboSchema;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        comments: any[];
+        completed: boolean;
+        completedBy: string;
+        completedDate: string;
+        creatableInSearchScope: boolean;
+        created: string;
+        createdAtClient: string;
+        deleted: boolean;
+        displayName: string;
+        dueDate: string;
+        eventDataValues: any[];
+        eventDate: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        geometry: D2Geometry;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedAtClient: string;
+        lastUpdatedBy: D2UserSchema;
+        messageConversations: D2MessageConversationSchema[];
+        name: string;
+        organisationUnit: D2OrganisationUnitSchema;
+        programInstance: D2ProgramInstanceSchema;
+        programStage: D2ProgramStageSchema;
+        publicAccess: string;
+        relationshipItems: any[];
+        status: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";
+        storedBy: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramStageInstance, keyof D2ProgramStageInstance>;
+        $identifiable: Preset<D2ProgramStageInstance, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramStageInstance, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramStageInstance,
+            | "code"
+            | "storedBy"
+            | "organisationUnit"
+            | "dueDate"
+            | "createdAtClient"
+            | "messageConversations"
+            | "lastUpdated"
+            | "eventDataValues"
+            | "relationshipItems"
+            | "id"
+            | "assignedUser"
+            | "programStage"
+            | "comments"
+            | "created"
+            | "completedDate"
+            | "programInstance"
+            | "deleted"
+            | "attributeOptionCombo"
+            | "geometry"
+            | "completedBy"
+            | "status"
+            | "lastUpdatedAtClient"
+            | "eventDate"
+        >;
+        $owner: Preset<
+            D2ProgramStageInstance,
+            | "code"
+            | "storedBy"
+            | "organisationUnit"
+            | "dueDate"
+            | "createdAtClient"
+            | "messageConversations"
+            | "lastUpdated"
+            | "eventDataValues"
+            | "id"
+            | "assignedUser"
+            | "programStage"
+            | "comments"
+            | "created"
+            | "completedDate"
+            | "programInstance"
+            | "deleted"
+            | "attributeOptionCombo"
+            | "geometry"
+            | "completedBy"
+            | "status"
+            | "lastUpdatedAtClient"
+            | "eventDate"
+        >;
+    };
+}
+
+export interface D2CategoryDimensionSchema {
+    name: "D2CategoryDimension";
+    model: D2CategoryDimension;
+    fields: { category: D2CategorySchema; categoryOptions: D2CategoryOptionSchema[] };
+    fieldPresets: {
+        $all: Preset<D2CategoryDimension, keyof D2CategoryDimension>;
+        $identifiable: Preset<D2CategoryDimension, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2CategoryDimension, FieldPresets["nameable"]>;
+        $persisted: Preset<D2CategoryDimension, "categoryOptions" | "category">;
+        $owner: Preset<D2CategoryDimension, "categoryOptions" | "category">;
+    };
+}
+
+export interface D2UserCredentialsSchema {
+    name: "D2UserCredentials";
+    model: D2UserCredentials;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        catDimensionConstraints: D2CategorySchema[];
+        code: Id;
+        cogsDimensionConstraints: D2CategoryOptionGroupSetSchema[];
+        created: string;
+        disabled: boolean;
+        displayName: string;
+        externalAccess: boolean;
+        externalAuth: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        invitation: boolean;
+        lastLogin: string;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        ldapId: string;
+        name: string;
+        openId: string;
+        password: string;
+        passwordLastUpdated: string;
+        publicAccess: string;
+        selfRegistered: boolean;
+        translations: D2Translation[];
+        twoFA: boolean;
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        userInfo: D2UserSchema;
+        userRoles: D2UserAuthorityGroupSchema[];
+        username: string;
+    };
+    fieldPresets: {
+        $all: Preset<D2UserCredentials, keyof D2UserCredentials>;
+        $identifiable: Preset<D2UserCredentials, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2UserCredentials, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2UserCredentials,
+            | "lastLogin"
+            | "userInfo"
+            | "code"
+            | "openId"
+            | "externalAuth"
+            | "cogsDimensionConstraints"
+            | "catDimensionConstraints"
+            | "lastUpdated"
+            | "password"
+            | "ldapId"
+            | "disabled"
+            | "id"
+            | "twoFA"
+            | "passwordLastUpdated"
+            | "lastUpdatedBy"
+            | "invitation"
+            | "created"
+            | "selfRegistered"
+            | "userRoles"
+            | "user"
+            | "username"
+        >;
+        $owner: Preset<
+            D2UserCredentials,
+            | "lastLogin"
+            | "userInfo"
+            | "code"
+            | "openId"
+            | "externalAuth"
+            | "cogsDimensionConstraints"
+            | "catDimensionConstraints"
+            | "lastUpdated"
+            | "password"
+            | "ldapId"
+            | "disabled"
+            | "id"
+            | "twoFA"
+            | "passwordLastUpdated"
+            | "lastUpdatedBy"
+            | "invitation"
+            | "created"
+            | "selfRegistered"
+            | "userRoles"
+            | "user"
+            | "username"
+        >;
     };
 }
 
@@ -13645,7 +13953,7 @@ export interface D2ColorSchema {
     model: D2Color;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         color: string;
         created: string;
@@ -13693,24 +14001,162 @@ export interface D2ColorSchema {
     };
 }
 
-export interface D2CategoryOptionGroupSetDimensionSchema {
-    name: "D2CategoryOptionGroupSetDimension";
-    model: D2CategoryOptionGroupSetDimension;
+export interface D2ProgramInstanceSchema {
+    name: "D2ProgramInstance";
+    model: D2ProgramInstance;
     fields: {
-        categoryOptionGroupSet: D2CategoryOptionGroupSetSchema;
-        categoryOptionGroups: D2CategoryOptionGroupSchema[];
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        completedBy: string;
+        created: string;
+        createdAtClient: string;
+        deleted: boolean;
+        displayName: string;
+        endDate: string;
+        enrollmentDate: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        followup: boolean;
+        geometry: D2Geometry;
+        href: string;
+        id: Id;
+        incidentDate: string;
+        lastUpdated: string;
+        lastUpdatedAtClient: string;
+        lastUpdatedBy: D2UserSchema;
+        messageConversations: D2MessageConversationSchema[];
+        name: string;
+        organisationUnit: D2OrganisationUnitSchema;
+        program: D2ProgramSchema;
+        programStageInstances: D2ProgramStageInstanceSchema[];
+        publicAccess: string;
+        relationshipItems: any[];
+        status: "ACTIVE" | "COMPLETED" | "CANCELLED";
+        storedBy: string;
+        trackedEntityComments: any[];
+        trackedEntityInstance: D2TrackedEntityInstanceSchema;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2CategoryOptionGroupSetDimension, keyof D2CategoryOptionGroupSetDimension>;
-        $identifiable: Preset<D2CategoryOptionGroupSetDimension, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2CategoryOptionGroupSetDimension, FieldPresets["nameable"]>;
+        $all: Preset<D2ProgramInstance, keyof D2ProgramInstance>;
+        $identifiable: Preset<D2ProgramInstance, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramInstance, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2CategoryOptionGroupSetDimension,
-            "categoryOptionGroups" | "categoryOptionGroupSet"
+            D2ProgramInstance,
+            | "storedBy"
+            | "endDate"
+            | "organisationUnit"
+            | "enrollmentDate"
+            | "createdAtClient"
+            | "program"
+            | "messageConversations"
+            | "trackedEntityComments"
+            | "lastUpdated"
+            | "relationshipItems"
+            | "id"
+            | "created"
+            | "programStageInstances"
+            | "trackedEntityInstance"
+            | "followup"
+            | "deleted"
+            | "geometry"
+            | "incidentDate"
+            | "completedBy"
+            | "status"
+            | "lastUpdatedAtClient"
         >;
         $owner: Preset<
-            D2CategoryOptionGroupSetDimension,
-            "categoryOptionGroups" | "categoryOptionGroupSet"
+            D2ProgramInstance,
+            | "storedBy"
+            | "endDate"
+            | "organisationUnit"
+            | "enrollmentDate"
+            | "createdAtClient"
+            | "program"
+            | "messageConversations"
+            | "trackedEntityComments"
+            | "lastUpdated"
+            | "id"
+            | "created"
+            | "trackedEntityInstance"
+            | "followup"
+            | "deleted"
+            | "geometry"
+            | "incidentDate"
+            | "completedBy"
+            | "status"
+            | "lastUpdatedAtClient"
+        >;
+    };
+}
+
+export interface D2FileResourceSchema {
+    name: "D2FileResource";
+    model: D2FileResource;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        contentLength: string;
+        contentMd5: string;
+        contentType: string;
+        created: string;
+        displayName: string;
+        domain: "DATA_VALUE" | "PUSH_ANALYSIS" | "DOCUMENT" | "MESSAGE_ATTACHMENT" | "USER_AVATAR";
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        hasMultipleStorageFiles: boolean;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        storageStatus: "NONE" | "PENDING" | "FAILED" | "STORED";
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2FileResource, keyof D2FileResource>;
+        $identifiable: Preset<D2FileResource, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2FileResource, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2FileResource,
+            | "contentMd5"
+            | "code"
+            | "lastUpdated"
+            | "id"
+            | "contentType"
+            | "lastUpdatedBy"
+            | "created"
+            | "domain"
+            | "hasMultipleStorageFiles"
+            | "name"
+            | "contentLength"
+            | "user"
+        >;
+        $owner: Preset<
+            D2FileResource,
+            | "contentMd5"
+            | "code"
+            | "lastUpdated"
+            | "id"
+            | "contentType"
+            | "lastUpdatedBy"
+            | "created"
+            | "domain"
+            | "hasMultipleStorageFiles"
+            | "name"
+            | "contentLength"
+            | "user"
         >;
     };
 }
@@ -13720,7 +14166,7 @@ export interface D2LegendSchema {
     model: D2Legend;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         color: string;
         created: string;
@@ -13788,6 +14234,8 @@ export interface D2ProgramTrackedEntityAttributeDimensionItemSchema {
             | "AVERAGE_SUM_ORG_UNIT"
             | "LAST"
             | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
             | "COUNT"
             | "STDDEV"
             | "VARIANCE"
@@ -13797,7 +14245,7 @@ export interface D2ProgramTrackedEntityAttributeDimensionItemSchema {
             | "CUSTOM"
             | "DEFAULT";
         attribute: D2TrackedEntityAttributeSchema;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         description: string;
@@ -13855,12 +14303,39 @@ export interface D2ProgramTrackedEntityAttributeDimensionItemSchema {
     };
 }
 
+export interface D2TrackedEntityDataElementDimensionSchema {
+    name: "D2TrackedEntityDataElementDimension";
+    model: D2TrackedEntityDataElementDimension;
+    fields: {
+        dataElement: D2DataElementSchema;
+        filter: string;
+        legendSet: D2LegendSetSchema;
+        programStage: D2ProgramStageSchema;
+    };
+    fieldPresets: {
+        $all: Preset<
+            D2TrackedEntityDataElementDimension,
+            keyof D2TrackedEntityDataElementDimension
+        >;
+        $identifiable: Preset<D2TrackedEntityDataElementDimension, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2TrackedEntityDataElementDimension, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2TrackedEntityDataElementDimension,
+            "filter" | "legendSet" | "programStage" | "dataElement"
+        >;
+        $owner: Preset<
+            D2TrackedEntityDataElementDimension,
+            "filter" | "legendSet" | "programStage" | "dataElement"
+        >;
+    };
+}
+
 export interface D2RelationshipSchema {
     name: "D2Relationship";
     model: D2Relationship;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
         description: string;
@@ -13923,16 +14398,78 @@ export interface D2RelationshipSchema {
     };
 }
 
-export interface D2CategoryDimensionSchema {
-    name: "D2CategoryDimension";
-    model: D2CategoryDimension;
-    fields: { category: D2CategorySchema; categoryOptions: D2CategoryOptionSchema[] };
+export interface D2DataElementOperandSchema {
+    name: "D2DataElementOperand";
+    model: D2DataElementOperand;
+    fields: {
+        access: D2Access;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        attributeOptionCombo: D2CategoryOptionComboSchema;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        categoryOptionCombo: D2CategoryOptionComboSchema;
+        code: Id;
+        created: string;
+        dataElement: D2DataElementSchema;
+        description: string;
+        dimensionItem: string;
+        dimensionItemType:
+            | "DATA_ELEMENT"
+            | "DATA_ELEMENT_OPERAND"
+            | "INDICATOR"
+            | "REPORTING_RATE"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION"
+            | "OPTION_GROUP"
+            | "DATA_ELEMENT_GROUP"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY_OPTION_GROUP";
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendSet: D2LegendSetSchema;
+        legendSets: D2LegendSetSchema[];
+        name: string;
+        publicAccess: string;
+        shortName: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
     fieldPresets: {
-        $all: Preset<D2CategoryDimension, keyof D2CategoryDimension>;
-        $identifiable: Preset<D2CategoryDimension, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2CategoryDimension, FieldPresets["nameable"]>;
-        $persisted: Preset<D2CategoryDimension, "categoryOptions" | "category">;
-        $owner: Preset<D2CategoryDimension, "categoryOptions" | "category">;
+        $all: Preset<D2DataElementOperand, keyof D2DataElementOperand>;
+        $identifiable: Preset<D2DataElementOperand, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2DataElementOperand, FieldPresets["nameable"]>;
+        $persisted: Preset<D2DataElementOperand, "categoryOptionCombo" | "dataElement">;
+        $owner: Preset<D2DataElementOperand, "categoryOptionCombo" | "dataElement">;
     };
 }
 
@@ -13941,7 +14478,6 @@ export type D2Model =
     | D2AnalyticsPeriodBoundary
     | D2AnalyticsTableHook
     | D2Attribute
-    | D2AttributeValue
     | D2Category
     | D2CategoryCombo
     | D2CategoryDimension
@@ -13979,7 +14515,6 @@ export type D2Model =
     | D2ValidationNotificationTemplate
     | D2KeyJsonValue
     | D2FileResource
-    | D2ProgramStageInstance
     | D2Indicator
     | D2IndicatorGroup
     | D2IndicatorGroupSet
@@ -14031,8 +14566,10 @@ export type D2Model =
     | D2ReportingRate
     | D2Section
     | D2SMSCommand
+    | D2ProgramStageInstance
     | D2SqlView
     | D2TrackedEntityAttribute
+    | D2TrackedEntityAttributeValue
     | D2TrackedEntityInstance
     | D2TrackedEntityInstanceFilter
     | D2TrackedEntityType
@@ -14045,7 +14582,8 @@ export type D2Model =
     | D2UserAuthorityGroup
     | D2ValidationResult
     | D2ValidationRule
-    | D2ValidationRuleGroup;
+    | D2ValidationRuleGroup
+    | D2Visualization;
 
 export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
     predictors: {
@@ -14900,42 +15438,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             },
         ],
     },
-    attributeValues: {
-        klass: "org.hisp.dhis.attribute.AttributeValue",
-        shareable: false,
-        metadata: false,
-        plural: "attributeValues",
-        displayName: "Attribute Value",
-        collectionName: "attributeValues",
-        nameableObject: false,
-        translatable: false,
-        identifiableObject: false,
-        dataShareable: false,
-        name: "attributeValue",
-        persisted: true,
-        embeddedObject: false,
-        properties: [
-            {
-                name: "lastUpdated",
-                fieldName: "lastUpdated",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "attribute",
-                fieldName: "attribute",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.attribute.Attribute",
-            },
-            { name: "value", fieldName: "value", propertyType: "TEXT", klass: "java.lang.String" },
-            {
-                name: "created",
-                fieldName: "created",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-        ],
-    },
     categories: {
         klass: "org.hisp.dhis.category.Category",
         shareable: true,
@@ -15070,6 +15572,12 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 fieldName: "lastUpdatedBy",
                 propertyType: "REFERENCE",
                 klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "programStage",
+                fieldName: "programStage",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.program.ProgramStage",
             },
             {
                 name: "userGroupAccess",
@@ -16084,6 +16592,12 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "org.hisp.dhis.user.User",
             },
             {
+                name: "programStage",
+                fieldName: "programStage",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.program.ProgramStage",
+            },
+            {
                 name: "userGroupAccess",
                 fieldName: "userGroupAccesses",
                 propertyType: "COLLECTION",
@@ -16214,18 +16728,18 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
     },
     charts: {
         klass: "org.hisp.dhis.chart.Chart",
-        shareable: true,
+        shareable: false,
         metadata: true,
         relativeApiEndpoint: "/charts",
         plural: "charts",
         displayName: "Chart",
         collectionName: "charts",
         nameableObject: true,
-        translatable: true,
+        translatable: false,
         identifiableObject: true,
         dataShareable: false,
         name: "chart",
-        persisted: true,
+        persisted: false,
         embeddedObject: false,
         properties: [
             {
@@ -16739,6 +17253,12 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 fieldName: "legendSet",
                 propertyType: "REFERENCE",
                 klass: "org.hisp.dhis.legend.LegendSet",
+            },
+            {
+                name: "userOrgUnitType",
+                fieldName: "userOrgUnitType",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.analytics.UserOrgUnitType",
             },
             {
                 name: "rangeAxisMaxValue",
@@ -17356,6 +17876,12 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 itemPropertyType: "REFERENCE",
                 klass: "java.util.List",
                 itemKlass: "org.hisp.dhis.report.Report",
+            },
+            {
+                name: "visualization",
+                fieldName: "visualization",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.visualization.Visualization",
             },
             {
                 name: "code",
@@ -18104,6 +18630,12 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "org.hisp.dhis.legend.LegendSet",
             },
             {
+                name: "programStage",
+                fieldName: "programStage",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.program.ProgramStage",
+            },
+            {
                 name: "dataElement",
                 fieldName: "dataElement",
                 propertyType: "REFERENCE",
@@ -18423,6 +18955,12 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 fieldName: "lastUpdatedBy",
                 propertyType: "REFERENCE",
                 klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "programStage",
+                fieldName: "programStage",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.program.ProgramStage",
             },
             {
                 name: "userGroupAccess",
@@ -19247,6 +19785,12 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 fieldName: "mobile",
                 propertyType: "BOOLEAN",
                 klass: "java.lang.Boolean",
+            },
+            {
+                name: "openPeriodsAfterCoEndDate",
+                fieldName: "openPeriodsAfterCoEndDate",
+                propertyType: "INTEGER",
+                klass: "java.lang.Integer",
             },
             {
                 name: "periodType",
@@ -20232,6 +20776,12 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "org.hisp.dhis.legend.LegendSet",
             },
             {
+                name: "userOrgUnitType",
+                fieldName: "userOrgUnitType",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.analytics.UserOrgUnitType",
+            },
+            {
                 name: "rangeAxisMaxValue",
                 fieldName: "rangeAxisMaxValue",
                 propertyType: "NUMBER",
@@ -20772,6 +21322,12 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 fieldName: "eventStatus",
                 propertyType: "CONSTANT",
                 klass: "org.hisp.dhis.event.EventStatus",
+            },
+            {
+                name: "userOrgUnitType",
+                fieldName: "userOrgUnitType",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.analytics.UserOrgUnitType",
             },
             {
                 name: "user",
@@ -21531,6 +22087,12 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 propertyType: "CONSTANT",
                 klass: "org.hisp.dhis.fileresource.FileResourceDomain",
             },
+            {
+                name: "hasMultipleStorageFiles",
+                fieldName: "hasMultipleStorageFiles",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
             { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
             {
                 name: "contentLength",
@@ -21538,122 +22100,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 propertyType: "TEXT",
                 klass: "java.lang.Long",
             },
-            {
-                name: "user",
-                fieldName: "user",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
-        ],
-    },
-    programStageInstances: {
-        klass: "org.hisp.dhis.program.ProgramStageInstance",
-        shareable: false,
-        metadata: false,
-        relativeApiEndpoint: "/programStageInstances",
-        plural: "programStageInstances",
-        displayName: "Program Stage Instance",
-        collectionName: "programStageInstances",
-        nameableObject: false,
-        translatable: false,
-        identifiableObject: true,
-        dataShareable: false,
-        name: "identifiableObject",
-        persisted: true,
-        embeddedObject: false,
-        properties: [
-            {
-                name: "favorite",
-                fieldName: "favorites",
-                propertyType: "COLLECTION",
-                itemPropertyType: "TEXT",
-                klass: "java.util.Set",
-                itemKlass: "java.lang.String",
-            },
-            {
-                name: "lastUpdatedBy",
-                fieldName: "lastUpdatedBy",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            {
-                name: "access",
-                fieldName: "access",
-                propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.security.acl.Access",
-            },
-            {
-                name: "userGroupAccess",
-                fieldName: "userGroupAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
-            },
-            {
-                name: "code",
-                fieldName: "code",
-                propertyType: "IDENTIFIER",
-                klass: "java.lang.String",
-            },
-            {
-                name: "created",
-                fieldName: "created",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "displayName",
-                fieldName: "displayName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "publicAccess",
-                fieldName: "publicAccess",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "attributeValue",
-                fieldName: "attributeValues",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
-            },
-            {
-                name: "externalAccess",
-                fieldName: "externalAccess",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "lastUpdated",
-                fieldName: "lastUpdated",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "translation",
-                fieldName: "translations",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.translation.Translation",
-            },
-            {
-                name: "userAccess",
-                fieldName: "userAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserAccess",
-            },
-            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
-            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
-            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
             {
                 name: "user",
                 fieldName: "user",
@@ -22349,6 +22795,12 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 itemKlass: "java.lang.String",
             },
             {
+                name: "visualization",
+                fieldName: "visualization",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.visualization.Visualization",
+            },
+            {
                 name: "code",
                 fieldName: "code",
                 propertyType: "IDENTIFIER",
@@ -22727,12 +23179,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "java.util.Date",
             },
             {
-                name: "continuousExecution",
-                fieldName: "continuousExecution",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
                 name: "translation",
                 fieldName: "translations",
                 propertyType: "COLLECTION",
@@ -22789,10 +23235,21 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "java.lang.String",
             },
             {
+                name: "schedulingType",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.scheduling.SchedulingType",
+            },
+            {
                 name: "lastRuntimeExecution",
                 fieldName: "lastRuntimeExecution",
                 propertyType: "TEXT",
                 klass: "java.lang.String",
+            },
+            {
+                name: "delay",
+                fieldName: "delay",
+                propertyType: "INTEGER",
+                klass: "java.lang.Integer",
             },
             {
                 name: "userAccess",
@@ -23347,18 +23804,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "java.lang.Boolean",
             },
             {
-                name: "colorScale",
-                fieldName: "colorScale",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "parentLevel",
-                fieldName: "parentLevel",
-                propertyType: "INTEGER",
-                klass: "java.lang.Integer",
-            },
-            {
                 name: "program",
                 fieldName: "program",
                 propertyType: "REFERENCE",
@@ -23386,12 +23831,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 itemPropertyType: "COMPLEX",
                 klass: "java.util.Set",
                 itemKlass: "org.hisp.dhis.translation.Translation",
-            },
-            {
-                name: "parentGraphMap",
-                fieldName: "parentGraphMap",
-                propertyType: "COMPLEX",
-                klass: "java.util.Map",
             },
             {
                 name: "eventCoordinateField",
@@ -23430,24 +23869,10 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 itemKlass: "org.hisp.dhis.interpretation.Interpretation",
             },
             {
-                name: "itemOrganisationUnitGroup",
-                fieldName: "itemOrganisationUnitGroups",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.List",
-                itemKlass: "org.hisp.dhis.organisationunit.OrganisationUnitGroup",
-            },
-            {
                 name: "displayDescription",
                 fieldName: "displayDescription",
                 propertyType: "TEXT",
                 klass: "java.lang.String",
-            },
-            {
-                name: "lastUpdatedBy",
-                fieldName: "lastUpdatedBy",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
             },
             {
                 name: "userGroupAccess",
@@ -23458,18 +23883,218 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 itemKlass: "org.hisp.dhis.user.UserGroupAccess",
             },
             {
+                name: "method",
+                fieldName: "method",
+                propertyType: "INTEGER",
+                klass: "java.lang.Integer",
+            },
+            {
+                name: "subscriber",
+                fieldName: "subscribers",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.Set",
+                itemKlass: "java.lang.String",
+            },
+            {
+                name: "renderingStrategy",
+                fieldName: "renderingStrategy",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.mapping.MapViewRenderingStrategy",
+            },
+            {
+                name: "labels",
+                fieldName: "labels",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "subtitle",
+                fieldName: "subtitle",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "sortOrder",
+                fieldName: "sortOrder",
+                propertyType: "INTEGER",
+                klass: "java.lang.Integer",
+            },
+            {
+                name: "shortName",
+                fieldName: "shortName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+            {
+                name: "topLimit",
+                fieldName: "topLimit",
+                propertyType: "INTEGER",
+                klass: "java.lang.Integer",
+            },
+            {
+                name: "startDate",
+                fieldName: "startDate",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "access",
+                fieldName: "access",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.security.acl.Access",
+            },
+            {
+                name: "userOrganisationUnitGrandChildren",
+                fieldName: "userOrganisationUnitGrandChildren",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "displayName",
+                fieldName: "displayName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "column",
+                fieldName: "columns",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.common.DimensionalObject",
+            },
+            {
+                name: "styleDataItem",
+                fieldName: "styleDataItem",
+                propertyType: "COMPLEX",
+                klass: "java.lang.Object",
+            },
+            {
+                name: "labelFontColor",
+                fieldName: "labelFontColor",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            { name: "layer", fieldName: "layer", propertyType: "TEXT", klass: "java.lang.String" },
+            {
+                name: "displayShortName",
+                fieldName: "displayShortName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "dataElementDimension",
+                fieldName: "dataElementDimensions",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.trackedentity.TrackedEntityDataElementDimension",
+            },
+            {
+                name: "formName",
+                fieldName: "formName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "period",
+                fieldName: "periods",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.period.Period",
+            },
+            {
+                name: "categoryDimension",
+                fieldName: "categoryDimensions",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.category.CategoryDimension",
+            },
+            {
+                name: "labelFontStyle",
+                fieldName: "labelFontStyle",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "radiusHigh",
+                fieldName: "radiusHigh",
+                propertyType: "INTEGER",
+                klass: "java.lang.Integer",
+            },
+            {
+                name: "hideTitle",
+                fieldName: "hideTitle",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "eventClustering",
+                fieldName: "eventClustering",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "colorLow",
+                fieldName: "colorLow",
+                propertyType: "COLOR",
+                klass: "java.lang.String",
+            },
+            {
+                name: "opacity",
+                fieldName: "opacity",
+                propertyType: "NUMBER",
+                klass: "java.lang.Double",
+            },
+            {
+                name: "config",
+                fieldName: "config",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "colorScale",
+                fieldName: "colorScale",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "parentLevel",
+                fieldName: "parentLevel",
+                propertyType: "INTEGER",
+                klass: "java.lang.Integer",
+            },
+            {
+                name: "parentGraphMap",
+                fieldName: "parentGraphMap",
+                propertyType: "COMPLEX",
+                klass: "java.util.Map",
+            },
+            {
+                name: "itemOrganisationUnitGroup",
+                fieldName: "itemOrganisationUnitGroups",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.organisationunit.OrganisationUnitGroup",
+            },
+            {
+                name: "lastUpdatedBy",
+                fieldName: "lastUpdatedBy",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
                 name: "programIndicatorDimension",
                 fieldName: "programIndicatorDimensions",
                 propertyType: "COLLECTION",
                 itemPropertyType: "COMPLEX",
                 klass: "java.util.List",
                 itemKlass: "org.hisp.dhis.trackedentity.TrackedEntityProgramIndicatorDimension",
-            },
-            {
-                name: "method",
-                fieldName: "method",
-                propertyType: "INTEGER",
-                klass: "java.lang.Integer",
             },
             {
                 name: "labelFontSize",
@@ -23482,14 +24107,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 fieldName: "created",
                 propertyType: "DATE",
                 klass: "java.util.Date",
-            },
-            {
-                name: "subscriber",
-                fieldName: "subscribers",
-                propertyType: "COLLECTION",
-                itemPropertyType: "TEXT",
-                klass: "java.util.Set",
-                itemKlass: "java.lang.String",
             },
             {
                 name: "colorHigh",
@@ -23538,24 +24155,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "java.lang.String",
             },
             {
-                name: "labels",
-                fieldName: "labels",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "subtitle",
-                fieldName: "subtitle",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "sortOrder",
-                fieldName: "sortOrder",
-                propertyType: "INTEGER",
-                klass: "java.lang.Integer",
-            },
-            {
                 name: "userAccess",
                 fieldName: "userAccesses",
                 propertyType: "COLLECTION",
@@ -23564,25 +24163,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 itemKlass: "org.hisp.dhis.user.UserAccess",
             },
             { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
-            {
-                name: "shortName",
-                fieldName: "shortName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
-            {
-                name: "topLimit",
-                fieldName: "topLimit",
-                propertyType: "INTEGER",
-                klass: "java.lang.Integer",
-            },
-            {
-                name: "startDate",
-                fieldName: "startDate",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
             {
                 name: "programStatus",
                 fieldName: "programStatus",
@@ -23626,36 +24206,10 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 itemKlass: "org.hisp.dhis.category.CategoryOptionGroupSetDimension",
             },
             {
-                name: "access",
-                fieldName: "access",
-                propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.security.acl.Access",
-            },
-            {
-                name: "userOrganisationUnitGrandChildren",
-                fieldName: "userOrganisationUnitGrandChildren",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
                 name: "hidden",
                 fieldName: "hidden",
                 propertyType: "BOOLEAN",
                 klass: "java.lang.Boolean",
-            },
-            {
-                name: "displayName",
-                fieldName: "displayName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "column",
-                fieldName: "columns",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.List",
-                itemKlass: "org.hisp.dhis.common.DimensionalObject",
             },
             {
                 name: "classes",
@@ -23670,20 +24224,8 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "java.lang.Boolean",
             },
             {
-                name: "styleDataItem",
-                fieldName: "styleDataItem",
-                propertyType: "COMPLEX",
-                klass: "java.lang.Object",
-            },
-            {
                 name: "description",
                 fieldName: "description",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "labelFontColor",
-                fieldName: "labelFontColor",
                 propertyType: "TEXT",
                 klass: "java.lang.String",
             },
@@ -23696,13 +24238,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 itemKlass: "org.hisp.dhis.organisationunit.OrganisationUnitGroupSetDimension",
             },
             { name: "title", fieldName: "title", propertyType: "TEXT", klass: "java.lang.String" },
-            { name: "layer", fieldName: "layer", propertyType: "TEXT", klass: "java.lang.String" },
-            {
-                name: "displayShortName",
-                fieldName: "displayShortName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
             {
                 name: "organisationUnitLevel",
                 fieldName: "organisationUnitLevels",
@@ -23736,28 +24271,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "org.hisp.dhis.period.RelativePeriods",
             },
             {
-                name: "dataElementDimension",
-                fieldName: "dataElementDimensions",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.List",
-                itemKlass: "org.hisp.dhis.trackedentity.TrackedEntityDataElementDimension",
-            },
-            {
-                name: "formName",
-                fieldName: "formName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "period",
-                fieldName: "periods",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.List",
-                itemKlass: "org.hisp.dhis.period.Period",
-            },
-            {
                 name: "organisationUnit",
                 fieldName: "organisationUnits",
                 propertyType: "COLLECTION",
@@ -23766,22 +24279,8 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 itemKlass: "org.hisp.dhis.organisationunit.OrganisationUnit",
             },
             {
-                name: "categoryDimension",
-                fieldName: "categoryDimensions",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.List",
-                itemKlass: "org.hisp.dhis.category.CategoryDimension",
-            },
-            {
                 name: "eventPointColor",
                 fieldName: "eventPointColor",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "labelFontStyle",
-                fieldName: "labelFontStyle",
                 propertyType: "TEXT",
                 klass: "java.lang.String",
             },
@@ -23832,34 +24331,10 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "java.lang.Integer",
             },
             {
-                name: "radiusHigh",
-                fieldName: "radiusHigh",
-                propertyType: "INTEGER",
-                klass: "java.lang.Integer",
-            },
-            {
                 name: "digitGroupSeparator",
                 fieldName: "digitGroupSeparator",
                 propertyType: "CONSTANT",
                 klass: "org.hisp.dhis.common.DigitGroupSeparator",
-            },
-            {
-                name: "hideTitle",
-                fieldName: "hideTitle",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "eventClustering",
-                fieldName: "eventClustering",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "colorLow",
-                fieldName: "colorLow",
-                propertyType: "COLOR",
-                klass: "java.lang.String",
             },
             {
                 name: "trackedEntityType",
@@ -23874,22 +24349,16 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "org.hisp.dhis.legend.LegendSet",
             },
             {
-                name: "opacity",
-                fieldName: "opacity",
-                propertyType: "NUMBER",
-                klass: "java.lang.Double",
+                name: "userOrgUnitType",
+                fieldName: "userOrgUnitType",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.analytics.UserOrgUnitType",
             },
             {
                 name: "user",
                 fieldName: "user",
                 propertyType: "REFERENCE",
                 klass: "org.hisp.dhis.user.User",
-            },
-            {
-                name: "config",
-                fieldName: "config",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
             },
         ],
     },
@@ -24922,6 +25391,12 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "org.hisp.dhis.user.User",
             },
             {
+                name: "programStage",
+                fieldName: "programStage",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.program.ProgramStage",
+            },
+            {
                 name: "userGroupAccess",
                 fieldName: "userGroupAccesses",
                 propertyType: "COLLECTION",
@@ -25770,6 +26245,12 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 fieldName: "lastUpdatedBy",
                 propertyType: "REFERENCE",
                 klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "programStage",
+                fieldName: "programStage",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.program.ProgramStage",
             },
             {
                 name: "userGroupAccess",
@@ -27352,16 +27833,16 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "java.lang.String",
             },
             {
-                name: "access",
-                fieldName: "access",
-                propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.security.acl.Access",
-            },
-            {
                 name: "storedBy",
                 fieldName: "storedBy",
                 propertyType: "TEXT",
                 klass: "java.lang.String",
+            },
+            {
+                name: "access",
+                fieldName: "access",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.security.acl.Access",
             },
             {
                 name: "endDate",
@@ -27442,7 +27923,7 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 itemKlass: "org.hisp.dhis.translation.Translation",
             },
             {
-                name: "relationshipItems",
+                name: "relationshipItem",
                 fieldName: "relationshipItems",
                 propertyType: "COLLECTION",
                 itemPropertyType: "COMPLEX",
@@ -27515,6 +27996,12 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             },
             { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
             {
+                name: "geometry",
+                fieldName: "geometry",
+                propertyType: "COMPLEX",
+                klass: "com.vividsolutions.jts.geom.Geometry",
+            },
+            {
                 name: "incidentDate",
                 fieldName: "incidentDate",
                 propertyType: "DATE",
@@ -27527,6 +28014,12 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "org.hisp.dhis.user.User",
             },
             { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+            {
+                name: "completedBy",
+                fieldName: "completedBy",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
             {
                 name: "status",
                 fieldName: "status",
@@ -27904,6 +28397,14 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 itemKlass: "java.lang.String",
             },
             {
+                name: "evaluationEnvironment",
+                fieldName: "programRuleActionEvaluationEnvironments",
+                propertyType: "COLLECTION",
+                itemPropertyType: "CONSTANT",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.programrule.ProgramRuleActionEvaluationEnvironment",
+            },
+            {
                 name: "code",
                 fieldName: "code",
                 propertyType: "IDENTIFIER",
@@ -28037,6 +28538,12 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 fieldName: "dataElement",
                 propertyType: "REFERENCE",
                 klass: "org.hisp.dhis.dataelement.DataElement",
+            },
+            {
+                name: "evaluationTime",
+                fieldName: "programRuleActionEvaluationTime",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.programrule.ProgramRuleActionEvaluationTime",
             },
             {
                 name: "userAccess",
@@ -28293,14 +28800,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "java.lang.Boolean",
             },
             {
-                name: "programTrackedEntityAttribute",
-                fieldName: "attributes",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.List",
-                itemKlass: "org.hisp.dhis.trackedentity.TrackedEntityAttribute",
-            },
-            {
                 name: "lastUpdated",
                 fieldName: "lastUpdated",
                 propertyType: "DATE",
@@ -28383,6 +28882,14 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 itemKlass: "org.hisp.dhis.user.UserAccess",
             },
             { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
+            {
+                name: "trackedEntityAttributes",
+                fieldName: "trackedEntityAttributes",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.trackedentity.TrackedEntityAttribute",
+            },
             {
                 name: "style",
                 fieldName: "style",
@@ -28678,6 +29185,12 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 fieldName: "displayGenerateEventBox",
                 propertyType: "BOOLEAN",
                 klass: "java.lang.Boolean",
+            },
+            {
+                name: "nextScheduleDate",
+                fieldName: "nextScheduleDate",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.dataelement.DataElement",
             },
             {
                 name: "validationStrategy",
@@ -30083,6 +30596,12 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "java.lang.String",
             },
             {
+                name: "visualization",
+                fieldName: "visualization",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.visualization.Visualization",
+            },
+            {
                 name: "access",
                 fieldName: "access",
                 propertyType: "COMPLEX",
@@ -30119,12 +30638,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "java.lang.Boolean",
             },
             {
-                name: "reportTable",
-                fieldName: "reportTable",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.reporttable.ReportTable",
-            },
-            {
                 name: "lastUpdated",
                 fieldName: "lastUpdated",
                 propertyType: "DATE",
@@ -30138,9 +30651,8 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             },
             {
                 name: "reportParams",
-                fieldName: "reportParams",
                 propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.reporttable.ReportParams",
+                klass: "org.hisp.dhis.visualization.ReportingParams",
             },
             {
                 name: "translation",
@@ -30206,18 +30718,18 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
     },
     reportTables: {
         klass: "org.hisp.dhis.reporttable.ReportTable",
-        shareable: true,
+        shareable: false,
         metadata: true,
         relativeApiEndpoint: "/reportTables",
         plural: "reportTables",
         displayName: "Report Table",
         collectionName: "reportTables",
         nameableObject: true,
-        translatable: true,
+        translatable: false,
         identifiableObject: true,
         dataShareable: false,
         name: "reportTable",
-        persisted: true,
+        persisted: false,
         embeddedObject: false,
         properties: [
             {
@@ -30719,6 +31231,12 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 fieldName: "legendSet",
                 propertyType: "REFERENCE",
                 klass: "org.hisp.dhis.legend.LegendSet",
+            },
+            {
+                name: "userOrgUnitType",
+                fieldName: "userOrgUnitType",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.analytics.UserOrgUnitType",
             },
             {
                 name: "user",
@@ -31322,6 +31840,246 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
         ],
     },
+    programStageInstances: {
+        klass: "org.hisp.dhis.program.ProgramStageInstance",
+        shareable: false,
+        metadata: false,
+        relativeApiEndpoint: "/programStageInstances",
+        plural: "programStageInstances",
+        displayName: "Program Stage Instance",
+        collectionName: "programStageInstances",
+        nameableObject: false,
+        translatable: false,
+        identifiableObject: true,
+        dataShareable: false,
+        name: "softDeletableObject",
+        persisted: true,
+        embeddedObject: false,
+        properties: [
+            {
+                name: "favorite",
+                fieldName: "favorites",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.Set",
+                itemKlass: "java.lang.String",
+            },
+            {
+                name: "code",
+                fieldName: "code",
+                propertyType: "IDENTIFIER",
+                klass: "java.lang.String",
+            },
+            {
+                name: "storedBy",
+                fieldName: "storedBy",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "access",
+                fieldName: "access",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.security.acl.Access",
+            },
+            {
+                name: "organisationUnit",
+                fieldName: "organisationUnit",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.organisationunit.OrganisationUnit",
+            },
+            {
+                name: "displayName",
+                fieldName: "displayName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "publicAccess",
+                fieldName: "publicAccess",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "dueDate",
+                fieldName: "dueDate",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "createdAtClient",
+                fieldName: "createdAtClient",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "messageConversations",
+                fieldName: "messageConversations",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.message.MessageConversation",
+            },
+            {
+                name: "externalAccess",
+                fieldName: "externalAccess",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "lastUpdated",
+                fieldName: "lastUpdated",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "eventDataValues",
+                fieldName: "eventDataValues",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.eventdatavalue.EventDataValue",
+            },
+            {
+                name: "translation",
+                fieldName: "translations",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.translation.Translation",
+            },
+            {
+                name: "relationshipItem",
+                fieldName: "relationshipItems",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.relationship.RelationshipItem",
+            },
+            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
+            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
+            {
+                name: "assignedUser",
+                fieldName: "assignedUser",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "lastUpdatedBy",
+                fieldName: "lastUpdatedBy",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "programStage",
+                fieldName: "programStage",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.program.ProgramStage",
+            },
+            {
+                name: "userGroupAccess",
+                fieldName: "userGroupAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
+            },
+            {
+                name: "comments",
+                fieldName: "comments",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.trackedentitycomment.TrackedEntityComment",
+            },
+            {
+                name: "created",
+                fieldName: "created",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            { name: "creatableInSearchScope", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+            {
+                name: "attributeValue",
+                fieldName: "attributeValues",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
+            },
+            { name: "completed", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+            {
+                name: "completedDate",
+                fieldName: "completedDate",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "programInstance",
+                fieldName: "programInstance",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.program.ProgramInstance",
+            },
+            {
+                name: "deleted",
+                fieldName: "deleted",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "userAccess",
+                fieldName: "userAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserAccess",
+            },
+            {
+                name: "attributeOptionCombo",
+                fieldName: "attributeOptionCombo",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.category.CategoryOptionCombo",
+            },
+            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
+            {
+                name: "geometry",
+                fieldName: "geometry",
+                propertyType: "COMPLEX",
+                klass: "com.vividsolutions.jts.geom.Geometry",
+            },
+            {
+                name: "user",
+                fieldName: "user",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+            {
+                name: "completedBy",
+                fieldName: "completedBy",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "status",
+                fieldName: "status",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.event.EventStatus",
+            },
+            {
+                name: "lastUpdatedAtClient",
+                fieldName: "lastUpdatedAtClient",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "eventDate",
+                fieldName: "executionDate",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+        ],
+    },
     sqlViews: {
         klass: "org.hisp.dhis.sqlview.SqlView",
         shareable: true,
@@ -31479,134 +32237,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
         embeddedObject: false,
         properties: [
             {
-                name: "programScope",
-                fieldName: "programScope",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "publicAccess",
-                fieldName: "publicAccess",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "lastUpdated",
-                fieldName: "lastUpdated",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "generated",
-                fieldName: "generated",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "translation",
-                fieldName: "translations",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.translation.Translation",
-            },
-            {
-                name: "valueType",
-                fieldName: "valueType",
-                propertyType: "CONSTANT",
-                klass: "org.hisp.dhis.common.ValueType",
-            },
-            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
-            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
-            {
-                name: "confidential",
-                fieldName: "confidential",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "displayDescription",
-                fieldName: "displayDescription",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "lastUpdatedBy",
-                fieldName: "lastUpdatedBy",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            {
-                name: "userGroupAccess",
-                fieldName: "userGroupAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
-            },
-            {
-                name: "created",
-                fieldName: "created",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "attributeValue",
-                fieldName: "attributeValues",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
-            },
-            {
-                name: "displayFormName",
-                fieldName: "displayFormName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "unique",
-                fieldName: "unique",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "userAccess",
-                fieldName: "userAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserAccess",
-            },
-            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
-            {
-                name: "legendSets",
-                fieldName: "legendSets",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.List",
-                itemKlass: "org.hisp.dhis.legend.LegendSet",
-            },
-            {
-                name: "style",
-                fieldName: "style",
-                propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.common.ObjectStyle",
-            },
-            {
-                name: "shortName",
-                fieldName: "shortName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
-            {
-                name: "dimensionItemType",
-                fieldName: "dimensionItemType",
-                propertyType: "CONSTANT",
-                klass: "org.hisp.dhis.common.DimensionItemType",
-            },
-            {
                 name: "favorite",
                 fieldName: "favorites",
                 propertyType: "COLLECTION",
@@ -31641,6 +32271,12 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             {
                 name: "displayName",
                 fieldName: "displayName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "publicAccess",
+                fieldName: "publicAccess",
                 propertyType: "TEXT",
                 klass: "java.lang.String",
             },
@@ -31681,16 +32317,42 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "java.lang.Integer",
             },
             {
+                name: "lastUpdated",
+                fieldName: "lastUpdated",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
                 name: "optionSet",
                 fieldName: "optionSet",
                 propertyType: "REFERENCE",
                 klass: "org.hisp.dhis.option.OptionSet",
             },
             {
+                name: "generated",
+                fieldName: "generated",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
                 name: "displayOnVisitSchedule",
                 fieldName: "displayOnVisitSchedule",
                 propertyType: "BOOLEAN",
                 klass: "java.lang.Boolean",
+            },
+            {
+                name: "translation",
+                fieldName: "translations",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.translation.Translation",
+            },
+            {
+                name: "valueType",
+                fieldName: "valueType",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.common.ValueType",
             },
             {
                 name: "formName",
@@ -31704,9 +32366,17 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 propertyType: "INTEGER",
                 klass: "java.lang.Integer",
             },
+            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
+            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
             {
                 name: "orgunitScope",
                 fieldName: "orgunitScope",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "confidential",
+                fieldName: "confidential",
                 propertyType: "BOOLEAN",
                 klass: "java.lang.Boolean",
             },
@@ -31717,6 +32387,26 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "java.lang.String",
             },
             {
+                name: "displayDescription",
+                fieldName: "displayDescription",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "lastUpdatedBy",
+                fieldName: "lastUpdatedBy",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "userGroupAccess",
+                fieldName: "userGroupAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
+            },
+            {
                 name: "expression",
                 fieldName: "expression",
                 propertyType: "TEXT",
@@ -31724,15 +32414,70 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             },
             { name: "dimensionItem", propertyType: "TEXT", klass: "java.lang.String" },
             {
+                name: "created",
+                fieldName: "created",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "attributeValue",
+                fieldName: "attributeValues",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
+            },
+            {
+                name: "displayFormName",
+                fieldName: "displayFormName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "unique",
+                fieldName: "unique",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "userAccess",
+                fieldName: "userAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserAccess",
+            },
+            {
                 name: "inherit",
                 fieldName: "inherit",
                 propertyType: "BOOLEAN",
                 klass: "java.lang.Boolean",
             },
+            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
             {
                 name: "legendSet",
                 propertyType: "REFERENCE",
                 klass: "org.hisp.dhis.legend.LegendSet",
+            },
+            {
+                name: "legendSets",
+                fieldName: "legendSets",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.legend.LegendSet",
+            },
+            {
+                name: "style",
+                fieldName: "style",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.common.ObjectStyle",
+            },
+            {
+                name: "shortName",
+                fieldName: "shortName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
             },
             {
                 name: "user",
@@ -31740,7 +32485,63 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 propertyType: "REFERENCE",
                 klass: "org.hisp.dhis.user.User",
             },
+            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
             { name: "optionSetValue", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+            {
+                name: "dimensionItemType",
+                fieldName: "dimensionItemType",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.common.DimensionItemType",
+            },
+        ],
+    },
+    trackedEntityAttributeValues: {
+        klass: "org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue",
+        shareable: false,
+        metadata: false,
+        relativeApiEndpoint: "/trackedEntityAttributeValues",
+        plural: "trackedEntityAttributeValues",
+        displayName: "Tracked Entity Attribute Value",
+        collectionName: "trackedEntityAttributeValues",
+        nameableObject: false,
+        translatable: false,
+        identifiableObject: false,
+        dataShareable: false,
+        name: "trackedEntityAttributeValue",
+        persisted: true,
+        embeddedObject: false,
+        properties: [
+            {
+                name: "lastUpdated",
+                fieldName: "lastUpdated",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "storedBy",
+                fieldName: "storedBy",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "created",
+                fieldName: "created",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            { name: "value", fieldName: "value", propertyType: "TEXT", klass: "java.lang.String" },
+            {
+                name: "trackedEntityAttribute",
+                fieldName: "attribute",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.trackedentity.TrackedEntityAttribute",
+            },
+            {
+                name: "trackedEntityInstance",
+                fieldName: "entityInstance",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.trackedentity.TrackedEntityInstance",
+            },
         ],
     },
     trackedEntityInstances: {
@@ -31846,7 +32647,7 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 itemKlass: "org.hisp.dhis.translation.Translation",
             },
             {
-                name: "relationshipItems",
+                name: "relationshipItem",
                 fieldName: "relationshipItems",
                 propertyType: "COLLECTION",
                 itemPropertyType: "COMPLEX",
@@ -32147,7 +32948,7 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "java.lang.String",
             },
             {
-                name: "trackedEntityTypeAttributes",
+                name: "trackedEntityTypeAttribute",
                 fieldName: "trackedEntityTypeAttributes",
                 propertyType: "COLLECTION",
                 itemPropertyType: "REFERENCE",
@@ -33708,6 +34509,672 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
         ],
     },
+    visualizations: {
+        klass: "org.hisp.dhis.visualization.Visualization",
+        shareable: true,
+        metadata: true,
+        relativeApiEndpoint: "/visualizations",
+        plural: "visualizations",
+        displayName: "Visualization",
+        collectionName: "visualizations",
+        nameableObject: true,
+        translatable: true,
+        identifiableObject: true,
+        dataShareable: true,
+        name: "visualization",
+        persisted: true,
+        embeddedObject: false,
+        properties: [
+            {
+                name: "dataElementGroupSetDimension",
+                fieldName: "dataElementGroupSetDimensions",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.dataelement.DataElementGroupSetDimension",
+            },
+            {
+                name: "orgUnitField",
+                fieldName: "orgUnitField",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "endDate",
+                fieldName: "endDate",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "baseLineValue",
+                fieldName: "baseLineValue",
+                propertyType: "NUMBER",
+                klass: "java.lang.Double",
+            },
+            {
+                name: "publicAccess",
+                fieldName: "publicAccess",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "userOrganisationUnitChildren",
+                fieldName: "userOrganisationUnitChildren",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "legendDisplayStyle",
+                fieldName: "legendDisplayStyle",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.legend.LegendDisplayStyle",
+            },
+            {
+                name: "type",
+                fieldName: "type",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.visualization.VisualizationType",
+            },
+            {
+                name: "hideEmptyColumns",
+                fieldName: "hideEmptyColumns",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "measureCriteria",
+                fieldName: "measureCriteria",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "lastUpdated",
+                fieldName: "lastUpdated",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            { name: "subscribed", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+            {
+                name: "attributeDimension",
+                fieldName: "attributeDimensions",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.trackedentity.TrackedEntityAttributeDimension",
+            },
+            {
+                name: "translation",
+                fieldName: "translations",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.translation.Translation",
+            },
+            {
+                name: "yearlySerie",
+                fieldName: "yearlySeries",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.List",
+                itemKlass: "java.lang.String",
+            },
+            {
+                name: "userOrganisationUnit",
+                fieldName: "userOrganisationUnit",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
+            {
+                name: "rowSubTotals",
+                fieldName: "rowSubTotals",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "filterDimension",
+                fieldName: "filterDimensions",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.List",
+                itemKlass: "java.lang.String",
+            },
+            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
+            {
+                name: "interpretation",
+                fieldName: "interpretations",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.interpretation.Interpretation",
+            },
+            {
+                name: "displayDescription",
+                fieldName: "displayDescription",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "visualizationPeriodName",
+                fieldName: "visualizationPeriodName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "userGroupAccess",
+                fieldName: "userGroupAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
+            },
+            {
+                name: "domainAxisLabel",
+                fieldName: "domainAxisLabel",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "subscriber",
+                fieldName: "subscribers",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.Set",
+                itemKlass: "java.lang.String",
+            },
+            {
+                name: "cumulativeValues",
+                fieldName: "cumulativeValues",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "axis",
+                fieldName: "optionalAxes",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.visualization.Axis",
+            },
+            {
+                name: "showDimensionLabels",
+                fieldName: "showDimensionLabels",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "sortOrder",
+                fieldName: "sortOrder",
+                propertyType: "INTEGER",
+                klass: "java.lang.Integer",
+            },
+            {
+                name: "subtitle",
+                fieldName: "subtitle",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "fontSize",
+                fieldName: "fontSize",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.common.FontSize",
+            },
+            {
+                name: "rangeAxisDecimals",
+                fieldName: "rangeAxisDecimals",
+                propertyType: "INTEGER",
+                klass: "java.lang.Integer",
+            },
+            {
+                name: "shortName",
+                fieldName: "shortName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+            {
+                name: "topLimit",
+                fieldName: "topLimit",
+                propertyType: "INTEGER",
+                klass: "java.lang.Integer",
+            },
+            {
+                name: "startDate",
+                fieldName: "startDate",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "access",
+                fieldName: "access",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.security.acl.Access",
+            },
+            {
+                name: "userOrganisationUnitGrandChildren",
+                fieldName: "userOrganisationUnitGrandChildren",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "displayName",
+                fieldName: "displayName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "column",
+                fieldName: "columns",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.common.DimensionalObject",
+            },
+            {
+                name: "displayShortName",
+                fieldName: "displayShortName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "percentStackedValues",
+                fieldName: "percentStackedValues",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "noSpaceBetweenColumns",
+                fieldName: "noSpaceBetweenColumns",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "dataElementDimension",
+                fieldName: "dataElementDimensions",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.trackedentity.TrackedEntityDataElementDimension",
+            },
+            {
+                name: "rangeAxisSteps",
+                fieldName: "rangeAxisSteps",
+                propertyType: "INTEGER",
+                klass: "java.lang.Integer",
+            },
+            {
+                name: "formName",
+                fieldName: "formName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "period",
+                fieldName: "periods",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.period.Period",
+            },
+            {
+                name: "categoryDimension",
+                fieldName: "categoryDimensions",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.category.CategoryDimension",
+            },
+            {
+                name: "showHierarchy",
+                fieldName: "showHierarchy",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "reportingParams",
+                fieldName: "reportingParams",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.visualization.ReportingParams",
+            },
+            {
+                name: "hideTitle",
+                fieldName: "hideTitle",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "rowDimension",
+                fieldName: "rowDimensions",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.List",
+                itemKlass: "java.lang.String",
+            },
+            {
+                name: "colorSet",
+                fieldName: "colorSet",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.color.ColorSet",
+            },
+            {
+                name: "skipRounding",
+                fieldName: "skipRounding",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "showData",
+                fieldName: "showData",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "numberType",
+                fieldName: "numberType",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.analytics.NumberType",
+            },
+            {
+                name: "hideEmptyRows",
+                fieldName: "hideEmptyRows",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "parentGraphMap",
+                fieldName: "parentGraphMap",
+                propertyType: "COMPLEX",
+                klass: "java.util.Map",
+            },
+            {
+                name: "itemOrganisationUnitGroup",
+                fieldName: "itemOrganisationUnitGroups",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.organisationunit.OrganisationUnitGroup",
+            },
+            {
+                name: "displayDensity",
+                fieldName: "displayDensity",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.common.DisplayDensity",
+            },
+            {
+                name: "lastUpdatedBy",
+                fieldName: "lastUpdatedBy",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "programIndicatorDimension",
+                fieldName: "programIndicatorDimensions",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.trackedentity.TrackedEntityProgramIndicatorDimension",
+            },
+            {
+                name: "created",
+                fieldName: "created",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "rangeAxisLabel",
+                fieldName: "rangeAxisLabel",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "regressionType",
+                fieldName: "regressionType",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.common.RegressionType",
+            },
+            {
+                name: "attributeValue",
+                fieldName: "attributeValues",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
+            },
+            {
+                name: "columnDimension",
+                fieldName: "columnDimensions",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.List",
+                itemKlass: "java.lang.String",
+            },
+            {
+                name: "completedOnly",
+                fieldName: "completedOnly",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "colTotals",
+                fieldName: "colTotals",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "displayFormName",
+                fieldName: "displayFormName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "userAccess",
+                fieldName: "userAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserAccess",
+            },
+            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
+            {
+                name: "hideEmptyRowItems",
+                fieldName: "hideEmptyRowItems",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.common.HideEmptyItemStrategy",
+            },
+            {
+                name: "favorite",
+                fieldName: "favorites",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.Set",
+                itemKlass: "java.lang.String",
+            },
+            {
+                name: "aggregationType",
+                fieldName: "aggregationType",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.analytics.AggregationType",
+            },
+            {
+                name: "dataDimensionItem",
+                fieldName: "dataDimensionItems",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.common.DataDimensionItem",
+            },
+            {
+                name: "code",
+                fieldName: "code",
+                propertyType: "IDENTIFIER",
+                klass: "java.lang.String",
+            },
+            {
+                name: "categoryOptionGroupSetDimension",
+                fieldName: "categoryOptionGroupSetDimensions",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.category.CategoryOptionGroupSetDimension",
+            },
+            {
+                name: "hideSubtitle",
+                fieldName: "hideSubtitle",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "description",
+                fieldName: "description",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "organisationUnitGroupSetDimension",
+                fieldName: "organisationUnitGroupSetDimensions",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.organisationunit.OrganisationUnitGroupSetDimension",
+            },
+            { name: "title", fieldName: "title", propertyType: "TEXT", klass: "java.lang.String" },
+            {
+                name: "hideLegend",
+                fieldName: "hideLegend",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "externalAccess",
+                fieldName: "externalAccess",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "rangeAxisMinValue",
+                fieldName: "rangeAxisMinValue",
+                propertyType: "NUMBER",
+                klass: "java.lang.Double",
+            },
+            {
+                name: "organisationUnitLevel",
+                fieldName: "organisationUnitLevels",
+                propertyType: "COLLECTION",
+                itemPropertyType: "INTEGER",
+                klass: "java.util.List",
+                itemKlass: "java.lang.Integer",
+            },
+            {
+                name: "legendDisplayStrategy",
+                fieldName: "legendDisplayStrategy",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.legend.LegendDisplayStrategy",
+            },
+            {
+                name: "colSubTotals",
+                fieldName: "colSubTotals",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "relativePeriods",
+                fieldName: "relatives",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.period.RelativePeriods",
+            },
+            {
+                name: "targetLineLabel",
+                fieldName: "targetLineLabel",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "organisationUnit",
+                fieldName: "organisationUnits",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.organisationunit.OrganisationUnit",
+            },
+            {
+                name: "rowTotals",
+                fieldName: "rowTotals",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "timeField",
+                fieldName: "timeField",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "targetLineValue",
+                fieldName: "targetLineValue",
+                propertyType: "NUMBER",
+                klass: "java.lang.Double",
+            },
+            {
+                name: "filter",
+                fieldName: "filters",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.common.DimensionalObject",
+            },
+            {
+                name: "row",
+                fieldName: "rows",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.common.DimensionalObject",
+            },
+            {
+                name: "baseLineLabel",
+                fieldName: "baseLineLabel",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "digitGroupSeparator",
+                fieldName: "digitGroupSeparator",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.common.DigitGroupSeparator",
+            },
+            {
+                name: "regression",
+                fieldName: "regression",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "legendSet",
+                fieldName: "legendSet",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.legend.LegendSet",
+            },
+            {
+                name: "userOrgUnitType",
+                fieldName: "userOrgUnitType",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.analytics.UserOrgUnitType",
+            },
+            {
+                name: "rangeAxisMaxValue",
+                fieldName: "rangeAxisMaxValue",
+                propertyType: "NUMBER",
+                klass: "java.lang.Double",
+            },
+            {
+                name: "user",
+                fieldName: "user",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+        ],
+    },
 };
 
 export type D2ModelSchemas = {
@@ -33715,7 +35182,6 @@ export type D2ModelSchemas = {
     analyticsPeriodBoundaries: D2AnalyticsPeriodBoundarySchema;
     analyticsTableHooks: D2AnalyticsTableHookSchema;
     attributes: D2AttributeSchema;
-    attributeValues: D2AttributeValueSchema;
     categories: D2CategorySchema;
     categoryCombos: D2CategoryComboSchema;
     categoryDimensions: D2CategoryDimensionSchema;
@@ -33753,7 +35219,6 @@ export type D2ModelSchemas = {
     validationNotificationTemplates: D2ValidationNotificationTemplateSchema;
     dataStores: D2KeyJsonValueSchema;
     fileResources: D2FileResourceSchema;
-    programStageInstances: D2ProgramStageInstanceSchema;
     indicators: D2IndicatorSchema;
     indicatorGroups: D2IndicatorGroupSchema;
     indicatorGroupSets: D2IndicatorGroupSetSchema;
@@ -33805,8 +35270,10 @@ export type D2ModelSchemas = {
     reportingRates: D2ReportingRateSchema;
     sections: D2SectionSchema;
     smsCommands: D2SMSCommandSchema;
+    programStageInstances: D2ProgramStageInstanceSchema;
     sqlViews: D2SqlViewSchema;
     trackedEntityAttributes: D2TrackedEntityAttributeSchema;
+    trackedEntityAttributeValues: D2TrackedEntityAttributeValueSchema;
     trackedEntityInstances: D2TrackedEntityInstanceSchema;
     trackedEntityInstanceFilters: D2TrackedEntityInstanceFilterSchema;
     trackedEntityTypes: D2TrackedEntityTypeSchema;
@@ -33820,4 +35287,5 @@ export type D2ModelSchemas = {
     validationResults: D2ValidationResultSchema;
     validationRules: D2ValidationRuleSchema;
     validationRuleGroups: D2ValidationRuleGroupSchema;
+    visualizations: D2VisualizationSchema;
 };

--- a/src/2.34/schemas.ts
+++ b/src/2.34/schemas.ts
@@ -13,15 +13,21 @@ import {
     D2DimensionalKeywords,
     D2Expression,
     D2RelationshipConstraint,
+    D2ReportingParams,
+    D2Axis,
 } from "../schemas/base";
 
-export type D2UserAuthorityGroup = {
+export type D2AnalyticsPeriodBoundary = {
     access: D2Access;
+    analyticsPeriodBoundaryType:
+        | "BEFORE_START_OF_REPORTING_PERIOD"
+        | "BEFORE_END_OF_REPORTING_PERIOD"
+        | "AFTER_START_OF_REPORTING_PERIOD"
+        | "AFTER_END_OF_REPORTING_PERIOD";
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    authorities: string[];
+    boundaryTarget: string;
     code: Id;
     created: string;
-    description: string;
     displayName: string;
     externalAccess: boolean;
     favorite: boolean;
@@ -31,12 +37,58 @@ export type D2UserAuthorityGroup = {
     lastUpdated: string;
     lastUpdatedBy: D2User;
     name: string;
+    offsetPeriodType: string;
+    offsetPeriods: number;
     publicAccess: string;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
-    users: D2User[];
+};
+
+export type D2AnalyticsTableHook = {
+    access: D2Access;
+    analyticsTableType:
+        | "DATA_VALUE"
+        | "COMPLETENESS"
+        | "COMPLETENESS_TARGET"
+        | "ORG_UNIT_TARGET"
+        | "EVENT"
+        | "ENROLLMENT"
+        | "VALIDATION_RESULT";
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    phase: "RESOURCE_TABLE_POPULATED" | "ANALYTICS_TABLE_POPULATED";
+    publicAccess: string;
+    resourceTableType:
+        | "ORG_UNIT_STRUCTURE"
+        | "DATA_SET_ORG_UNIT_CATEGORY"
+        | "CATEGORY_OPTION_COMBO_NAME"
+        | "DATA_ELEMENT_GROUP_SET_STRUCTURE"
+        | "INDICATOR_GROUP_SET_STRUCTURE"
+        | "ORG_UNIT_GROUP_SET_STRUCTURE"
+        | "CATEGORY_STRUCTURE"
+        | "DATA_ELEMENT_STRUCTURE"
+        | "PERIOD_STRUCTURE"
+        | "DATE_PERIOD_STRUCTURE"
+        | "DATA_ELEMENT_CATEGORY_OPTION_COMBO"
+        | "DATA_APPROVAL_REMAP_LEVEL"
+        | "DATA_APPROVAL_MIN_LEVEL";
+    sql: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
 };
 
 export type D2Attribute = {
@@ -126,359 +178,7 @@ export type D2Attribute = {
         | "IMAGE";
 };
 
-export type D2User = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    avatar: D2FileResource;
-    birthday: string;
-    code: Id;
-    created: string;
-    dataViewOrganisationUnits: D2OrganisationUnit[];
-    displayName: string;
-    education: string;
-    email: string;
-    employer: string;
-    externalAccess: boolean;
-    facebookMessenger: string;
-    favorite: boolean;
-    favorites: string[];
-    firstName: string;
-    gender: string;
-    href: string;
-    id: Id;
-    interests: string;
-    introduction: string;
-    jobTitle: string;
-    languages: string;
-    lastCheckedInterpretations: string;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    nationality: string;
-    organisationUnits: D2OrganisationUnit[];
-    phoneNumber: string;
-    publicAccess: string;
-    skype: string;
-    surname: string;
-    teiSearchOrganisationUnits: D2OrganisationUnit[];
-    telegram: string;
-    translations: D2Translation[];
-    twitter: string;
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userCredentials: D2UserCredentials;
-    userGroupAccesses: D2UserGroupAccess[];
-    userGroups: D2UserGroup[];
-    welcomeMessage: string;
-    whatsApp: string;
-};
-
-export type D2UserGroup = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    managedByGroups: D2UserGroup[];
-    managedGroups: D2UserGroup[];
-    name: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    users: D2User[];
-};
-
-export type D2Expression = {
-    description: string;
-    expression: string;
-    missingValueStrategy: "SKIP_IF_ANY_VALUE_MISSING" | "SKIP_IF_ALL_VALUES_MISSING" | "NEVER_SKIP";
-    slidingWindow: boolean;
-};
-
-export type D2ExternalFileResource = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2SqlView = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    cacheStrategy:
-        | "NO_CACHE"
-        | "CACHE_1_MINUTE"
-        | "CACHE_5_MINUTES"
-        | "CACHE_10_MINUTES"
-        | "CACHE_15_MINUTES"
-        | "CACHE_30_MINUTES"
-        | "CACHE_1_HOUR"
-        | "CACHE_6AM_TOMORROW"
-        | "CACHE_TWO_WEEKS"
-        | "RESPECT_SYSTEM_SETTING";
-    code: Id;
-    created: string;
-    description: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    sqlQuery: string;
-    translations: D2Translation[];
-    type: "VIEW" | "MATERIALIZED_VIEW" | "QUERY";
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2Constant = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    shortName: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    value: number;
-};
-
-export type D2OAuth2Client = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    cid: Id;
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    grantTypes: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    redirectUris: string[];
-    secret: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2Option = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: string;
-    created: string;
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    optionSet: D2OptionSet;
-    publicAccess: string;
-    shortName: string;
-    sortOrder: number;
-    style: D2Style;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2JobConfiguration = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    configurable: boolean;
-    created: string;
-    cronExpression: string;
-    delay: number;
-    displayName: string;
-    enabled: boolean;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    jobParameters: string;
-    jobStatus:
-        | "RUNNING"
-        | "COMPLETED"
-        | "STOPPED"
-        | "SCHEDULED"
-        | "DISABLED"
-        | "FAILED"
-        | "NOT_STARTED";
-    jobType:
-        | "DATA_STATISTICS"
-        | "DATA_INTEGRITY"
-        | "RESOURCE_TABLE"
-        | "ANALYTICS_TABLE"
-        | "CONTINUOUS_ANALYTICS_TABLE"
-        | "DATA_SYNC"
-        | "TRACKER_PROGRAMS_DATA_SYNC"
-        | "EVENT_PROGRAMS_DATA_SYNC"
-        | "FILE_RESOURCE_CLEANUP"
-        | "IMAGE_PROCESSING"
-        | "META_DATA_SYNC"
-        | "SMS_SEND"
-        | "SEND_SCHEDULED_MESSAGE"
-        | "PROGRAM_NOTIFICATIONS"
-        | "VALIDATION_RESULTS_NOTIFICATION"
-        | "CREDENTIALS_EXPIRY_ALERT"
-        | "MONITORING"
-        | "PUSH_ANALYSIS"
-        | "PREDICTOR"
-        | "DATA_SET_NOTIFICATION"
-        | "REMOVE_EXPIRED_RESERVED_VALUES"
-        | "TRACKER_IMPORT_JOB"
-        | "TRACKER_IMPORT_NOTIFICATION_JOB"
-        | "TRACKER_IMPORT_RULE_ENGINE_JOB"
-        | "MOCK"
-        | "DATAVALUE_IMPORT"
-        | "ANALYTICSTABLE_UPDATE"
-        | "METADATA_IMPORT"
-        | "GML_IMPORT"
-        | "DATAVALUE_IMPORT_INTERNAL"
-        | "EVENT_IMPORT"
-        | "ENROLLMENT_IMPORT"
-        | "TEI_IMPORT"
-        | "LEADER_ELECTION"
-        | "LEADER_RENEWAL"
-        | "COMPLETE_DATA_SET_REGISTRATION_IMPORT"
-        | "PROGRAM_DATA_SYNC";
-    lastExecuted: string;
-    lastExecutedStatus:
-        | "RUNNING"
-        | "COMPLETED"
-        | "STOPPED"
-        | "SCHEDULED"
-        | "DISABLED"
-        | "FAILED"
-        | "NOT_STARTED";
-    lastRuntimeExecution: string;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    leaderOnlyJob: boolean;
-    name: string;
-    nextExecutionTime: string;
-    publicAccess: string;
-    schedulingType: "CRON" | "FIXED_DELAY";
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    userUid: string;
-};
-
-export type D2OptionSet = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    options: D2Option[];
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    valueType:
-        | "TEXT"
-        | "LONG_TEXT"
-        | "LETTER"
-        | "PHONE_NUMBER"
-        | "EMAIL"
-        | "BOOLEAN"
-        | "TRUE_ONLY"
-        | "DATE"
-        | "DATETIME"
-        | "TIME"
-        | "NUMBER"
-        | "UNIT_INTERVAL"
-        | "PERCENTAGE"
-        | "INTEGER"
-        | "INTEGER_POSITIVE"
-        | "INTEGER_NEGATIVE"
-        | "INTEGER_ZERO_OR_POSITIVE"
-        | "TRACKER_ASSOCIATE"
-        | "USERNAME"
-        | "COORDINATE"
-        | "ORGANISATION_UNIT"
-        | "AGE"
-        | "URL"
-        | "FILE_RESOURCE"
-        | "IMAGE";
-    version: number;
-};
-
-export type D2OptionGroupSet = {
+export type D2Category = {
     access: D2Access;
     aggregationType:
         | "SUM"
@@ -498,6 +198,8 @@ export type D2OptionGroupSet = {
         | "DEFAULT";
     allItems: boolean;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    categoryCombos: D2CategoryCombo[];
+    categoryOptions: D2CategoryOption[];
     code: Id;
     created: string;
     dataDimension: boolean;
@@ -540,8 +242,6 @@ export type D2OptionGroupSet = {
     lastUpdatedBy: D2User;
     legendSet: D2LegendSet;
     name: string;
-    optionGroups: D2OptionGroup[];
-    optionSet: D2OptionSet;
     programStage: D2ProgramStage;
     publicAccess: string;
     shortName: string;
@@ -551,358 +251,35 @@ export type D2OptionGroupSet = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2OptionGroup = {
-    access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "FIRST"
-        | "FIRST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
-    name: string;
-    optionSet: D2OptionSet;
-    options: D2Option[];
-    publicAccess: string;
-    shortName: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2LegendSet = {
+export type D2CategoryCombo = {
     access: D2Access;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    categories: D2Category[];
+    categoryOptionCombos: D2CategoryOptionCombo[];
     code: Id;
     created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    legends: D2Legend[];
-    name: string;
-    publicAccess: string;
-    symbolizer: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2ColorSet = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    colors: D2Color[];
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2OrganisationUnit = {
-    access: D2Access;
-    address: string;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "FIRST"
-        | "FIRST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    ancestors: D2OrganisationUnit[];
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    children: D2OrganisationUnit[];
-    closedDate: string;
-    code: Id;
-    comment: string;
-    contactPerson: string;
-    created: string;
-    dataSets: D2DataSet[];
-    description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    email: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    geometry: D2Geometry;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    leaf: boolean;
-    legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
-    level: number;
-    memberCount: number;
-    name: string;
-    openingDate: string;
-    organisationUnitGroups: D2OrganisationUnitGroup[];
-    parent: D2OrganisationUnit;
-    path: string;
-    phoneNumber: string;
-    programs: D2Program[];
-    publicAccess: string;
-    shortName: string;
-    translations: D2Translation[];
-    type: string;
-    url: string;
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    users: D2User[];
-};
-
-export type D2OrganisationUnitLevel = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    level: number;
-    name: string;
-    offlineLevels: number;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2OrganisationUnitGroup = {
-    access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "FIRST"
-        | "FIRST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    color: string;
-    created: string;
-    description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
-    formName: string;
-    geometry: D2Geometry;
-    groupSets: D2OrganisationUnitGroupSet[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
-    name: string;
-    organisationUnits: D2OrganisationUnit[];
-    publicAccess: string;
-    shortName: string;
-    symbol: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2OrganisationUnitGroupSet = {
-    access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "FIRST"
-        | "FIRST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    allItems: boolean;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    compulsory: boolean;
-    created: string;
-    dataDimension: boolean;
     dataDimensionType: "DISAGGREGATION" | "ATTRIBUTE";
-    description: string;
-    dimension: string;
-    dimensionType:
-        | "DATA_X"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "DATA_COLLAPSED"
-        | "CATEGORY_OPTION_COMBO"
-        | "ATTRIBUTE_OPTION_COMBO"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION_GROUP_SET"
-        | "DATA_ELEMENT_GROUP_SET"
-        | "ORGANISATION_UNIT_GROUP_SET"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY"
-        | "OPTION_GROUP_SET"
-        | "VALIDATION_RULE"
-        | "STATIC"
-        | "ORGANISATION_UNIT_LEVEL";
-    dimensionalKeywords: D2DimensionalKeywords;
-    displayDescription: string;
-    displayFormName: string;
     displayName: string;
-    displayShortName: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
-    filter: string;
-    formName: string;
     href: string;
     id: Id;
-    includeSubhierarchyInAnalytics: boolean;
-    items: any[];
+    isDefault: boolean;
     lastUpdated: string;
     lastUpdatedBy: D2User;
-    legendSet: D2LegendSet;
     name: string;
-    organisationUnitGroups: D2OrganisationUnitGroup[];
-    programStage: D2ProgramStage;
     publicAccess: string;
-    shortName: string;
+    skipTotal: boolean;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2CategoryDimension = {
+    category: D2Category;
+    categoryOptions: D2CategoryOption[];
 };
 
 export type D2CategoryOption = {
@@ -968,6 +345,70 @@ export type D2CategoryOption = {
     shortName: string;
     startDate: string;
     style: D2Style;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2CategoryOptionCombo = {
+    access: D2Access;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    categoryCombo: D2CategoryCombo;
+    categoryOptions: D2CategoryOption[];
+    code: Id;
+    created: string;
+    description: string;
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    ignoreApproval: boolean;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
+    name: string;
+    publicAccess: string;
+    shortName: string;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
@@ -1110,7 +551,12 @@ export type D2CategoryOptionGroupSet = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2Category = {
+export type D2CategoryOptionGroupSetDimension = {
+    categoryOptionGroupSet: D2CategoryOptionGroupSet;
+    categoryOptionGroups: D2CategoryOptionGroup[];
+};
+
+export type D2Chart = {
     access: D2Access;
     aggregationType:
         | "SUM"
@@ -1128,36 +574,155 @@ export type D2Category = {
         | "NONE"
         | "CUSTOM"
         | "DEFAULT";
-    allItems: boolean;
+    attributeDimensions: any[];
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    categoryCombos: D2CategoryCombo[];
-    categoryOptions: D2CategoryOption[];
+    baseLineLabel: string;
+    baseLineValue: number;
+    category: string;
+    categoryDimensions: D2CategoryDimension[];
+    categoryOptionGroupSetDimensions: D2CategoryOptionGroupSetDimension[];
+    code: Id;
+    colorSet: D2ColorSet;
+    columns: any[];
+    completedOnly: boolean;
+    created: string;
+    cumulativeValues: boolean;
+    dataDimensionItems: any[];
+    dataElementDimensions: D2TrackedEntityDataElementDimension[];
+    dataElementGroupSetDimensions: D2DataElementGroupSetDimension[];
+    description: string;
+    digitGroupSeparator: "COMMA" | "SPACE" | "NONE";
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    domainAxisLabel: string;
+    endDate: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    filterDimensions: string[];
+    filters: any[];
+    formName: string;
+    hideEmptyRowItems: "NONE" | "BEFORE_FIRST" | "AFTER_LAST" | "BEFORE_FIRST_AFTER_LAST" | "ALL";
+    hideLegend: boolean;
+    hideSubtitle: boolean;
+    hideTitle: boolean;
+    href: string;
+    id: Id;
+    interpretations: D2Interpretation[];
+    itemOrganisationUnitGroups: D2OrganisationUnitGroup[];
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendDisplayStrategy: "FIXED" | "BY_DATA_ITEM";
+    legendSet: D2LegendSet;
+    name: string;
+    noSpaceBetweenColumns: boolean;
+    orgUnitField: string;
+    organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimension[];
+    organisationUnitLevels: number[];
+    organisationUnits: D2OrganisationUnit[];
+    parentGraphMap: D2Map;
+    percentStackedValues: boolean;
+    periods: any[];
+    programIndicatorDimensions: D2TrackedEntityProgramIndicatorDimension[];
+    publicAccess: string;
+    rangeAxisDecimals: number;
+    rangeAxisLabel: string;
+    rangeAxisMaxValue: number;
+    rangeAxisMinValue: number;
+    rangeAxisSteps: number;
+    regressionType: "NONE" | "LINEAR" | "POLYNOMIAL" | "LOESS";
+    relativePeriods: any;
+    rows: any[];
+    series: string;
+    seriesItems: any[];
+    shortName: string;
+    showData: boolean;
+    sortOrder: number;
+    startDate: string;
+    subscribed: boolean;
+    subscribers: string[];
+    subtitle: string;
+    targetLineLabel: string;
+    targetLineValue: number;
+    timeField: string;
+    title: string;
+    topLimit: number;
+    translations: D2Translation[];
+    type:
+        | "COLUMN"
+        | "STACKED_COLUMN"
+        | "BAR"
+        | "STACKED_BAR"
+        | "LINE"
+        | "AREA"
+        | "PIE"
+        | "RADAR"
+        | "GAUGE"
+        | "YEAR_OVER_YEAR_LINE"
+        | "YEAR_OVER_YEAR_COLUMN"
+        | "SINGLE_VALUE";
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    userOrgUnitType: "DATA_CAPTURE" | "DATA_OUTPUT" | "TEI_SEARCH";
+    userOrganisationUnit: boolean;
+    userOrganisationUnitChildren: boolean;
+    userOrganisationUnitGrandChildren: boolean;
+    yearlySeries: string[];
+};
+
+export type D2Color = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    color: string;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ColorSet = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    colors: D2Color[];
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2Constant = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
-    dataDimension: boolean;
-    dataDimensionType: "DISAGGREGATION" | "ATTRIBUTE";
     description: string;
-    dimension: string;
-    dimensionType:
-        | "DATA_X"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "DATA_COLLAPSED"
-        | "CATEGORY_OPTION_COMBO"
-        | "ATTRIBUTE_OPTION_COMBO"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION_GROUP_SET"
-        | "DATA_ELEMENT_GROUP_SET"
-        | "ORGANISATION_UNIT_GROUP_SET"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY"
-        | "OPTION_GROUP_SET"
-        | "VALIDATION_RULE"
-        | "STATIC"
-        | "ORGANISATION_UNIT_LEVEL";
-    dimensionalKeywords: D2DimensionalKeywords;
     displayDescription: string;
     displayFormName: string;
     displayName: string;
@@ -1165,16 +730,42 @@ export type D2Category = {
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
-    filter: string;
     formName: string;
     href: string;
     id: Id;
-    items: any[];
     lastUpdated: string;
     lastUpdatedBy: D2User;
-    legendSet: D2LegendSet;
     name: string;
-    programStage: D2ProgramStage;
+    publicAccess: string;
+    shortName: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    value: number;
+};
+
+export type D2Dashboard = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    dashboardItems: D2DashboardItem[];
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    itemCount: number;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
     publicAccess: string;
     shortName: string;
     translations: D2Translation[];
@@ -1183,90 +774,104 @@ export type D2Category = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2CategoryCombo = {
+export type D2DashboardItem = {
+    access: D2Access;
+    appKey: string;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    chart: D2Chart;
+    code: Id;
+    contentCount: number;
+    created: string;
+    displayName: string;
+    eventChart: D2EventChart;
+    eventReport: D2EventReport;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    height: number;
+    href: string;
+    id: Id;
+    interpretationCount: number;
+    interpretationLikeCount: number;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    map: D2Map;
+    messages: boolean;
+    name: string;
+    publicAccess: string;
+    reportTable: D2ReportTable;
+    reports: D2Report[];
+    resources: D2Document[];
+    shape: "NORMAL" | "DOUBLE_WIDTH" | "FULL_WIDTH";
+    text: string;
+    translations: D2Translation[];
+    type:
+        | "VISUALIZATION"
+        | "CHART"
+        | "EVENT_CHART"
+        | "MAP"
+        | "REPORT_TABLE"
+        | "EVENT_REPORT"
+        | "USERS"
+        | "REPORTS"
+        | "RESOURCES"
+        | "TEXT"
+        | "MESSAGES"
+        | "APP";
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    users: D2User[];
+    visualization: D2Visualization;
+    width: number;
+    x: number;
+    y: number;
+};
+
+export type D2DataApprovalLevel = {
     access: D2Access;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    categories: D2Category[];
-    categoryOptionCombos: D2CategoryOptionCombo[];
+    categoryOptionGroupSet: D2CategoryOptionGroupSet;
     code: Id;
     created: string;
-    dataDimensionType: "DISAGGREGATION" | "ATTRIBUTE";
     displayName: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
     href: string;
     id: Id;
-    isDefault: boolean;
     lastUpdated: string;
     lastUpdatedBy: D2User;
+    level: number;
     name: string;
+    orgUnitLevel: number;
+    orgUnitLevelName: string;
     publicAccess: string;
-    skipTotal: boolean;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2CategoryOptionCombo = {
+export type D2DataApprovalWorkflow = {
     access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "FIRST"
-        | "FIRST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     categoryCombo: D2CategoryCombo;
-    categoryOptions: D2CategoryOption[];
     code: Id;
     created: string;
-    description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
-    displayDescription: string;
-    displayFormName: string;
+    dataApprovalLevels: D2DataApprovalLevel[];
+    dataSets: D2DataSet[];
     displayName: string;
-    displayShortName: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
-    formName: string;
     href: string;
     id: Id;
-    ignoreApproval: boolean;
     lastUpdated: string;
     lastUpdatedBy: D2User;
-    legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
     name: string;
+    periodType: string;
     publicAccess: string;
-    shortName: string;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
@@ -1508,78 +1113,13 @@ export type D2DataElementGroupSet = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2AnalyticsTableHook = {
-    access: D2Access;
-    analyticsTableType:
-        | "DATA_VALUE"
-        | "COMPLETENESS"
-        | "COMPLETENESS_TARGET"
-        | "ORG_UNIT_TARGET"
-        | "EVENT"
-        | "ENROLLMENT"
-        | "VALIDATION_RESULT";
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    phase: "RESOURCE_TABLE_POPULATED" | "ANALYTICS_TABLE_POPULATED";
-    publicAccess: string;
-    resourceTableType:
-        | "ORG_UNIT_STRUCTURE"
-        | "DATA_SET_ORG_UNIT_CATEGORY"
-        | "CATEGORY_OPTION_COMBO_NAME"
-        | "DATA_ELEMENT_GROUP_SET_STRUCTURE"
-        | "INDICATOR_GROUP_SET_STRUCTURE"
-        | "ORG_UNIT_GROUP_SET_STRUCTURE"
-        | "CATEGORY_STRUCTURE"
-        | "DATA_ELEMENT_STRUCTURE"
-        | "PERIOD_STRUCTURE"
-        | "DATE_PERIOD_STRUCTURE"
-        | "DATA_ELEMENT_CATEGORY_OPTION_COMBO"
-        | "DATA_APPROVAL_REMAP_LEVEL"
-        | "DATA_APPROVAL_MIN_LEVEL";
-    sql: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
+export type D2DataElementGroupSetDimension = {
+    dataElementGroupSet: D2DataElementGroupSet;
+    dataElementGroups: D2DataElementGroup[];
 };
 
-export type D2IndicatorType = {
+export type D2DataElementOperand = {
     access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    factor: number;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    number: boolean;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2Indicator = {
-    access: D2Access;
-    aggregateExportAttributeOptionCombo: string;
-    aggregateExportCategoryOptionCombo: string;
     aggregationType:
         | "SUM"
         | "AVERAGE"
@@ -1596,14 +1136,12 @@ export type D2Indicator = {
         | "NONE"
         | "CUSTOM"
         | "DEFAULT";
-    annualized: boolean;
+    attributeOptionCombo: D2CategoryOptionCombo;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    categoryOptionCombo: D2CategoryOptionCombo;
     code: Id;
     created: string;
-    dataSets: D2DataSet[];
-    decimals: number;
-    denominator: string;
-    denominatorDescription: string;
+    dataElement: D2DataElement;
     description: string;
     dimensionItem: string;
     dimensionItemType:
@@ -1621,11 +1159,9 @@ export type D2Indicator = {
         | "DATA_ELEMENT_GROUP"
         | "ORGANISATION_UNIT_GROUP"
         | "CATEGORY_OPTION_GROUP";
-    displayDenominatorDescription: string;
     displayDescription: string;
     displayFormName: string;
     displayName: string;
-    displayNumeratorDescription: string;
     displayShortName: string;
     externalAccess: boolean;
     favorite: boolean;
@@ -1633,66 +1169,13 @@ export type D2Indicator = {
     formName: string;
     href: string;
     id: Id;
-    indicatorGroups: D2IndicatorGroup[];
-    indicatorType: D2IndicatorType;
     lastUpdated: string;
     lastUpdatedBy: D2User;
     legendSet: D2LegendSet;
     legendSets: D2LegendSet[];
     name: string;
-    numerator: string;
-    numeratorDescription: string;
     publicAccess: string;
     shortName: string;
-    style: D2Style;
-    translations: D2Translation[];
-    url: string;
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2IndicatorGroup = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    indicatorGroupSet: D2IndicatorGroupSet;
-    indicators: D2Indicator[];
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2IndicatorGroupSet = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    compulsory: boolean;
-    created: string;
-    description: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    indicatorGroups: D2IndicatorGroup[];
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
@@ -1721,6 +1204,12 @@ export type D2DataEntryForm = {
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2DataInputPeriod = {
+    closingDate: string;
+    openingDate: string;
+    period: any;
 };
 
 export type D2DataSet = {
@@ -1813,6 +1302,12 @@ export type D2DataSet = {
     workflow: D2DataApprovalWorkflow;
 };
 
+export type D2DataSetElement = {
+    categoryCombo: D2CategoryCombo;
+    dataElement: D2DataElement;
+    dataSet: D2DataSet;
+};
+
 export type D2DataSetNotificationTemplate = {
     access: D2Access;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
@@ -1845,174 +1340,15 @@ export type D2DataSetNotificationTemplate = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2Section = {
+export type D2Document = {
     access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    categoryCombos: D2CategoryCombo[];
-    code: Id;
-    created: string;
-    dataElements: D2DataElement[];
-    dataSet: D2DataSet;
-    description: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    greyedFields: D2DataElementOperand[];
-    href: string;
-    id: Id;
-    indicators: D2Indicator[];
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    showColumnTotals: boolean;
-    showRowTotals: boolean;
-    sortOrder: number;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2DataApprovalLevel = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    categoryOptionGroupSet: D2CategoryOptionGroupSet;
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    level: number;
-    name: string;
-    orgUnitLevel: number;
-    orgUnitLevelName: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2DataApprovalWorkflow = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    categoryCombo: D2CategoryCombo;
-    code: Id;
-    created: string;
-    dataApprovalLevels: D2DataApprovalLevel[];
-    dataSets: D2DataSet[];
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    periodType: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2ValidationRule = {
-    access: D2Access;
-    aggregateExportAttributeOptionCombo: string;
-    aggregateExportCategoryOptionCombo: string;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "FIRST"
-        | "FIRST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
+    attachment: boolean;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
+    contentType: string;
     created: string;
-    description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
-    displayDescription: string;
-    displayFormName: string;
     displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    importance: "HIGH" | "MEDIUM" | "LOW";
-    instruction: string;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    leftSide: D2Expression;
-    legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
-    name: string;
-    notificationTemplates: D2ValidationNotificationTemplate[];
-    operator:
-        | "equal_to"
-        | "not_equal_to"
-        | "greater_than"
-        | "greater_than_or_equal_to"
-        | "less_than"
-        | "less_than_or_equal_to"
-        | "compulsory_pair"
-        | "exclusive_pair";
-    organisationUnitLevels: number[];
-    periodType: string;
-    publicAccess: string;
-    rightSide: D2Expression;
-    shortName: string;
-    skipFormValidation: boolean;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    validationRuleGroups: D2ValidationRuleGroup[];
-};
-
-export type D2ValidationRuleGroup = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    description: string;
-    displayName: string;
+    external: boolean;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
@@ -2023,596 +1359,10 @@ export type D2ValidationRuleGroup = {
     name: string;
     publicAccess: string;
     translations: D2Translation[];
+    url: string;
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
-    validationRules: D2ValidationRule[];
-};
-
-export type D2ValidationNotificationTemplate = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    messageTemplate: string;
-    name: string;
-    notifyParentOrganisationUnitOnly: boolean;
-    notifyUsersInHierarchyOnly: boolean;
-    publicAccess: string;
-    recipientUserGroups: D2UserGroup[];
-    sendStrategy: "COLLECTIVE_SUMMARY" | "SINGLE_NOTIFICATION";
-    subjectTemplate: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    validationRules: D2ValidationRule[];
-};
-
-export type D2TrackedEntityAttribute = {
-    access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "FIRST"
-        | "FIRST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    confidential: boolean;
-    created: string;
-    description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
-    displayDescription: string;
-    displayFormName: string;
-    displayInListNoProgram: boolean;
-    displayName: string;
-    displayOnVisitSchedule: boolean;
-    displayShortName: string;
-    expression: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    fieldMask: string;
-    formName: string;
-    generated: boolean;
-    href: string;
-    id: Id;
-    inherit: boolean;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
-    name: string;
-    optionSet: D2OptionSet;
-    optionSetValue: boolean;
-    orgunitScope: boolean;
-    pattern: string;
-    publicAccess: string;
-    shortName: string;
-    skipSynchronization: boolean;
-    sortOrderInListNoProgram: number;
-    sortOrderInVisitSchedule: number;
-    style: D2Style;
-    translations: D2Translation[];
-    unique: boolean;
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    valueType:
-        | "TEXT"
-        | "LONG_TEXT"
-        | "LETTER"
-        | "PHONE_NUMBER"
-        | "EMAIL"
-        | "BOOLEAN"
-        | "TRUE_ONLY"
-        | "DATE"
-        | "DATETIME"
-        | "TIME"
-        | "NUMBER"
-        | "UNIT_INTERVAL"
-        | "PERCENTAGE"
-        | "INTEGER"
-        | "INTEGER_POSITIVE"
-        | "INTEGER_NEGATIVE"
-        | "INTEGER_ZERO_OR_POSITIVE"
-        | "TRACKER_ASSOCIATE"
-        | "USERNAME"
-        | "COORDINATE"
-        | "ORGANISATION_UNIT"
-        | "AGE"
-        | "URL"
-        | "FILE_RESOURCE"
-        | "IMAGE";
-};
-
-export type D2TrackedEntityType = {
-    access: D2Access;
-    allowAuditLog: boolean;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    maxTeiCountToReturn: number;
-    minAttributesRequiredToSearch: number;
-    name: string;
-    publicAccess: string;
-    shortName: string;
-    style: D2Style;
-    trackedEntityTypeAttributes: D2TrackedEntityTypeAttribute[];
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2TrackedEntityTypeAttribute = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    displayInList: boolean;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    mandatory: boolean;
-    name: string;
-    publicAccess: string;
-    searchable: boolean;
-    trackedEntityAttribute: D2TrackedEntityAttribute;
-    trackedEntityType: D2TrackedEntityType;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    valueType:
-        | "TEXT"
-        | "LONG_TEXT"
-        | "LETTER"
-        | "PHONE_NUMBER"
-        | "EMAIL"
-        | "BOOLEAN"
-        | "TRUE_ONLY"
-        | "DATE"
-        | "DATETIME"
-        | "TIME"
-        | "NUMBER"
-        | "UNIT_INTERVAL"
-        | "PERCENTAGE"
-        | "INTEGER"
-        | "INTEGER_POSITIVE"
-        | "INTEGER_NEGATIVE"
-        | "INTEGER_ZERO_OR_POSITIVE"
-        | "TRACKER_ASSOCIATE"
-        | "USERNAME"
-        | "COORDINATE"
-        | "ORGANISATION_UNIT"
-        | "AGE"
-        | "URL"
-        | "FILE_RESOURCE"
-        | "IMAGE";
-};
-
-export type D2ProgramTrackedEntityAttributeGroup = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    attributes: D2ProgramTrackedEntityAttribute[];
-    code: Id;
-    created: string;
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    shortName: string;
-    translations: D2Translation[];
-    uniqunessType: "NONE" | "STRICT" | "VALIDATION";
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2ProgramStageSection = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    dataElements: D2DataElement[];
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    programIndicators: D2ProgramIndicator[];
-    programStage: D2ProgramStage;
-    publicAccess: string;
-    renderType: any;
-    shortName: string;
-    sortOrder: number;
-    style: D2Style;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2ProgramNotificationTemplate = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    deliveryChannels: never[];
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    messageTemplate: string;
-    name: string;
-    notificationRecipient:
-        | "TRACKED_ENTITY_INSTANCE"
-        | "ORGANISATION_UNIT_CONTACT"
-        | "USERS_AT_ORGANISATION_UNIT"
-        | "USER_GROUP"
-        | "PROGRAM_ATTRIBUTE"
-        | "DATA_ELEMENT";
-    notificationTrigger:
-        | "ENROLLMENT"
-        | "COMPLETION"
-        | "PROGRAM_RULE"
-        | "SCHEDULED_DAYS_DUE_DATE"
-        | "SCHEDULED_DAYS_INCIDENT_DATE"
-        | "SCHEDULED_DAYS_ENROLLMENT_DATE";
-    notifyParentOrganisationUnitOnly: boolean;
-    notifyUsersInHierarchyOnly: boolean;
-    publicAccess: string;
-    recipientDataElement: D2DataElement;
-    recipientProgramAttribute: D2TrackedEntityAttribute;
-    recipientUserGroup: D2UserGroup;
-    relativeScheduledDays: number;
-    subjectTemplate: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2SMSCommand = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    codeValueSeparator: string;
-    completenessMethod: "ALL_DATAVALUE" | "AT_LEAST_ONE_DATAVALUE" | "DO_NOT_MARK_COMPLETE";
-    created: string;
-    currentPeriodUsedForReporting: boolean;
-    dataset: D2DataSet;
-    defaultMessage: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    moreThanOneOrgUnitMessage: string;
-    name: string;
-    noUserMessage: string;
-    parserType:
-        | "KEY_VALUE_PARSER"
-        | "J2ME_PARSER"
-        | "ALERT_PARSER"
-        | "UNREGISTERED_PARSER"
-        | "TRACKED_ENTITY_REGISTRATION_PARSER"
-        | "PROGRAM_STAGE_DATAENTRY_PARSER"
-        | "EVENT_REGISTRATION_PARSER";
-    program: D2Program;
-    programStage: D2ProgramStage;
-    publicAccess: string;
-    receivedMessage: string;
-    separator: string;
-    smsCodes: any[];
-    specialCharacters: any[];
-    successMessage: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroup: D2UserGroup;
-    userGroupAccesses: D2UserGroupAccess[];
-    wrongFormatMessage: string;
-};
-
-export type D2ProgramStage = {
-    access: D2Access;
-    allowGenerateNextVisit: boolean;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    autoGenerateEvent: boolean;
-    blockEntryForm: boolean;
-    code: Id;
-    created: string;
-    dataEntryForm: D2DataEntryForm;
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayGenerateEventBox: boolean;
-    displayName: string;
-    displayShortName: string;
-    dueDateLabel: string;
-    enableUserAssignment: boolean;
-    executionDateLabel: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
-    formName: string;
-    formType: "DEFAULT" | "CUSTOM" | "SECTION" | "SECTION_MULTIORG";
-    generatedByEnrollmentDate: boolean;
-    hideDueDate: boolean;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    minDaysFromStart: number;
-    name: string;
-    nextScheduleDate: D2DataElement;
-    notificationTemplates: D2ProgramNotificationTemplate[];
-    openAfterEnrollment: boolean;
-    periodType: string;
-    preGenerateUID: boolean;
-    program: D2Program;
-    programStageDataElements: D2ProgramStageDataElement[];
-    programStageSections: D2ProgramStageSection[];
-    publicAccess: string;
-    remindCompleted: boolean;
-    repeatable: boolean;
-    reportDateToUse: string;
-    shortName: string;
-    sortOrder: number;
-    standardInterval: number;
-    style: D2Style;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    validationStrategy: "ON_COMPLETE" | "ON_UPDATE_AND_INSERT";
-};
-
-export type D2Program = {
-    access: D2Access;
-    accessLevel: "OPEN" | "AUDITED" | "PROTECTED" | "CLOSED";
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    categoryCombo: D2CategoryCombo;
-    code: Id;
-    completeEventsExpiryDays: number;
-    created: string;
-    dataEntryForm: D2DataEntryForm;
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayFrontPageList: boolean;
-    displayIncidentDate: boolean;
-    displayName: string;
-    displayShortName: string;
-    enrollmentDateLabel: string;
-    expiryDays: number;
-    expiryPeriodType: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
-    formName: string;
-    href: string;
-    id: Id;
-    ignoreOverdueEvents: boolean;
-    incidentDateLabel: string;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    maxTeiCountToReturn: number;
-    minAttributesRequiredToSearch: number;
-    name: string;
-    notificationTemplates: D2ProgramNotificationTemplate[];
-    onlyEnrollOnce: boolean;
-    organisationUnits: D2OrganisationUnit[];
-    programIndicators: D2ProgramIndicator[];
-    programRuleVariables: D2ProgramRuleVariable[];
-    programSections: D2ProgramSection[];
-    programStages: D2ProgramStage[];
-    programTrackedEntityAttributes: D2ProgramTrackedEntityAttribute[];
-    programType: "WITH_REGISTRATION" | "WITHOUT_REGISTRATION";
-    publicAccess: string;
-    registration: boolean;
-    relatedProgram: D2Program;
-    selectEnrollmentDatesInFuture: boolean;
-    selectIncidentDatesInFuture: boolean;
-    shortName: string;
-    skipOffline: boolean;
-    style: D2Style;
-    trackedEntityType: D2TrackedEntityType;
-    translations: D2Translation[];
-    useFirstStageDuringRegistration: boolean;
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    userRoles: D2UserAuthorityGroup[];
-    version: number;
-    withoutRegistration: boolean;
-};
-
-export type D2EventReport = {
-    access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "FIRST"
-        | "FIRST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    attributeDimensions: any[];
-    attributeValueDimension: D2TrackedEntityAttribute;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    categoryDimensions: D2CategoryDimension[];
-    categoryOptionGroupSetDimensions: D2CategoryOptionGroupSetDimension[];
-    code: Id;
-    colSubTotals: boolean;
-    colTotals: boolean;
-    collapseDataDimensions: boolean;
-    columnDimensions: string[];
-    columns: any[];
-    completedOnly: boolean;
-    created: string;
-    dataDimensionItems: any[];
-    dataElementDimensions: D2TrackedEntityDataElementDimension[];
-    dataElementGroupSetDimensions: D2DataElementGroupSetDimension[];
-    dataElementValueDimension: D2DataElement;
-    dataType: "AGGREGATED_VALUES" | "EVENTS";
-    description: string;
-    digitGroupSeparator: "COMMA" | "SPACE" | "NONE";
-    displayDensity: "COMFORTABLE" | "NORMAL" | "COMPACT" | "NONE";
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    endDate: string;
-    eventStatus: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    filterDimensions: string[];
-    filters: any[];
-    fontSize: "LARGE" | "NORMAL" | "SMALL";
-    formName: string;
-    hideEmptyRows: boolean;
-    hideNaData: boolean;
-    hideSubtitle: boolean;
-    hideTitle: boolean;
-    href: string;
-    id: Id;
-    interpretations: D2Interpretation[];
-    itemOrganisationUnitGroups: D2OrganisationUnitGroup[];
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    orgUnitField: string;
-    organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimension[];
-    organisationUnitLevels: number[];
-    organisationUnits: D2OrganisationUnit[];
-    outputType: "EVENT" | "ENROLLMENT" | "TRACKED_ENTITY_INSTANCE";
-    parentGraphMap: D2Map;
-    periods: any[];
-    program: D2Program;
-    programIndicatorDimensions: D2TrackedEntityProgramIndicatorDimension[];
-    programStage: D2ProgramStage;
-    programStatus: "ACTIVE" | "COMPLETED" | "CANCELLED";
-    publicAccess: string;
-    relativePeriods: any;
-    rowDimensions: string[];
-    rowSubTotals: boolean;
-    rowTotals: boolean;
-    rows: any[];
-    shortName: string;
-    showDimensionLabels: boolean;
-    showHierarchy: boolean;
-    sortOrder: number;
-    startDate: string;
-    subscribed: boolean;
-    subscribers: string[];
-    subtitle: string;
-    timeField: string;
-    title: string;
-    topLimit: number;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    userOrgUnitType: "DATA_CAPTURE" | "DATA_OUTPUT" | "TEI_SEARCH";
-    userOrganisationUnit: boolean;
-    userOrganisationUnitChildren: boolean;
-    userOrganisationUnitGrandChildren: boolean;
-    value: any;
 };
 
 export type D2EventChart = {
@@ -2741,39 +1491,195 @@ export type D2EventChart = {
     yearlySeries: string[];
 };
 
-export type D2ProgramSection = {
+export type D2EventReport = {
     access: D2Access;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    attributeDimensions: any[];
+    attributeValueDimension: D2TrackedEntityAttribute;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    categoryDimensions: D2CategoryDimension[];
+    categoryOptionGroupSetDimensions: D2CategoryOptionGroupSetDimension[];
     code: Id;
+    colSubTotals: boolean;
+    colTotals: boolean;
+    collapseDataDimensions: boolean;
+    columnDimensions: string[];
+    columns: any[];
+    completedOnly: boolean;
     created: string;
+    dataDimensionItems: any[];
+    dataElementDimensions: D2TrackedEntityDataElementDimension[];
+    dataElementGroupSetDimensions: D2DataElementGroupSetDimension[];
+    dataElementValueDimension: D2DataElement;
+    dataType: "AGGREGATED_VALUES" | "EVENTS";
     description: string;
+    digitGroupSeparator: "COMMA" | "SPACE" | "NONE";
+    displayDensity: "COMFORTABLE" | "NORMAL" | "COMPACT" | "NONE";
     displayDescription: string;
     displayFormName: string;
     displayName: string;
     displayShortName: string;
+    endDate: string;
+    eventStatus: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
+    filterDimensions: string[];
+    filters: any[];
+    fontSize: "LARGE" | "NORMAL" | "SMALL";
     formName: string;
+    hideEmptyRows: boolean;
+    hideNaData: boolean;
+    hideSubtitle: boolean;
+    hideTitle: boolean;
+    href: string;
+    id: Id;
+    interpretations: D2Interpretation[];
+    itemOrganisationUnitGroups: D2OrganisationUnitGroup[];
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    orgUnitField: string;
+    organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimension[];
+    organisationUnitLevels: number[];
+    organisationUnits: D2OrganisationUnit[];
+    outputType: "EVENT" | "ENROLLMENT" | "TRACKED_ENTITY_INSTANCE";
+    parentGraphMap: D2Map;
+    periods: any[];
+    program: D2Program;
+    programIndicatorDimensions: D2TrackedEntityProgramIndicatorDimension[];
+    programStage: D2ProgramStage;
+    programStatus: "ACTIVE" | "COMPLETED" | "CANCELLED";
+    publicAccess: string;
+    relativePeriods: any;
+    rowDimensions: string[];
+    rowSubTotals: boolean;
+    rowTotals: boolean;
+    rows: any[];
+    shortName: string;
+    showDimensionLabels: boolean;
+    showHierarchy: boolean;
+    sortOrder: number;
+    startDate: string;
+    subscribed: boolean;
+    subscribers: string[];
+    subtitle: string;
+    timeField: string;
+    title: string;
+    topLimit: number;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    userOrgUnitType: "DATA_CAPTURE" | "DATA_OUTPUT" | "TEI_SEARCH";
+    userOrganisationUnit: boolean;
+    userOrganisationUnitChildren: boolean;
+    userOrganisationUnitGrandChildren: boolean;
+    value: any;
+};
+
+export type D2Expression = {
+    description: string;
+    expression: string;
+    missingValueStrategy: "SKIP_IF_ANY_VALUE_MISSING" | "SKIP_IF_ALL_VALUES_MISSING" | "NEVER_SKIP";
+    slidingWindow: boolean;
+};
+
+export type D2ExternalFileResource = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
     href: string;
     id: Id;
     lastUpdated: string;
     lastUpdatedBy: D2User;
     name: string;
-    program: D2Program;
     publicAccess: string;
-    renderType: any;
-    shortName: string;
-    sortOrder: number;
-    style: D2Style;
-    trackedEntityAttributes: D2TrackedEntityAttribute[];
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2ProgramIndicator = {
+export type D2ExternalMapLayer = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    attribution: string;
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    imageFormat: "PNG" | "JPG";
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    layers: string;
+    legendSet: D2LegendSet;
+    legendSetUrl: string;
+    mapLayerPosition: "BASEMAP" | "OVERLAY";
+    mapService: "WMS" | "TMS" | "XYZ";
+    name: string;
+    publicAccess: string;
+    translations: D2Translation[];
+    url: string;
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2FileResource = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    contentLength: string;
+    contentMd5: string;
+    contentType: string;
+    created: string;
+    displayName: string;
+    domain: "DATA_VALUE" | "PUSH_ANALYSIS" | "DOCUMENT" | "MESSAGE_ATTACHMENT" | "USER_AVATAR";
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    hasMultipleStorageFiles: boolean;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    storageStatus: "NONE" | "PENDING" | "FAILED" | "STORED";
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2Icon = {};
+
+export type D2Indicator = {
     access: D2Access;
     aggregateExportAttributeOptionCombo: string;
     aggregateExportCategoryOptionCombo: string;
@@ -2793,12 +1699,14 @@ export type D2ProgramIndicator = {
         | "NONE"
         | "CUSTOM"
         | "DEFAULT";
-    analyticsPeriodBoundaries: D2AnalyticsPeriodBoundary[];
-    analyticsType: "EVENT" | "ENROLLMENT";
+    annualized: boolean;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
+    dataSets: D2DataSet[];
     decimals: number;
+    denominator: string;
+    denominatorDescription: string;
     description: string;
     dimensionItem: string;
     dimensionItemType:
@@ -2816,68 +1724,65 @@ export type D2ProgramIndicator = {
         | "DATA_ELEMENT_GROUP"
         | "ORGANISATION_UNIT_GROUP"
         | "CATEGORY_OPTION_GROUP";
+    displayDenominatorDescription: string;
     displayDescription: string;
     displayFormName: string;
-    displayInForm: boolean;
     displayName: string;
+    displayNumeratorDescription: string;
     displayShortName: string;
-    expression: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
-    filter: string;
     formName: string;
     href: string;
     id: Id;
+    indicatorGroups: D2IndicatorGroup[];
+    indicatorType: D2IndicatorType;
     lastUpdated: string;
     lastUpdatedBy: D2User;
     legendSet: D2LegendSet;
     legendSets: D2LegendSet[];
     name: string;
-    program: D2Program;
-    programIndicatorGroups: D2ProgramIndicatorGroup[];
+    numerator: string;
+    numeratorDescription: string;
     publicAccess: string;
     shortName: string;
     style: D2Style;
     translations: D2Translation[];
+    url: string;
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2RelationshipType = {
+export type D2IndicatorGroup = {
     access: D2Access;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    bidirectional: boolean;
     code: Id;
     created: string;
-    description: string;
-    displayFromToName: string;
     displayName: string;
-    displayToFromName: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
-    fromConstraint: D2RelationshipConstraint;
-    fromToName: string;
     href: string;
     id: Id;
+    indicatorGroupSet: D2IndicatorGroupSet;
+    indicators: D2Indicator[];
     lastUpdated: string;
     lastUpdatedBy: D2User;
     name: string;
     publicAccess: string;
-    toConstraint: D2RelationshipConstraint;
-    toFromName: string;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2ProgramIndicatorGroup = {
+export type D2IndicatorGroupSet = {
     access: D2Access;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
+    compulsory: boolean;
     created: string;
     description: string;
     displayName: string;
@@ -2886,10 +1791,10 @@ export type D2ProgramIndicatorGroup = {
     favorites: string[];
     href: string;
     id: Id;
+    indicatorGroups: D2IndicatorGroup[];
     lastUpdated: string;
     lastUpdatedBy: D2User;
     name: string;
-    programIndicators: D2ProgramIndicator[];
     publicAccess: string;
     translations: D2Translation[];
     user: D2User;
@@ -2897,12 +1802,77 @@ export type D2ProgramIndicatorGroup = {
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2ProgramRuleVariable = {
+export type D2IndicatorType = {
     access: D2Access;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
     created: string;
-    dataElement: D2DataElement;
+    displayName: string;
+    externalAccess: boolean;
+    factor: number;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    number: boolean;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2Interpretation = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    chart: D2Chart;
+    code: Id;
+    comments: D2InterpretationComment[];
+    created: string;
+    dataSet: D2DataSet;
+    displayName: string;
+    eventChart: D2EventChart;
+    eventReport: D2EventReport;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    likedBy: D2User[];
+    likes: number;
+    map: D2Map;
+    mentions: any[];
+    name: string;
+    organisationUnit: D2OrganisationUnit;
+    period: any;
+    publicAccess: string;
+    reportTable: D2ReportTable;
+    text: string;
+    translations: D2Translation[];
+    type:
+        | "VISUALIZATION"
+        | "REPORT_TABLE"
+        | "CHART"
+        | "MAP"
+        | "EVENT_REPORT"
+        | "EVENT_CHART"
+        | "DATASET_REPORT";
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    visualization: D2Visualization;
+};
+
+export type D2InterpretationComment = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
     displayName: string;
     externalAccess: boolean;
     favorite: boolean;
@@ -2911,36 +1881,157 @@ export type D2ProgramRuleVariable = {
     id: Id;
     lastUpdated: string;
     lastUpdatedBy: D2User;
+    mentions: any[];
     name: string;
-    program: D2Program;
-    programRuleVariableSourceType:
-        | "DATAELEMENT_NEWEST_EVENT_PROGRAM_STAGE"
-        | "DATAELEMENT_NEWEST_EVENT_PROGRAM"
-        | "DATAELEMENT_CURRENT_EVENT"
-        | "DATAELEMENT_PREVIOUS_EVENT"
-        | "CALCULATED_VALUE"
-        | "TEI_ATTRIBUTE";
-    programStage: D2ProgramStage;
     publicAccess: string;
-    trackedEntityAttribute: D2TrackedEntityAttribute;
+    text: string;
     translations: D2Translation[];
-    useCodeForOptionSet: boolean;
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2ProgramRuleAction = {
+export type D2JobConfiguration = {
     access: D2Access;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
-    content: string;
+    configurable: boolean;
     created: string;
-    data: string;
-    dataElement: D2DataElement;
+    cronExpression: string;
+    delay: number;
     displayName: string;
-    evaluationEnvironments: never[];
-    evaluationTime: "ON_DATA_ENTRY" | "ON_COMPLETE" | "ALWAYS";
+    enabled: boolean;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    jobParameters: string;
+    jobStatus:
+        | "RUNNING"
+        | "COMPLETED"
+        | "STOPPED"
+        | "SCHEDULED"
+        | "DISABLED"
+        | "FAILED"
+        | "NOT_STARTED";
+    jobType:
+        | "DATA_STATISTICS"
+        | "DATA_INTEGRITY"
+        | "RESOURCE_TABLE"
+        | "ANALYTICS_TABLE"
+        | "CONTINUOUS_ANALYTICS_TABLE"
+        | "DATA_SYNC"
+        | "TRACKER_PROGRAMS_DATA_SYNC"
+        | "EVENT_PROGRAMS_DATA_SYNC"
+        | "FILE_RESOURCE_CLEANUP"
+        | "IMAGE_PROCESSING"
+        | "META_DATA_SYNC"
+        | "SMS_SEND"
+        | "SEND_SCHEDULED_MESSAGE"
+        | "PROGRAM_NOTIFICATIONS"
+        | "VALIDATION_RESULTS_NOTIFICATION"
+        | "CREDENTIALS_EXPIRY_ALERT"
+        | "MONITORING"
+        | "PUSH_ANALYSIS"
+        | "PREDICTOR"
+        | "DATA_SET_NOTIFICATION"
+        | "REMOVE_EXPIRED_RESERVED_VALUES"
+        | "TRACKER_IMPORT_JOB"
+        | "TRACKER_IMPORT_NOTIFICATION_JOB"
+        | "TRACKER_IMPORT_RULE_ENGINE_JOB"
+        | "MOCK"
+        | "DATAVALUE_IMPORT"
+        | "ANALYTICSTABLE_UPDATE"
+        | "METADATA_IMPORT"
+        | "GML_IMPORT"
+        | "DATAVALUE_IMPORT_INTERNAL"
+        | "EVENT_IMPORT"
+        | "ENROLLMENT_IMPORT"
+        | "TEI_IMPORT"
+        | "LEADER_ELECTION"
+        | "LEADER_RENEWAL"
+        | "COMPLETE_DATA_SET_REGISTRATION_IMPORT"
+        | "PROGRAM_DATA_SYNC";
+    lastExecuted: string;
+    lastExecutedStatus:
+        | "RUNNING"
+        | "COMPLETED"
+        | "STOPPED"
+        | "SCHEDULED"
+        | "DISABLED"
+        | "FAILED"
+        | "NOT_STARTED";
+    lastRuntimeExecution: string;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    leaderOnlyJob: boolean;
+    name: string;
+    nextExecutionTime: string;
+    publicAccess: string;
+    schedulingType: "CRON" | "FIXED_DELAY";
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    userUid: string;
+};
+
+export type D2KeyJsonValue = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    key: string;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    namespace: string;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    value: string;
+};
+
+export type D2Legend = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    color: string;
+    created: string;
+    displayName: string;
+    endValue: number;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    image: string;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    startValue: number;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2LegendSet = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    displayName: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
@@ -2948,66 +2039,50 @@ export type D2ProgramRuleAction = {
     id: Id;
     lastUpdated: string;
     lastUpdatedBy: D2User;
-    location: string;
+    legends: D2Legend[];
     name: string;
-    option: D2Option;
-    optionGroup: D2OptionGroup;
-    programIndicator: D2ProgramIndicator;
-    programRule: D2ProgramRule;
-    programRuleActionType:
-        | "DISPLAYTEXT"
-        | "DISPLAYKEYVALUEPAIR"
-        | "HIDEFIELD"
-        | "HIDESECTION"
-        | "HIDEPROGRAMSTAGE"
-        | "ASSIGN"
-        | "SHOWWARNING"
-        | "WARNINGONCOMPLETE"
-        | "SHOWERROR"
-        | "ERRORONCOMPLETE"
-        | "CREATEEVENT"
-        | "SETMANDATORYFIELD"
-        | "SENDMESSAGE"
-        | "SCHEDULEMESSAGE"
-        | "HIDEOPTION"
-        | "SHOWOPTIONGROUP"
-        | "HIDEOPTIONGROUP";
-    programStage: D2ProgramStage;
-    programStageSection: D2ProgramStageSection;
     publicAccess: string;
-    templateUid: string;
-    trackedEntityAttribute: D2TrackedEntityAttribute;
+    symbolizer: string;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
 };
 
-export type D2ProgramRule = {
+export type D2Map = {
     access: D2Access;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    basemap: string;
     code: Id;
-    condition: string;
     created: string;
     description: string;
+    displayDescription: string;
+    displayFormName: string;
     displayName: string;
+    displayShortName: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
+    formName: string;
     href: string;
     id: Id;
+    interpretations: D2Interpretation[];
     lastUpdated: string;
     lastUpdatedBy: D2User;
+    latitude: number;
+    longitude: number;
+    mapViews: D2MapView[];
     name: string;
-    priority: number;
-    program: D2Program;
-    programRuleActions: D2ProgramRuleAction[];
-    programStage: D2ProgramStage;
     publicAccess: string;
+    shortName: string;
+    subscribed: boolean;
+    subscribers: string[];
+    title: string;
     translations: D2Translation[];
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
+    zoom: number;
 };
 
 export type D2MapView = {
@@ -3130,6 +2205,1521 @@ export type D2MapView = {
     userOrganisationUnitGrandChildren: boolean;
 };
 
+export type D2MessageConversation = {
+    access: D2Access;
+    assignee: D2User;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    followUp: boolean;
+    href: string;
+    id: Id;
+    lastMessage: string;
+    lastSender: D2User;
+    lastSenderFirstname: string;
+    lastSenderSurname: string;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    messageCount: number;
+    messageType: "PRIVATE" | "SYSTEM" | "VALIDATION_RESULT" | "TICKET";
+    messages: any[];
+    name: string;
+    priority: "NONE" | "LOW" | "MEDIUM" | "HIGH";
+    publicAccess: string;
+    read: boolean;
+    status: "NONE" | "OPEN" | "PENDING" | "INVALID" | "SOLVED";
+    subject: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userFirstname: string;
+    userGroupAccesses: D2UserGroupAccess[];
+    userMessages: any[];
+    userSurname: string;
+};
+
+export type D2MetadataVersion = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    hashCode: string;
+    href: string;
+    id: Id;
+    importDate: string;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    translations: D2Translation[];
+    type: "BEST_EFFORT" | "ATOMIC";
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2MinMaxDataElement = {
+    dataElement: D2DataElement;
+    generated: boolean;
+    max: number;
+    min: number;
+    optionCombo: D2CategoryOptionCombo;
+    source: D2OrganisationUnit;
+};
+
+export type D2OAuth2Client = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    cid: Id;
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    grantTypes: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    redirectUris: string[];
+    secret: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2Option = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: string;
+    created: string;
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    optionSet: D2OptionSet;
+    publicAccess: string;
+    shortName: string;
+    sortOrder: number;
+    style: D2Style;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2OptionGroup = {
+    access: D2Access;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    description: string;
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
+    name: string;
+    optionSet: D2OptionSet;
+    options: D2Option[];
+    publicAccess: string;
+    shortName: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2OptionGroupSet = {
+    access: D2Access;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    allItems: boolean;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    dataDimension: boolean;
+    dataDimensionType: "DISAGGREGATION" | "ATTRIBUTE";
+    description: string;
+    dimension: string;
+    dimensionType:
+        | "DATA_X"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "DATA_COLLAPSED"
+        | "CATEGORY_OPTION_COMBO"
+        | "ATTRIBUTE_OPTION_COMBO"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION_GROUP_SET"
+        | "DATA_ELEMENT_GROUP_SET"
+        | "ORGANISATION_UNIT_GROUP_SET"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY"
+        | "OPTION_GROUP_SET"
+        | "VALIDATION_RULE"
+        | "STATIC"
+        | "ORGANISATION_UNIT_LEVEL";
+    dimensionalKeywords: D2DimensionalKeywords;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    filter: string;
+    formName: string;
+    href: string;
+    id: Id;
+    items: any[];
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendSet: D2LegendSet;
+    name: string;
+    optionGroups: D2OptionGroup[];
+    optionSet: D2OptionSet;
+    programStage: D2ProgramStage;
+    publicAccess: string;
+    shortName: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2OptionSet = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    options: D2Option[];
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    valueType:
+        | "TEXT"
+        | "LONG_TEXT"
+        | "LETTER"
+        | "PHONE_NUMBER"
+        | "EMAIL"
+        | "BOOLEAN"
+        | "TRUE_ONLY"
+        | "DATE"
+        | "DATETIME"
+        | "TIME"
+        | "NUMBER"
+        | "UNIT_INTERVAL"
+        | "PERCENTAGE"
+        | "INTEGER"
+        | "INTEGER_POSITIVE"
+        | "INTEGER_NEGATIVE"
+        | "INTEGER_ZERO_OR_POSITIVE"
+        | "TRACKER_ASSOCIATE"
+        | "USERNAME"
+        | "COORDINATE"
+        | "ORGANISATION_UNIT"
+        | "AGE"
+        | "URL"
+        | "FILE_RESOURCE"
+        | "IMAGE";
+    version: number;
+};
+
+export type D2OrganisationUnit = {
+    access: D2Access;
+    address: string;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    ancestors: D2OrganisationUnit[];
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    children: D2OrganisationUnit[];
+    closedDate: string;
+    code: Id;
+    comment: string;
+    contactPerson: string;
+    created: string;
+    dataSets: D2DataSet[];
+    description: string;
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    email: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    geometry: D2Geometry;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    leaf: boolean;
+    legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
+    level: number;
+    memberCount: number;
+    name: string;
+    openingDate: string;
+    organisationUnitGroups: D2OrganisationUnitGroup[];
+    parent: D2OrganisationUnit;
+    path: string;
+    phoneNumber: string;
+    programs: D2Program[];
+    publicAccess: string;
+    shortName: string;
+    translations: D2Translation[];
+    type: string;
+    url: string;
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    users: D2User[];
+};
+
+export type D2OrganisationUnitGroup = {
+    access: D2Access;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    color: string;
+    created: string;
+    description: string;
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
+    formName: string;
+    geometry: D2Geometry;
+    groupSets: D2OrganisationUnitGroupSet[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
+    name: string;
+    organisationUnits: D2OrganisationUnit[];
+    publicAccess: string;
+    shortName: string;
+    symbol: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2OrganisationUnitGroupSet = {
+    access: D2Access;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    allItems: boolean;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    compulsory: boolean;
+    created: string;
+    dataDimension: boolean;
+    dataDimensionType: "DISAGGREGATION" | "ATTRIBUTE";
+    description: string;
+    dimension: string;
+    dimensionType:
+        | "DATA_X"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "DATA_COLLAPSED"
+        | "CATEGORY_OPTION_COMBO"
+        | "ATTRIBUTE_OPTION_COMBO"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION_GROUP_SET"
+        | "DATA_ELEMENT_GROUP_SET"
+        | "ORGANISATION_UNIT_GROUP_SET"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY"
+        | "OPTION_GROUP_SET"
+        | "VALIDATION_RULE"
+        | "STATIC"
+        | "ORGANISATION_UNIT_LEVEL";
+    dimensionalKeywords: D2DimensionalKeywords;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    filter: string;
+    formName: string;
+    href: string;
+    id: Id;
+    includeSubhierarchyInAnalytics: boolean;
+    items: any[];
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendSet: D2LegendSet;
+    name: string;
+    organisationUnitGroups: D2OrganisationUnitGroup[];
+    programStage: D2ProgramStage;
+    publicAccess: string;
+    shortName: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2OrganisationUnitGroupSetDimension = {
+    organisationUnitGroupSet: D2OrganisationUnitGroupSet;
+    organisationUnitGroups: D2OrganisationUnitGroup[];
+};
+
+export type D2OrganisationUnitLevel = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    level: number;
+    name: string;
+    offlineLevels: number;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2Predictor = {
+    access: D2Access;
+    annualSampleCount: number;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    generator: D2Expression;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    organisationUnitLevels: D2OrganisationUnitLevel[];
+    output: D2DataElement;
+    outputCombo: D2CategoryOptionCombo;
+    periodType: string;
+    predictorGroups: D2PredictorGroup[];
+    publicAccess: string;
+    sampleSkipTest: D2Expression;
+    sequentialSampleCount: number;
+    sequentialSkipCount: number;
+    shortName: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2PredictorGroup = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    description: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    predictors: D2Predictor[];
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2Program = {
+    access: D2Access;
+    accessLevel: "OPEN" | "AUDITED" | "PROTECTED" | "CLOSED";
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    categoryCombo: D2CategoryCombo;
+    code: Id;
+    completeEventsExpiryDays: number;
+    created: string;
+    dataEntryForm: D2DataEntryForm;
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayFrontPageList: boolean;
+    displayIncidentDate: boolean;
+    displayName: string;
+    displayShortName: string;
+    enrollmentDateLabel: string;
+    expiryDays: number;
+    expiryPeriodType: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
+    formName: string;
+    href: string;
+    id: Id;
+    ignoreOverdueEvents: boolean;
+    incidentDateLabel: string;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    maxTeiCountToReturn: number;
+    minAttributesRequiredToSearch: number;
+    name: string;
+    notificationTemplates: D2ProgramNotificationTemplate[];
+    onlyEnrollOnce: boolean;
+    organisationUnits: D2OrganisationUnit[];
+    programIndicators: D2ProgramIndicator[];
+    programRuleVariables: D2ProgramRuleVariable[];
+    programSections: D2ProgramSection[];
+    programStages: D2ProgramStage[];
+    programTrackedEntityAttributes: D2ProgramTrackedEntityAttribute[];
+    programType: "WITH_REGISTRATION" | "WITHOUT_REGISTRATION";
+    publicAccess: string;
+    registration: boolean;
+    relatedProgram: D2Program;
+    selectEnrollmentDatesInFuture: boolean;
+    selectIncidentDatesInFuture: boolean;
+    shortName: string;
+    skipOffline: boolean;
+    style: D2Style;
+    trackedEntityType: D2TrackedEntityType;
+    translations: D2Translation[];
+    useFirstStageDuringRegistration: boolean;
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    userRoles: D2UserAuthorityGroup[];
+    version: number;
+    withoutRegistration: boolean;
+};
+
+export type D2ProgramDataElementDimensionItem = {
+    access: D2Access;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    dataElement: D2DataElement;
+    description: string;
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
+    name: string;
+    program: D2Program;
+    publicAccess: string;
+    shortName: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    valueType:
+        | "TEXT"
+        | "LONG_TEXT"
+        | "LETTER"
+        | "PHONE_NUMBER"
+        | "EMAIL"
+        | "BOOLEAN"
+        | "TRUE_ONLY"
+        | "DATE"
+        | "DATETIME"
+        | "TIME"
+        | "NUMBER"
+        | "UNIT_INTERVAL"
+        | "PERCENTAGE"
+        | "INTEGER"
+        | "INTEGER_POSITIVE"
+        | "INTEGER_NEGATIVE"
+        | "INTEGER_ZERO_OR_POSITIVE"
+        | "TRACKER_ASSOCIATE"
+        | "USERNAME"
+        | "COORDINATE"
+        | "ORGANISATION_UNIT"
+        | "AGE"
+        | "URL"
+        | "FILE_RESOURCE"
+        | "IMAGE";
+};
+
+export type D2ProgramIndicator = {
+    access: D2Access;
+    aggregateExportAttributeOptionCombo: string;
+    aggregateExportCategoryOptionCombo: string;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    analyticsPeriodBoundaries: D2AnalyticsPeriodBoundary[];
+    analyticsType: "EVENT" | "ENROLLMENT";
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    decimals: number;
+    description: string;
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
+    displayDescription: string;
+    displayFormName: string;
+    displayInForm: boolean;
+    displayName: string;
+    displayShortName: string;
+    expression: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    filter: string;
+    formName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
+    name: string;
+    program: D2Program;
+    programIndicatorGroups: D2ProgramIndicatorGroup[];
+    publicAccess: string;
+    shortName: string;
+    style: D2Style;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramIndicatorGroup = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    description: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    programIndicators: D2ProgramIndicator[];
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramInstance = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    completedBy: string;
+    created: string;
+    createdAtClient: string;
+    deleted: boolean;
+    displayName: string;
+    endDate: string;
+    enrollmentDate: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    followup: boolean;
+    geometry: D2Geometry;
+    href: string;
+    id: Id;
+    incidentDate: string;
+    lastUpdated: string;
+    lastUpdatedAtClient: string;
+    lastUpdatedBy: D2User;
+    messageConversations: D2MessageConversation[];
+    name: string;
+    organisationUnit: D2OrganisationUnit;
+    program: D2Program;
+    programStageInstances: D2ProgramStageInstance[];
+    publicAccess: string;
+    relationshipItems: any[];
+    status: "ACTIVE" | "COMPLETED" | "CANCELLED";
+    storedBy: string;
+    trackedEntityComments: any[];
+    trackedEntityInstance: D2TrackedEntityInstance;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramNotificationTemplate = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    deliveryChannels: never[];
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    messageTemplate: string;
+    name: string;
+    notificationRecipient:
+        | "TRACKED_ENTITY_INSTANCE"
+        | "ORGANISATION_UNIT_CONTACT"
+        | "USERS_AT_ORGANISATION_UNIT"
+        | "USER_GROUP"
+        | "PROGRAM_ATTRIBUTE"
+        | "DATA_ELEMENT";
+    notificationTrigger:
+        | "ENROLLMENT"
+        | "COMPLETION"
+        | "PROGRAM_RULE"
+        | "SCHEDULED_DAYS_DUE_DATE"
+        | "SCHEDULED_DAYS_INCIDENT_DATE"
+        | "SCHEDULED_DAYS_ENROLLMENT_DATE";
+    notifyParentOrganisationUnitOnly: boolean;
+    notifyUsersInHierarchyOnly: boolean;
+    publicAccess: string;
+    recipientDataElement: D2DataElement;
+    recipientProgramAttribute: D2TrackedEntityAttribute;
+    recipientUserGroup: D2UserGroup;
+    relativeScheduledDays: number;
+    subjectTemplate: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramRule = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    condition: string;
+    created: string;
+    description: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    priority: number;
+    program: D2Program;
+    programRuleActions: D2ProgramRuleAction[];
+    programStage: D2ProgramStage;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramRuleAction = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    content: string;
+    created: string;
+    data: string;
+    dataElement: D2DataElement;
+    displayName: string;
+    evaluationEnvironments: never[];
+    evaluationTime: "ON_DATA_ENTRY" | "ON_COMPLETE" | "ALWAYS";
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    location: string;
+    name: string;
+    option: D2Option;
+    optionGroup: D2OptionGroup;
+    programIndicator: D2ProgramIndicator;
+    programRule: D2ProgramRule;
+    programRuleActionType:
+        | "DISPLAYTEXT"
+        | "DISPLAYKEYVALUEPAIR"
+        | "HIDEFIELD"
+        | "HIDESECTION"
+        | "HIDEPROGRAMSTAGE"
+        | "ASSIGN"
+        | "SHOWWARNING"
+        | "WARNINGONCOMPLETE"
+        | "SHOWERROR"
+        | "ERRORONCOMPLETE"
+        | "CREATEEVENT"
+        | "SETMANDATORYFIELD"
+        | "SENDMESSAGE"
+        | "SCHEDULEMESSAGE"
+        | "HIDEOPTION"
+        | "SHOWOPTIONGROUP"
+        | "HIDEOPTIONGROUP";
+    programStage: D2ProgramStage;
+    programStageSection: D2ProgramStageSection;
+    publicAccess: string;
+    templateUid: string;
+    trackedEntityAttribute: D2TrackedEntityAttribute;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramRuleVariable = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    dataElement: D2DataElement;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    program: D2Program;
+    programRuleVariableSourceType:
+        | "DATAELEMENT_NEWEST_EVENT_PROGRAM_STAGE"
+        | "DATAELEMENT_NEWEST_EVENT_PROGRAM"
+        | "DATAELEMENT_CURRENT_EVENT"
+        | "DATAELEMENT_PREVIOUS_EVENT"
+        | "CALCULATED_VALUE"
+        | "TEI_ATTRIBUTE";
+    programStage: D2ProgramStage;
+    publicAccess: string;
+    trackedEntityAttribute: D2TrackedEntityAttribute;
+    translations: D2Translation[];
+    useCodeForOptionSet: boolean;
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramSection = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    program: D2Program;
+    publicAccess: string;
+    renderType: any;
+    shortName: string;
+    sortOrder: number;
+    style: D2Style;
+    trackedEntityAttributes: D2TrackedEntityAttribute[];
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramStage = {
+    access: D2Access;
+    allowGenerateNextVisit: boolean;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    autoGenerateEvent: boolean;
+    blockEntryForm: boolean;
+    code: Id;
+    created: string;
+    dataEntryForm: D2DataEntryForm;
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayGenerateEventBox: boolean;
+    displayName: string;
+    displayShortName: string;
+    dueDateLabel: string;
+    enableUserAssignment: boolean;
+    executionDateLabel: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
+    formName: string;
+    formType: "DEFAULT" | "CUSTOM" | "SECTION" | "SECTION_MULTIORG";
+    generatedByEnrollmentDate: boolean;
+    hideDueDate: boolean;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    minDaysFromStart: number;
+    name: string;
+    nextScheduleDate: D2DataElement;
+    notificationTemplates: D2ProgramNotificationTemplate[];
+    openAfterEnrollment: boolean;
+    periodType: string;
+    preGenerateUID: boolean;
+    program: D2Program;
+    programStageDataElements: D2ProgramStageDataElement[];
+    programStageSections: D2ProgramStageSection[];
+    publicAccess: string;
+    remindCompleted: boolean;
+    repeatable: boolean;
+    reportDateToUse: string;
+    shortName: string;
+    sortOrder: number;
+    standardInterval: number;
+    style: D2Style;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    validationStrategy: "ON_COMPLETE" | "ON_UPDATE_AND_INSERT";
+};
+
+export type D2ProgramStageDataElement = {
+    access: D2Access;
+    allowFutureDate: boolean;
+    allowProvidedElsewhere: boolean;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    compulsory: boolean;
+    created: string;
+    dataElement: D2DataElement;
+    displayInReports: boolean;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    programStage: D2ProgramStage;
+    publicAccess: string;
+    renderOptionsAsRadio: boolean;
+    renderType: any;
+    skipSynchronization: boolean;
+    sortOrder: number;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramStageInstance = {
+    access: D2Access;
+    assignedUser: D2User;
+    attributeOptionCombo: D2CategoryOptionCombo;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    comments: any[];
+    completed: boolean;
+    completedBy: string;
+    completedDate: string;
+    creatableInSearchScope: boolean;
+    created: string;
+    createdAtClient: string;
+    deleted: boolean;
+    displayName: string;
+    dueDate: string;
+    eventDataValues: any[];
+    eventDate: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    geometry: D2Geometry;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedAtClient: string;
+    lastUpdatedBy: D2User;
+    messageConversations: D2MessageConversation[];
+    name: string;
+    organisationUnit: D2OrganisationUnit;
+    programInstance: D2ProgramInstance;
+    programStage: D2ProgramStage;
+    publicAccess: string;
+    relationshipItems: any[];
+    status: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";
+    storedBy: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramStageInstanceFilter = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    description: string;
+    displayName: string;
+    eventQueryCriteria: any;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    program: Id;
+    programStage: Id;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramStageSection = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    dataElements: D2DataElement[];
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    programIndicators: D2ProgramIndicator[];
+    programStage: D2ProgramStage;
+    publicAccess: string;
+    renderType: any;
+    shortName: string;
+    sortOrder: number;
+    style: D2Style;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramTrackedEntityAttribute = {
+    access: D2Access;
+    allowFutureDate: boolean;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    displayInList: boolean;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    mandatory: boolean;
+    name: string;
+    program: D2Program;
+    programTrackedEntityAttributeGroups: D2ProgramTrackedEntityAttributeGroup[];
+    publicAccess: string;
+    renderOptionsAsRadio: boolean;
+    renderType: any;
+    searchable: boolean;
+    sortOrder: number;
+    trackedEntityAttribute: D2TrackedEntityAttribute;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    valueType:
+        | "TEXT"
+        | "LONG_TEXT"
+        | "LETTER"
+        | "PHONE_NUMBER"
+        | "EMAIL"
+        | "BOOLEAN"
+        | "TRUE_ONLY"
+        | "DATE"
+        | "DATETIME"
+        | "TIME"
+        | "NUMBER"
+        | "UNIT_INTERVAL"
+        | "PERCENTAGE"
+        | "INTEGER"
+        | "INTEGER_POSITIVE"
+        | "INTEGER_NEGATIVE"
+        | "INTEGER_ZERO_OR_POSITIVE"
+        | "TRACKER_ASSOCIATE"
+        | "USERNAME"
+        | "COORDINATE"
+        | "ORGANISATION_UNIT"
+        | "AGE"
+        | "URL"
+        | "FILE_RESOURCE"
+        | "IMAGE";
+};
+
+export type D2ProgramTrackedEntityAttributeDimensionItem = {
+    access: D2Access;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    attribute: D2TrackedEntityAttribute;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    description: string;
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
+    name: string;
+    program: D2Program;
+    publicAccess: string;
+    shortName: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2ProgramTrackedEntityAttributeGroup = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    attributes: D2ProgramTrackedEntityAttribute[];
+    code: Id;
+    created: string;
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    shortName: string;
+    translations: D2Translation[];
+    uniqunessType: "NONE" | "STRICT" | "VALIDATION";
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2PushAnalysis = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    dashboard: D2Dashboard;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    message: string;
+    name: string;
+    publicAccess: string;
+    recipientUserGroups: D2UserGroup[];
+    title: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2Relationship = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    from: any;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    relationshipType: D2RelationshipType;
+    shortName: string;
+    style: D2Style;
+    to: any;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2RelationshipType = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    bidirectional: boolean;
+    code: Id;
+    created: string;
+    description: string;
+    displayFromToName: string;
+    displayName: string;
+    displayToFromName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    fromConstraint: D2RelationshipConstraint;
+    fromToName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    toConstraint: D2RelationshipConstraint;
+    toFromName: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
 export type D2Report = {
     access: D2Access;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
@@ -3158,103 +3748,13 @@ export type D2Report = {
     name: string;
     publicAccess: string;
     relativePeriods: any;
-    reportParams: any;
+    reportParams: D2ReportingParams;
     translations: D2Translation[];
     type: "JASPER_REPORT_TABLE" | "JASPER_JDBC" | "HTML";
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
     visualization: D2Visualization;
-};
-
-export type D2Map = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    basemap: string;
-    code: Id;
-    created: string;
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    interpretations: D2Interpretation[];
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    latitude: number;
-    longitude: number;
-    mapViews: D2MapView[];
-    name: string;
-    publicAccess: string;
-    shortName: string;
-    subscribed: boolean;
-    subscribers: string[];
-    title: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    zoom: number;
-};
-
-export type D2Document = {
-    access: D2Access;
-    attachment: boolean;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    contentType: string;
-    created: string;
-    displayName: string;
-    external: boolean;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    url: string;
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2ExternalMapLayer = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    attribution: string;
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    imageFormat: "PNG" | "JPG";
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    layers: string;
-    legendSet: D2LegendSet;
-    legendSetUrl: string;
-    mapLayerPosition: "BASEMAP" | "OVERLAY";
-    mapService: "WMS" | "TMS" | "XYZ";
-    name: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    url: string;
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
 };
 
 export type D2ReportTable = {
@@ -3358,7 +3858,7 @@ export type D2ReportTable = {
     userOrganisationUnitGrandChildren: boolean;
 };
 
-export type D2Chart = {
+export type D2ReportingRate = {
     access: D2Access;
     aggregationType:
         | "SUM"
@@ -3376,103 +3876,726 @@ export type D2Chart = {
         | "NONE"
         | "CUSTOM"
         | "DEFAULT";
-    attributeDimensions: any[];
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    baseLineLabel: string;
-    baseLineValue: number;
-    category: string;
-    categoryDimensions: D2CategoryDimension[];
-    categoryOptionGroupSetDimensions: D2CategoryOptionGroupSetDimension[];
     code: Id;
-    colorSet: D2ColorSet;
-    columns: any[];
-    completedOnly: boolean;
     created: string;
-    cumulativeValues: boolean;
-    dataDimensionItems: any[];
-    dataElementDimensions: D2TrackedEntityDataElementDimension[];
-    dataElementGroupSetDimensions: D2DataElementGroupSetDimension[];
+    dataSet: D2DataSet;
     description: string;
-    digitGroupSeparator: "COMMA" | "SPACE" | "NONE";
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
     displayDescription: string;
     displayFormName: string;
     displayName: string;
     displayShortName: string;
-    domainAxisLabel: string;
-    endDate: string;
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
-    filterDimensions: string[];
-    filters: any[];
     formName: string;
-    hideEmptyRowItems: "NONE" | "BEFORE_FIRST" | "AFTER_LAST" | "BEFORE_FIRST_AFTER_LAST" | "ALL";
-    hideLegend: boolean;
-    hideSubtitle: boolean;
-    hideTitle: boolean;
     href: string;
     id: Id;
-    interpretations: D2Interpretation[];
-    itemOrganisationUnitGroups: D2OrganisationUnitGroup[];
     lastUpdated: string;
     lastUpdatedBy: D2User;
-    legendDisplayStrategy: "FIXED" | "BY_DATA_ITEM";
     legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
+    metric:
+        | "REPORTING_RATE"
+        | "REPORTING_RATE_ON_TIME"
+        | "ACTUAL_REPORTS"
+        | "ACTUAL_REPORTS_ON_TIME"
+        | "EXPECTED_REPORTS";
     name: string;
-    noSpaceBetweenColumns: boolean;
-    orgUnitField: string;
-    organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimension[];
-    organisationUnitLevels: number[];
-    organisationUnits: D2OrganisationUnit[];
-    parentGraphMap: D2Map;
-    percentStackedValues: boolean;
-    periods: any[];
-    programIndicatorDimensions: D2TrackedEntityProgramIndicatorDimension[];
     publicAccess: string;
-    rangeAxisDecimals: number;
-    rangeAxisLabel: string;
-    rangeAxisMaxValue: number;
-    rangeAxisMinValue: number;
-    rangeAxisSteps: number;
-    regressionType: "NONE" | "LINEAR" | "POLYNOMIAL" | "LOESS";
-    relativePeriods: any;
-    rows: any[];
-    series: string;
-    seriesItems: any[];
     shortName: string;
-    showData: boolean;
-    sortOrder: number;
-    startDate: string;
-    subscribed: boolean;
-    subscribers: string[];
-    subtitle: string;
-    targetLineLabel: string;
-    targetLineValue: number;
-    timeField: string;
-    title: string;
-    topLimit: number;
     translations: D2Translation[];
-    type:
-        | "COLUMN"
-        | "STACKED_COLUMN"
-        | "BAR"
-        | "STACKED_BAR"
-        | "LINE"
-        | "AREA"
-        | "PIE"
-        | "RADAR"
-        | "GAUGE"
-        | "YEAR_OVER_YEAR_LINE"
-        | "YEAR_OVER_YEAR_COLUMN"
-        | "SINGLE_VALUE";
     user: D2User;
     userAccesses: D2UserAccess[];
     userGroupAccesses: D2UserGroupAccess[];
-    userOrgUnitType: "DATA_CAPTURE" | "DATA_OUTPUT" | "TEI_SEARCH";
-    userOrganisationUnit: boolean;
-    userOrganisationUnitChildren: boolean;
-    userOrganisationUnitGrandChildren: boolean;
-    yearlySeries: string[];
+};
+
+export type D2SMSCommand = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    codeValueSeparator: string;
+    completenessMethod: "ALL_DATAVALUE" | "AT_LEAST_ONE_DATAVALUE" | "DO_NOT_MARK_COMPLETE";
+    created: string;
+    currentPeriodUsedForReporting: boolean;
+    dataset: D2DataSet;
+    defaultMessage: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    moreThanOneOrgUnitMessage: string;
+    name: string;
+    noUserMessage: string;
+    parserType:
+        | "KEY_VALUE_PARSER"
+        | "J2ME_PARSER"
+        | "ALERT_PARSER"
+        | "UNREGISTERED_PARSER"
+        | "TRACKED_ENTITY_REGISTRATION_PARSER"
+        | "PROGRAM_STAGE_DATAENTRY_PARSER"
+        | "EVENT_REGISTRATION_PARSER";
+    program: D2Program;
+    programStage: D2ProgramStage;
+    publicAccess: string;
+    receivedMessage: string;
+    separator: string;
+    smsCodes: any[];
+    specialCharacters: any[];
+    successMessage: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroup: D2UserGroup;
+    userGroupAccesses: D2UserGroupAccess[];
+    wrongFormatMessage: string;
+};
+
+export type D2Section = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    categoryCombos: D2CategoryCombo[];
+    code: Id;
+    created: string;
+    dataElements: D2DataElement[];
+    dataSet: D2DataSet;
+    description: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    greyedFields: D2DataElementOperand[];
+    href: string;
+    id: Id;
+    indicators: D2Indicator[];
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    showColumnTotals: boolean;
+    showRowTotals: boolean;
+    sortOrder: number;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2SqlView = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    cacheStrategy:
+        | "NO_CACHE"
+        | "CACHE_1_MINUTE"
+        | "CACHE_5_MINUTES"
+        | "CACHE_10_MINUTES"
+        | "CACHE_15_MINUTES"
+        | "CACHE_30_MINUTES"
+        | "CACHE_1_HOUR"
+        | "CACHE_6AM_TOMORROW"
+        | "CACHE_TWO_WEEKS"
+        | "RESPECT_SYSTEM_SETTING";
+    code: Id;
+    created: string;
+    description: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    sqlQuery: string;
+    translations: D2Translation[];
+    type: "VIEW" | "MATERIALIZED_VIEW" | "QUERY";
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2TrackedEntityAttribute = {
+    access: D2Access;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    confidential: boolean;
+    created: string;
+    description: string;
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
+    displayDescription: string;
+    displayFormName: string;
+    displayInListNoProgram: boolean;
+    displayName: string;
+    displayOnVisitSchedule: boolean;
+    displayShortName: string;
+    expression: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    fieldMask: string;
+    formName: string;
+    generated: boolean;
+    href: string;
+    id: Id;
+    inherit: boolean;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
+    name: string;
+    optionSet: D2OptionSet;
+    optionSetValue: boolean;
+    orgunitScope: boolean;
+    pattern: string;
+    publicAccess: string;
+    shortName: string;
+    skipSynchronization: boolean;
+    sortOrderInListNoProgram: number;
+    sortOrderInVisitSchedule: number;
+    style: D2Style;
+    translations: D2Translation[];
+    unique: boolean;
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    valueType:
+        | "TEXT"
+        | "LONG_TEXT"
+        | "LETTER"
+        | "PHONE_NUMBER"
+        | "EMAIL"
+        | "BOOLEAN"
+        | "TRUE_ONLY"
+        | "DATE"
+        | "DATETIME"
+        | "TIME"
+        | "NUMBER"
+        | "UNIT_INTERVAL"
+        | "PERCENTAGE"
+        | "INTEGER"
+        | "INTEGER_POSITIVE"
+        | "INTEGER_NEGATIVE"
+        | "INTEGER_ZERO_OR_POSITIVE"
+        | "TRACKER_ASSOCIATE"
+        | "USERNAME"
+        | "COORDINATE"
+        | "ORGANISATION_UNIT"
+        | "AGE"
+        | "URL"
+        | "FILE_RESOURCE"
+        | "IMAGE";
+};
+
+export type D2TrackedEntityAttributeValue = {
+    created: string;
+    lastUpdated: string;
+    storedBy: string;
+    trackedEntityAttribute: D2TrackedEntityAttribute;
+    trackedEntityInstance: D2TrackedEntityInstance;
+    value: string;
+};
+
+export type D2TrackedEntityDataElementDimension = {
+    dataElement: D2DataElement;
+    filter: string;
+    legendSet: D2LegendSet;
+    programStage: D2ProgramStage;
+};
+
+export type D2TrackedEntityInstance = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    createdAtClient: string;
+    deleted: boolean;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    geometry: D2Geometry;
+    href: string;
+    id: Id;
+    inactive: boolean;
+    lastUpdated: string;
+    lastUpdatedAtClient: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    organisationUnit: D2OrganisationUnit;
+    programInstances: D2ProgramInstance[];
+    programOwners: any[];
+    publicAccess: string;
+    relationshipItems: any[];
+    trackedEntityAttributeValues: D2TrackedEntityAttributeValue[];
+    trackedEntityType: D2TrackedEntityType;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2TrackedEntityInstanceFilter = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    description: string;
+    displayName: string;
+    enrollmentCreatedPeriod: any;
+    enrollmentStatus: "ACTIVE" | "COMPLETED" | "CANCELLED";
+    eventFilters: any[];
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    followup: boolean;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    program: D2Program;
+    publicAccess: string;
+    sortOrder: number;
+    style: D2Style;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2TrackedEntityProgramIndicatorDimension = {
+    filter: string;
+    legendSet: D2LegendSet;
+    programIndicator: D2ProgramIndicator;
+};
+
+export type D2TrackedEntityType = {
+    access: D2Access;
+    allowAuditLog: boolean;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    description: string;
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
+    formName: string;
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    maxTeiCountToReturn: number;
+    minAttributesRequiredToSearch: number;
+    name: string;
+    publicAccess: string;
+    shortName: string;
+    style: D2Style;
+    trackedEntityTypeAttributes: D2TrackedEntityTypeAttribute[];
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+};
+
+export type D2TrackedEntityTypeAttribute = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    displayInList: boolean;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    mandatory: boolean;
+    name: string;
+    publicAccess: string;
+    searchable: boolean;
+    trackedEntityAttribute: D2TrackedEntityAttribute;
+    trackedEntityType: D2TrackedEntityType;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    valueType:
+        | "TEXT"
+        | "LONG_TEXT"
+        | "LETTER"
+        | "PHONE_NUMBER"
+        | "EMAIL"
+        | "BOOLEAN"
+        | "TRUE_ONLY"
+        | "DATE"
+        | "DATETIME"
+        | "TIME"
+        | "NUMBER"
+        | "UNIT_INTERVAL"
+        | "PERCENTAGE"
+        | "INTEGER"
+        | "INTEGER_POSITIVE"
+        | "INTEGER_NEGATIVE"
+        | "INTEGER_ZERO_OR_POSITIVE"
+        | "TRACKER_ASSOCIATE"
+        | "USERNAME"
+        | "COORDINATE"
+        | "ORGANISATION_UNIT"
+        | "AGE"
+        | "URL"
+        | "FILE_RESOURCE"
+        | "IMAGE";
+};
+
+export type D2User = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    avatar: D2FileResource;
+    birthday: string;
+    code: Id;
+    created: string;
+    dataViewOrganisationUnits: D2OrganisationUnit[];
+    displayName: string;
+    education: string;
+    email: string;
+    employer: string;
+    externalAccess: boolean;
+    facebookMessenger: string;
+    favorite: boolean;
+    favorites: string[];
+    firstName: string;
+    gender: string;
+    href: string;
+    id: Id;
+    interests: string;
+    introduction: string;
+    jobTitle: string;
+    languages: string;
+    lastCheckedInterpretations: string;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    nationality: string;
+    organisationUnits: D2OrganisationUnit[];
+    phoneNumber: string;
+    publicAccess: string;
+    skype: string;
+    surname: string;
+    teiSearchOrganisationUnits: D2OrganisationUnit[];
+    telegram: string;
+    translations: D2Translation[];
+    twitter: string;
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userCredentials: D2UserCredentials;
+    userGroupAccesses: D2UserGroupAccess[];
+    userGroups: D2UserGroup[];
+    welcomeMessage: string;
+    whatsApp: string;
+};
+
+export type D2UserAccess = {
+    access: string;
+    displayName: string;
+    id: string;
+    userUid: string;
+};
+
+export type D2UserAuthorityGroup = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    authorities: string[];
+    code: Id;
+    created: string;
+    description: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    users: D2User[];
+};
+
+export type D2UserCredentials = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    catDimensionConstraints: D2Category[];
+    code: Id;
+    cogsDimensionConstraints: D2CategoryOptionGroupSet[];
+    created: string;
+    disabled: boolean;
+    displayName: string;
+    externalAccess: boolean;
+    externalAuth: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    invitation: boolean;
+    lastLogin: string;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    ldapId: string;
+    name: string;
+    openId: string;
+    password: string;
+    passwordLastUpdated: string;
+    publicAccess: string;
+    selfRegistered: boolean;
+    translations: D2Translation[];
+    twoFA: boolean;
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    userInfo: D2User;
+    userRoles: D2UserAuthorityGroup[];
+    username: string;
+};
+
+export type D2UserGroup = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    managedByGroups: D2UserGroup[];
+    managedGroups: D2UserGroup[];
+    name: string;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    users: D2User[];
+};
+
+export type D2UserGroupAccess = {
+    access: string;
+    displayName: string;
+    id: string;
+    userGroupUid: string;
+};
+
+export type D2ValidationNotificationTemplate = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    messageTemplate: string;
+    name: string;
+    notifyParentOrganisationUnitOnly: boolean;
+    notifyUsersInHierarchyOnly: boolean;
+    publicAccess: string;
+    recipientUserGroups: D2UserGroup[];
+    sendStrategy: "COLLECTIVE_SUMMARY" | "SINGLE_NOTIFICATION";
+    subjectTemplate: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    validationRules: D2ValidationRule[];
+};
+
+export type D2ValidationResult = {
+    attributeOptionCombo: D2CategoryOptionCombo;
+    created: string;
+    dayInPeriod: number;
+    id: string;
+    leftsideValue: number;
+    notificationSent: boolean;
+    organisationUnit: D2OrganisationUnit;
+    period: any;
+    rightsideValue: number;
+    validationRule: D2ValidationRule;
+};
+
+export type D2ValidationRule = {
+    access: D2Access;
+    aggregateExportAttributeOptionCombo: string;
+    aggregateExportCategoryOptionCombo: string;
+    aggregationType:
+        | "SUM"
+        | "AVERAGE"
+        | "AVERAGE_SUM_ORG_UNIT"
+        | "LAST"
+        | "LAST_AVERAGE_ORG_UNIT"
+        | "FIRST"
+        | "FIRST_AVERAGE_ORG_UNIT"
+        | "COUNT"
+        | "STDDEV"
+        | "VARIANCE"
+        | "MIN"
+        | "MAX"
+        | "NONE"
+        | "CUSTOM"
+        | "DEFAULT";
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    description: string;
+    dimensionItem: string;
+    dimensionItemType:
+        | "DATA_ELEMENT"
+        | "DATA_ELEMENT_OPERAND"
+        | "INDICATOR"
+        | "REPORTING_RATE"
+        | "PROGRAM_DATA_ELEMENT"
+        | "PROGRAM_ATTRIBUTE"
+        | "PROGRAM_INDICATOR"
+        | "PERIOD"
+        | "ORGANISATION_UNIT"
+        | "CATEGORY_OPTION"
+        | "OPTION_GROUP"
+        | "DATA_ELEMENT_GROUP"
+        | "ORGANISATION_UNIT_GROUP"
+        | "CATEGORY_OPTION_GROUP";
+    displayDescription: string;
+    displayFormName: string;
+    displayName: string;
+    displayShortName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    formName: string;
+    href: string;
+    id: Id;
+    importance: "HIGH" | "MEDIUM" | "LOW";
+    instruction: string;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    leftSide: D2Expression;
+    legendSet: D2LegendSet;
+    legendSets: D2LegendSet[];
+    name: string;
+    notificationTemplates: D2ValidationNotificationTemplate[];
+    operator:
+        | "equal_to"
+        | "not_equal_to"
+        | "greater_than"
+        | "greater_than_or_equal_to"
+        | "less_than"
+        | "less_than_or_equal_to"
+        | "compulsory_pair"
+        | "exclusive_pair";
+    organisationUnitLevels: number[];
+    periodType: string;
+    publicAccess: string;
+    rightSide: D2Expression;
+    shortName: string;
+    skipFormValidation: boolean;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    validationRuleGroups: D2ValidationRuleGroup[];
+};
+
+export type D2ValidationRuleGroup = {
+    access: D2Access;
+    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+    code: Id;
+    created: string;
+    description: string;
+    displayName: string;
+    externalAccess: boolean;
+    favorite: boolean;
+    favorites: string[];
+    href: string;
+    id: Id;
+    lastUpdated: string;
+    lastUpdatedBy: D2User;
+    name: string;
+    publicAccess: string;
+    translations: D2Translation[];
+    user: D2User;
+    userAccesses: D2UserAccess[];
+    userGroupAccesses: D2UserGroupAccess[];
+    validationRules: D2ValidationRule[];
 };
 
 export type D2Visualization = {
@@ -3546,7 +4669,7 @@ export type D2Visualization = {
     name: string;
     noSpaceBetweenColumns: boolean;
     numberType: "VALUE" | "ROW_PERCENTAGE" | "COLUMN_PERCENTAGE";
-    optionalAxes: any[];
+    optionalAxes: D2Axis[];
     orgUnitField: string;
     organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimension[];
     organisationUnitLevels: number[];
@@ -3564,7 +4687,7 @@ export type D2Visualization = {
     regression: boolean;
     regressionType: "NONE" | "LINEAR" | "POLYNOMIAL" | "LOESS";
     relativePeriods: any;
-    reportingParams: any;
+    reportingParams: D2ReportingParams;
     rowDimensions: string[];
     rowSubTotals: boolean;
     rowTotals: boolean;
@@ -3610,1137 +4733,20 @@ export type D2Visualization = {
     yearlySeries: string[];
 };
 
-export type D2ValidationResult = {
-    attributeOptionCombo: D2CategoryOptionCombo;
-    created: string;
-    dayInPeriod: number;
-    id: string;
-    leftsideValue: number;
-    notificationSent: boolean;
-    organisationUnit: D2OrganisationUnit;
-    period: any;
-    rightsideValue: number;
-    validationRule: D2ValidationRule;
-};
-
-export type D2Predictor = {
-    access: D2Access;
-    annualSampleCount: number;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    generator: D2Expression;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    organisationUnitLevels: D2OrganisationUnitLevel[];
-    output: D2DataElement;
-    outputCombo: D2CategoryOptionCombo;
-    periodType: string;
-    predictorGroups: D2PredictorGroup[];
-    publicAccess: string;
-    sampleSkipTest: D2Expression;
-    sequentialSampleCount: number;
-    sequentialSkipCount: number;
-    shortName: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2PredictorGroup = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    description: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    predictors: D2Predictor[];
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2DashboardItem = {
-    access: D2Access;
-    appKey: string;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    chart: D2Chart;
-    code: Id;
-    contentCount: number;
-    created: string;
-    displayName: string;
-    eventChart: D2EventChart;
-    eventReport: D2EventReport;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    height: number;
-    href: string;
-    id: Id;
-    interpretationCount: number;
-    interpretationLikeCount: number;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    map: D2Map;
-    messages: boolean;
-    name: string;
-    publicAccess: string;
-    reportTable: D2ReportTable;
-    reports: D2Report[];
-    resources: D2Document[];
-    shape: "NORMAL" | "DOUBLE_WIDTH" | "FULL_WIDTH";
-    text: string;
-    translations: D2Translation[];
-    type:
-        | "VISUALIZATION"
-        | "CHART"
-        | "EVENT_CHART"
-        | "MAP"
-        | "REPORT_TABLE"
-        | "EVENT_REPORT"
-        | "USERS"
-        | "REPORTS"
-        | "RESOURCES"
-        | "TEXT"
-        | "MESSAGES"
-        | "APP";
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    users: D2User[];
-    visualization: D2Visualization;
-    width: number;
-    x: number;
-    y: number;
-};
-
-export type D2Dashboard = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    dashboardItems: D2DashboardItem[];
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    itemCount: number;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    shortName: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2PushAnalysis = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    dashboard: D2Dashboard;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    message: string;
-    name: string;
-    publicAccess: string;
-    recipientUserGroups: D2UserGroup[];
-    title: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2KeyJsonValue = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    key: string;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    namespace: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    value: string;
-};
-
-export type D2UserAccess = {
-    access: string;
-    displayName: string;
-    id: string;
-    userUid: string;
-};
-
-export type D2AnalyticsPeriodBoundary = {
-    access: D2Access;
-    analyticsPeriodBoundaryType:
-        | "BEFORE_START_OF_REPORTING_PERIOD"
-        | "BEFORE_END_OF_REPORTING_PERIOD"
-        | "AFTER_START_OF_REPORTING_PERIOD"
-        | "AFTER_END_OF_REPORTING_PERIOD";
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    boundaryTarget: string;
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    offsetPeriodType: string;
-    offsetPeriods: number;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2DataSetElement = {
-    categoryCombo: D2CategoryCombo;
-    dataElement: D2DataElement;
-    dataSet: D2DataSet;
-};
-
-export type D2TrackedEntityInstance = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    createdAtClient: string;
-    deleted: boolean;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    geometry: D2Geometry;
-    href: string;
-    id: Id;
-    inactive: boolean;
-    lastUpdated: string;
-    lastUpdatedAtClient: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    organisationUnit: D2OrganisationUnit;
-    programInstances: D2ProgramInstance[];
-    programOwners: any[];
-    publicAccess: string;
-    relationshipItems: any[];
-    trackedEntityAttributeValues: D2TrackedEntityAttributeValue[];
-    trackedEntityType: D2TrackedEntityType;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2MinMaxDataElement = {
-    dataElement: D2DataElement;
-    generated: boolean;
-    max: number;
-    min: number;
-    optionCombo: D2CategoryOptionCombo;
-    source: D2OrganisationUnit;
-};
-
-export type D2ProgramStageInstanceFilter = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    description: string;
-    displayName: string;
-    eventQueryCriteria: any;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    program: Id;
-    programStage: Id;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2DataElementGroupSetDimension = {
-    dataElementGroupSet: D2DataElementGroupSet;
-    dataElementGroups: D2DataElementGroup[];
-};
-
-export type D2ProgramTrackedEntityAttribute = {
-    access: D2Access;
-    allowFutureDate: boolean;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    displayInList: boolean;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    mandatory: boolean;
-    name: string;
-    program: D2Program;
-    programTrackedEntityAttributeGroups: D2ProgramTrackedEntityAttributeGroup[];
-    publicAccess: string;
-    renderOptionsAsRadio: boolean;
-    renderType: any;
-    searchable: boolean;
-    sortOrder: number;
-    trackedEntityAttribute: D2TrackedEntityAttribute;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    valueType:
-        | "TEXT"
-        | "LONG_TEXT"
-        | "LETTER"
-        | "PHONE_NUMBER"
-        | "EMAIL"
-        | "BOOLEAN"
-        | "TRUE_ONLY"
-        | "DATE"
-        | "DATETIME"
-        | "TIME"
-        | "NUMBER"
-        | "UNIT_INTERVAL"
-        | "PERCENTAGE"
-        | "INTEGER"
-        | "INTEGER_POSITIVE"
-        | "INTEGER_NEGATIVE"
-        | "INTEGER_ZERO_OR_POSITIVE"
-        | "TRACKER_ASSOCIATE"
-        | "USERNAME"
-        | "COORDINATE"
-        | "ORGANISATION_UNIT"
-        | "AGE"
-        | "URL"
-        | "FILE_RESOURCE"
-        | "IMAGE";
-};
-
-export type D2MessageConversation = {
-    access: D2Access;
-    assignee: D2User;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    followUp: boolean;
-    href: string;
-    id: Id;
-    lastMessage: string;
-    lastSender: D2User;
-    lastSenderFirstname: string;
-    lastSenderSurname: string;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    messageCount: number;
-    messageType: "PRIVATE" | "SYSTEM" | "VALIDATION_RESULT" | "TICKET";
-    messages: any[];
-    name: string;
-    priority: "NONE" | "LOW" | "MEDIUM" | "HIGH";
-    publicAccess: string;
-    read: boolean;
-    status: "NONE" | "OPEN" | "PENDING" | "INVALID" | "SOLVED";
-    subject: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userFirstname: string;
-    userGroupAccesses: D2UserGroupAccess[];
-    userMessages: any[];
-    userSurname: string;
-};
-
-export type D2OrganisationUnitGroupSetDimension = {
-    organisationUnitGroupSet: D2OrganisationUnitGroupSet;
-    organisationUnitGroups: D2OrganisationUnitGroup[];
-};
-
-export type D2CategoryOptionGroupSetDimension = {
-    categoryOptionGroupSet: D2CategoryOptionGroupSet;
-    categoryOptionGroups: D2CategoryOptionGroup[];
-};
-
-export type D2UserGroupAccess = {
-    access: string;
-    displayName: string;
-    id: string;
-    userGroupUid: string;
-};
-
-export type D2TrackedEntityInstanceFilter = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    description: string;
-    displayName: string;
-    enrollmentCreatedPeriod: any;
-    enrollmentStatus: "ACTIVE" | "COMPLETED" | "CANCELLED";
-    eventFilters: any[];
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    followup: boolean;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    program: D2Program;
-    publicAccess: string;
-    sortOrder: number;
-    style: D2Style;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2ProgramDataElementDimensionItem = {
-    access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "FIRST"
-        | "FIRST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    dataElement: D2DataElement;
-    description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
-    name: string;
-    program: D2Program;
-    publicAccess: string;
-    shortName: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    valueType:
-        | "TEXT"
-        | "LONG_TEXT"
-        | "LETTER"
-        | "PHONE_NUMBER"
-        | "EMAIL"
-        | "BOOLEAN"
-        | "TRUE_ONLY"
-        | "DATE"
-        | "DATETIME"
-        | "TIME"
-        | "NUMBER"
-        | "UNIT_INTERVAL"
-        | "PERCENTAGE"
-        | "INTEGER"
-        | "INTEGER_POSITIVE"
-        | "INTEGER_NEGATIVE"
-        | "INTEGER_ZERO_OR_POSITIVE"
-        | "TRACKER_ASSOCIATE"
-        | "USERNAME"
-        | "COORDINATE"
-        | "ORGANISATION_UNIT"
-        | "AGE"
-        | "URL"
-        | "FILE_RESOURCE"
-        | "IMAGE";
-};
-
-export type D2ReportingRate = {
-    access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "FIRST"
-        | "FIRST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    dataSet: D2DataSet;
-    description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
-    metric:
-        | "REPORTING_RATE"
-        | "REPORTING_RATE_ON_TIME"
-        | "ACTUAL_REPORTS"
-        | "ACTUAL_REPORTS_ON_TIME"
-        | "EXPECTED_REPORTS";
-    name: string;
-    publicAccess: string;
-    shortName: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2MetadataVersion = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    hashCode: string;
-    href: string;
-    id: Id;
-    importDate: string;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    type: "BEST_EFFORT" | "ATOMIC";
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2DataInputPeriod = {
-    closingDate: string;
-    openingDate: string;
-    period: any;
-};
-
-export type D2Icon = {};
-
-export type D2TrackedEntityAttributeValue = {
-    created: string;
-    lastUpdated: string;
-    storedBy: string;
-    trackedEntityAttribute: D2TrackedEntityAttribute;
-    trackedEntityInstance: D2TrackedEntityInstance;
-    value: string;
-};
-
-export type D2Interpretation = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    chart: D2Chart;
-    code: Id;
-    comments: D2InterpretationComment[];
-    created: string;
-    dataSet: D2DataSet;
-    displayName: string;
-    eventChart: D2EventChart;
-    eventReport: D2EventReport;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    likedBy: D2User[];
-    likes: number;
-    map: D2Map;
-    mentions: any[];
-    name: string;
-    organisationUnit: D2OrganisationUnit;
-    period: any;
-    publicAccess: string;
-    reportTable: D2ReportTable;
-    text: string;
-    translations: D2Translation[];
-    type:
-        | "VISUALIZATION"
-        | "REPORT_TABLE"
-        | "CHART"
-        | "MAP"
-        | "EVENT_REPORT"
-        | "EVENT_CHART"
-        | "DATASET_REPORT";
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    visualization: D2Visualization;
-};
-
-export type D2ProgramStageDataElement = {
-    access: D2Access;
-    allowFutureDate: boolean;
-    allowProvidedElsewhere: boolean;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    compulsory: boolean;
-    created: string;
-    dataElement: D2DataElement;
-    displayInReports: boolean;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    programStage: D2ProgramStage;
-    publicAccess: string;
-    renderOptionsAsRadio: boolean;
-    renderType: any;
-    skipSynchronization: boolean;
-    sortOrder: number;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2InterpretationComment = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    mentions: any[];
-    name: string;
-    publicAccess: string;
-    text: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2TrackedEntityProgramIndicatorDimension = {
-    filter: string;
-    legendSet: D2LegendSet;
-    programIndicator: D2ProgramIndicator;
-};
-
-export type D2ProgramStageInstance = {
-    access: D2Access;
-    assignedUser: D2User;
-    attributeOptionCombo: D2CategoryOptionCombo;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    comments: any[];
-    completed: boolean;
-    completedBy: string;
-    completedDate: string;
-    creatableInSearchScope: boolean;
-    created: string;
-    createdAtClient: string;
-    deleted: boolean;
-    displayName: string;
-    dueDate: string;
-    eventDataValues: any[];
-    eventDate: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    geometry: D2Geometry;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedAtClient: string;
-    lastUpdatedBy: D2User;
-    messageConversations: D2MessageConversation[];
-    name: string;
-    organisationUnit: D2OrganisationUnit;
-    programInstance: D2ProgramInstance;
-    programStage: D2ProgramStage;
-    publicAccess: string;
-    relationshipItems: any[];
-    status: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";
-    storedBy: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2CategoryDimension = {
-    category: D2Category;
-    categoryOptions: D2CategoryOption[];
-};
-
-export type D2UserCredentials = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    catDimensionConstraints: D2Category[];
-    code: Id;
-    cogsDimensionConstraints: D2CategoryOptionGroupSet[];
-    created: string;
-    disabled: boolean;
-    displayName: string;
-    externalAccess: boolean;
-    externalAuth: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    invitation: boolean;
-    lastLogin: string;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    ldapId: string;
-    name: string;
-    openId: string;
-    password: string;
-    passwordLastUpdated: string;
-    publicAccess: string;
-    selfRegistered: boolean;
-    translations: D2Translation[];
-    twoFA: boolean;
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-    userInfo: D2User;
-    userRoles: D2UserAuthorityGroup[];
-    username: string;
-};
-
-export type D2Color = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    color: string;
-    created: string;
-    displayName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2ProgramInstance = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    completedBy: string;
-    created: string;
-    createdAtClient: string;
-    deleted: boolean;
-    displayName: string;
-    endDate: string;
-    enrollmentDate: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    followup: boolean;
-    geometry: D2Geometry;
-    href: string;
-    id: Id;
-    incidentDate: string;
-    lastUpdated: string;
-    lastUpdatedAtClient: string;
-    lastUpdatedBy: D2User;
-    messageConversations: D2MessageConversation[];
-    name: string;
-    organisationUnit: D2OrganisationUnit;
-    program: D2Program;
-    programStageInstances: D2ProgramStageInstance[];
-    publicAccess: string;
-    relationshipItems: any[];
-    status: "ACTIVE" | "COMPLETED" | "CANCELLED";
-    storedBy: string;
-    trackedEntityComments: any[];
-    trackedEntityInstance: D2TrackedEntityInstance;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2FileResource = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    contentLength: string;
-    contentMd5: string;
-    contentType: string;
-    created: string;
-    displayName: string;
-    domain: "DATA_VALUE" | "PUSH_ANALYSIS" | "DOCUMENT" | "MESSAGE_ATTACHMENT" | "USER_AVATAR";
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    hasMultipleStorageFiles: boolean;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    storageStatus: "NONE" | "PENDING" | "FAILED" | "STORED";
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2Legend = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    color: string;
-    created: string;
-    displayName: string;
-    endValue: number;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    href: string;
-    id: Id;
-    image: string;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    startValue: number;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2ProgramTrackedEntityAttributeDimensionItem = {
-    access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "FIRST"
-        | "FIRST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    attribute: D2TrackedEntityAttribute;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
-    name: string;
-    program: D2Program;
-    publicAccess: string;
-    shortName: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2TrackedEntityDataElementDimension = {
-    dataElement: D2DataElement;
-    filter: string;
-    legendSet: D2LegendSet;
-    programStage: D2ProgramStage;
-};
-
-export type D2Relationship = {
-    access: D2Access;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    code: Id;
-    created: string;
-    description: string;
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    from: any;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    name: string;
-    publicAccess: string;
-    relationshipType: D2RelationshipType;
-    shortName: string;
-    style: D2Style;
-    to: any;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export type D2DataElementOperand = {
-    access: D2Access;
-    aggregationType:
-        | "SUM"
-        | "AVERAGE"
-        | "AVERAGE_SUM_ORG_UNIT"
-        | "LAST"
-        | "LAST_AVERAGE_ORG_UNIT"
-        | "FIRST"
-        | "FIRST_AVERAGE_ORG_UNIT"
-        | "COUNT"
-        | "STDDEV"
-        | "VARIANCE"
-        | "MIN"
-        | "MAX"
-        | "NONE"
-        | "CUSTOM"
-        | "DEFAULT";
-    attributeOptionCombo: D2CategoryOptionCombo;
-    attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-    categoryOptionCombo: D2CategoryOptionCombo;
-    code: Id;
-    created: string;
-    dataElement: D2DataElement;
-    description: string;
-    dimensionItem: string;
-    dimensionItemType:
-        | "DATA_ELEMENT"
-        | "DATA_ELEMENT_OPERAND"
-        | "INDICATOR"
-        | "REPORTING_RATE"
-        | "PROGRAM_DATA_ELEMENT"
-        | "PROGRAM_ATTRIBUTE"
-        | "PROGRAM_INDICATOR"
-        | "PERIOD"
-        | "ORGANISATION_UNIT"
-        | "CATEGORY_OPTION"
-        | "OPTION_GROUP"
-        | "DATA_ELEMENT_GROUP"
-        | "ORGANISATION_UNIT_GROUP"
-        | "CATEGORY_OPTION_GROUP";
-    displayDescription: string;
-    displayFormName: string;
-    displayName: string;
-    displayShortName: string;
-    externalAccess: boolean;
-    favorite: boolean;
-    favorites: string[];
-    formName: string;
-    href: string;
-    id: Id;
-    lastUpdated: string;
-    lastUpdatedBy: D2User;
-    legendSet: D2LegendSet;
-    legendSets: D2LegendSet[];
-    name: string;
-    publicAccess: string;
-    shortName: string;
-    translations: D2Translation[];
-    user: D2User;
-    userAccesses: D2UserAccess[];
-    userGroupAccesses: D2UserGroupAccess[];
-};
-
-export interface D2UserAuthorityGroupSchema {
-    name: "D2UserAuthorityGroup";
-    model: D2UserAuthorityGroup;
+export interface D2AnalyticsPeriodBoundarySchema {
+    name: "D2AnalyticsPeriodBoundary";
+    model: D2AnalyticsPeriodBoundary;
     fields: {
         access: D2Access;
+        analyticsPeriodBoundaryType:
+            | "BEFORE_START_OF_REPORTING_PERIOD"
+            | "BEFORE_END_OF_REPORTING_PERIOD"
+            | "AFTER_START_OF_REPORTING_PERIOD"
+            | "AFTER_END_OF_REPORTING_PERIOD";
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        authorities: string[];
+        boundaryTarget: string;
         code: Id;
         created: string;
-        description: string;
         displayName: string;
         externalAccess: boolean;
         favorite: boolean;
@@ -4750,48 +4756,121 @@ export interface D2UserAuthorityGroupSchema {
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
         name: string;
+        offsetPeriodType: string;
+        offsetPeriods: number;
         publicAccess: string;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
-        users: D2UserSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2UserAuthorityGroup, keyof D2UserAuthorityGroup>;
-        $identifiable: Preset<D2UserAuthorityGroup, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2UserAuthorityGroup, FieldPresets["nameable"]>;
+        $all: Preset<D2AnalyticsPeriodBoundary, keyof D2AnalyticsPeriodBoundary>;
+        $identifiable: Preset<D2AnalyticsPeriodBoundary, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2AnalyticsPeriodBoundary, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2UserAuthorityGroup,
+            D2AnalyticsPeriodBoundary,
             | "lastUpdatedBy"
-            | "userGroupAccesses"
             | "code"
             | "created"
-            | "publicAccess"
-            | "description"
-            | "authorities"
             | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
+            | "offsetPeriodType"
             | "id"
-            | "user"
+            | "analyticsPeriodBoundaryType"
+            | "boundaryTarget"
+            | "offsetPeriods"
         >;
         $owner: Preset<
-            D2UserAuthorityGroup,
+            D2AnalyticsPeriodBoundary,
             | "lastUpdatedBy"
-            | "userGroupAccesses"
             | "code"
             | "created"
-            | "publicAccess"
-            | "description"
-            | "authorities"
             | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
+            | "offsetPeriodType"
             | "id"
-            | "user"
+            | "analyticsPeriodBoundaryType"
+            | "boundaryTarget"
+            | "offsetPeriods"
+        >;
+    };
+}
+
+export interface D2AnalyticsTableHookSchema {
+    name: "D2AnalyticsTableHook";
+    model: D2AnalyticsTableHook;
+    fields: {
+        access: D2Access;
+        analyticsTableType:
+            | "DATA_VALUE"
+            | "COMPLETENESS"
+            | "COMPLETENESS_TARGET"
+            | "ORG_UNIT_TARGET"
+            | "EVENT"
+            | "ENROLLMENT"
+            | "VALIDATION_RESULT";
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        phase: "RESOURCE_TABLE_POPULATED" | "ANALYTICS_TABLE_POPULATED";
+        publicAccess: string;
+        resourceTableType:
+            | "ORG_UNIT_STRUCTURE"
+            | "DATA_SET_ORG_UNIT_CATEGORY"
+            | "CATEGORY_OPTION_COMBO_NAME"
+            | "DATA_ELEMENT_GROUP_SET_STRUCTURE"
+            | "INDICATOR_GROUP_SET_STRUCTURE"
+            | "ORG_UNIT_GROUP_SET_STRUCTURE"
+            | "CATEGORY_STRUCTURE"
+            | "DATA_ELEMENT_STRUCTURE"
+            | "PERIOD_STRUCTURE"
+            | "DATE_PERIOD_STRUCTURE"
+            | "DATA_ELEMENT_CATEGORY_OPTION_COMBO"
+            | "DATA_APPROVAL_REMAP_LEVEL"
+            | "DATA_APPROVAL_MIN_LEVEL";
+        sql: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2AnalyticsTableHook, keyof D2AnalyticsTableHook>;
+        $identifiable: Preset<D2AnalyticsTableHook, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2AnalyticsTableHook, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2AnalyticsTableHook,
+            | "phase"
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "analyticsTableType"
+            | "sql"
+            | "lastUpdated"
+            | "name"
+            | "resourceTableType"
+            | "id"
+        >;
+        $owner: Preset<
+            D2AnalyticsTableHook,
+            | "phase"
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "analyticsTableType"
+            | "sql"
+            | "lastUpdated"
+            | "name"
+            | "resourceTableType"
+            | "id"
         >;
     };
 }
@@ -4994,778 +5073,9 @@ export interface D2AttributeSchema {
     };
 }
 
-export interface D2UserSchema {
-    name: "D2User";
-    model: D2User;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        avatar: D2FileResourceSchema;
-        birthday: string;
-        code: Id;
-        created: string;
-        dataViewOrganisationUnits: D2OrganisationUnitSchema[];
-        displayName: string;
-        education: string;
-        email: string;
-        employer: string;
-        externalAccess: boolean;
-        facebookMessenger: string;
-        favorite: boolean;
-        favorites: string[];
-        firstName: string;
-        gender: string;
-        href: string;
-        id: Id;
-        interests: string;
-        introduction: string;
-        jobTitle: string;
-        languages: string;
-        lastCheckedInterpretations: string;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        nationality: string;
-        organisationUnits: D2OrganisationUnitSchema[];
-        phoneNumber: string;
-        publicAccess: string;
-        skype: string;
-        surname: string;
-        teiSearchOrganisationUnits: D2OrganisationUnitSchema[];
-        telegram: string;
-        translations: D2Translation[];
-        twitter: string;
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userCredentials: D2UserCredentialsSchema;
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        userGroups: D2UserGroupSchema[];
-        welcomeMessage: string;
-        whatsApp: string;
-    };
-    fieldPresets: {
-        $all: Preset<D2User, keyof D2User>;
-        $identifiable: Preset<D2User, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2User, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2User,
-            | "birthday"
-            | "code"
-            | "education"
-            | "gender"
-            | "jobTitle"
-            | "skype"
-            | "lastUpdated"
-            | "teiSearchOrganisationUnits"
-            | "twitter"
-            | "surname"
-            | "employer"
-            | "id"
-            | "organisationUnits"
-            | "facebookMessenger"
-            | "introduction"
-            | "email"
-            | "dataViewOrganisationUnits"
-            | "whatsApp"
-            | "languages"
-            | "created"
-            | "welcomeMessage"
-            | "userCredentials"
-            | "attributeValues"
-            | "telegram"
-            | "avatar"
-            | "lastCheckedInterpretations"
-            | "userGroups"
-            | "firstName"
-            | "phoneNumber"
-            | "nationality"
-            | "interests"
-        >;
-        $owner: Preset<
-            D2User,
-            | "birthday"
-            | "code"
-            | "education"
-            | "gender"
-            | "jobTitle"
-            | "skype"
-            | "lastUpdated"
-            | "teiSearchOrganisationUnits"
-            | "twitter"
-            | "surname"
-            | "employer"
-            | "id"
-            | "organisationUnits"
-            | "facebookMessenger"
-            | "introduction"
-            | "email"
-            | "dataViewOrganisationUnits"
-            | "whatsApp"
-            | "languages"
-            | "created"
-            | "welcomeMessage"
-            | "userCredentials"
-            | "attributeValues"
-            | "telegram"
-            | "avatar"
-            | "lastCheckedInterpretations"
-            | "firstName"
-            | "phoneNumber"
-            | "nationality"
-            | "interests"
-        >;
-    };
-}
-
-export interface D2UserGroupSchema {
-    name: "D2UserGroup";
-    model: D2UserGroup;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        managedByGroups: D2UserGroupSchema[];
-        managedGroups: D2UserGroupSchema[];
-        name: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        users: D2UserSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2UserGroup, keyof D2UserGroup>;
-        $identifiable: Preset<D2UserGroup, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2UserGroup, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2UserGroup,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "managedByGroups"
-            | "attributeValues"
-            | "users"
-            | "managedGroups"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2UserGroup,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "users"
-            | "managedGroups"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
-export interface D2ExpressionSchema {
-    name: "D2Expression";
-    model: D2Expression;
-    fields: {
-        description: string;
-        expression: string;
-        missingValueStrategy:
-            | "SKIP_IF_ANY_VALUE_MISSING"
-            | "SKIP_IF_ALL_VALUES_MISSING"
-            | "NEVER_SKIP";
-        slidingWindow: boolean;
-    };
-    fieldPresets: {
-        $all: Preset<D2Expression, keyof D2Expression>;
-        $identifiable: Preset<D2Expression, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Expression, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Expression,
-            "description" | "expression" | "missingValueStrategy" | "slidingWindow"
-        >;
-        $owner: Preset<
-            D2Expression,
-            "description" | "expression" | "missingValueStrategy" | "slidingWindow"
-        >;
-    };
-}
-
-export interface D2ExternalFileResourceSchema {
-    name: "D2ExternalFileResource";
-    model: D2ExternalFileResource;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ExternalFileResource, keyof D2ExternalFileResource>;
-        $identifiable: Preset<D2ExternalFileResource, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ExternalFileResource, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ExternalFileResource,
-            "lastUpdatedBy" | "code" | "created" | "lastUpdated" | "id"
-        >;
-        $owner: Preset<
-            D2ExternalFileResource,
-            "lastUpdatedBy" | "code" | "created" | "lastUpdated" | "id"
-        >;
-    };
-}
-
-export interface D2SqlViewSchema {
-    name: "D2SqlView";
-    model: D2SqlView;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        cacheStrategy:
-            | "NO_CACHE"
-            | "CACHE_1_MINUTE"
-            | "CACHE_5_MINUTES"
-            | "CACHE_10_MINUTES"
-            | "CACHE_15_MINUTES"
-            | "CACHE_30_MINUTES"
-            | "CACHE_1_HOUR"
-            | "CACHE_6AM_TOMORROW"
-            | "CACHE_TWO_WEEKS"
-            | "RESPECT_SYSTEM_SETTING";
-        code: Id;
-        created: string;
-        description: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        sqlQuery: string;
-        translations: D2Translation[];
-        type: "VIEW" | "MATERIALIZED_VIEW" | "QUERY";
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2SqlView, keyof D2SqlView>;
-        $identifiable: Preset<D2SqlView, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2SqlView, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2SqlView,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "sqlQuery"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "description"
-            | "type"
-            | "externalAccess"
-            | "lastUpdated"
-            | "userAccesses"
-            | "name"
-            | "cacheStrategy"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2SqlView,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "sqlQuery"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "description"
-            | "type"
-            | "externalAccess"
-            | "lastUpdated"
-            | "userAccesses"
-            | "name"
-            | "cacheStrategy"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
-export interface D2ConstantSchema {
-    name: "D2Constant";
-    model: D2Constant;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        shortName: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        value: number;
-    };
-    fieldPresets: {
-        $all: Preset<D2Constant, keyof D2Constant>;
-        $identifiable: Preset<D2Constant, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Constant, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Constant,
-            | "code"
-            | "publicAccess"
-            | "description"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "value"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "userAccesses"
-            | "name"
-            | "shortName"
-            | "user"
-        >;
-        $owner: Preset<
-            D2Constant,
-            | "code"
-            | "publicAccess"
-            | "description"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "value"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "userAccesses"
-            | "name"
-            | "shortName"
-            | "user"
-        >;
-    };
-}
-
-export interface D2OAuth2ClientSchema {
-    name: "D2OAuth2Client";
-    model: D2OAuth2Client;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        cid: Id;
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        grantTypes: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        redirectUris: string[];
-        secret: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2OAuth2Client, keyof D2OAuth2Client>;
-        $identifiable: Preset<D2OAuth2Client, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OAuth2Client, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2OAuth2Client,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "secret"
-            | "redirectUris"
-            | "lastUpdated"
-            | "grantTypes"
-            | "name"
-            | "id"
-            | "cid"
-        >;
-        $owner: Preset<
-            D2OAuth2Client,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "secret"
-            | "redirectUris"
-            | "lastUpdated"
-            | "grantTypes"
-            | "name"
-            | "id"
-            | "cid"
-        >;
-    };
-}
-
-export interface D2OptionSchema {
-    name: "D2Option";
-    model: D2Option;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: string;
-        created: string;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        optionSet: D2OptionSetSchema;
-        publicAccess: string;
-        shortName: string;
-        sortOrder: number;
-        style: D2Style;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Option, keyof D2Option>;
-        $identifiable: Preset<D2Option, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Option, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Option,
-            | "code"
-            | "description"
-            | "lastUpdated"
-            | "optionSet"
-            | "translations"
-            | "formName"
-            | "id"
-            | "created"
-            | "attributeValues"
-            | "sortOrder"
-            | "name"
-            | "style"
-        >;
-        $owner: Preset<
-            D2Option,
-            | "code"
-            | "description"
-            | "lastUpdated"
-            | "optionSet"
-            | "translations"
-            | "formName"
-            | "id"
-            | "created"
-            | "attributeValues"
-            | "sortOrder"
-            | "name"
-            | "style"
-        >;
-    };
-}
-
-export interface D2JobConfigurationSchema {
-    name: "D2JobConfiguration";
-    model: D2JobConfiguration;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        configurable: boolean;
-        created: string;
-        cronExpression: string;
-        delay: number;
-        displayName: string;
-        enabled: boolean;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        jobParameters: string;
-        jobStatus:
-            | "RUNNING"
-            | "COMPLETED"
-            | "STOPPED"
-            | "SCHEDULED"
-            | "DISABLED"
-            | "FAILED"
-            | "NOT_STARTED";
-        jobType:
-            | "DATA_STATISTICS"
-            | "DATA_INTEGRITY"
-            | "RESOURCE_TABLE"
-            | "ANALYTICS_TABLE"
-            | "CONTINUOUS_ANALYTICS_TABLE"
-            | "DATA_SYNC"
-            | "TRACKER_PROGRAMS_DATA_SYNC"
-            | "EVENT_PROGRAMS_DATA_SYNC"
-            | "FILE_RESOURCE_CLEANUP"
-            | "IMAGE_PROCESSING"
-            | "META_DATA_SYNC"
-            | "SMS_SEND"
-            | "SEND_SCHEDULED_MESSAGE"
-            | "PROGRAM_NOTIFICATIONS"
-            | "VALIDATION_RESULTS_NOTIFICATION"
-            | "CREDENTIALS_EXPIRY_ALERT"
-            | "MONITORING"
-            | "PUSH_ANALYSIS"
-            | "PREDICTOR"
-            | "DATA_SET_NOTIFICATION"
-            | "REMOVE_EXPIRED_RESERVED_VALUES"
-            | "TRACKER_IMPORT_JOB"
-            | "TRACKER_IMPORT_NOTIFICATION_JOB"
-            | "TRACKER_IMPORT_RULE_ENGINE_JOB"
-            | "MOCK"
-            | "DATAVALUE_IMPORT"
-            | "ANALYTICSTABLE_UPDATE"
-            | "METADATA_IMPORT"
-            | "GML_IMPORT"
-            | "DATAVALUE_IMPORT_INTERNAL"
-            | "EVENT_IMPORT"
-            | "ENROLLMENT_IMPORT"
-            | "TEI_IMPORT"
-            | "LEADER_ELECTION"
-            | "LEADER_RENEWAL"
-            | "COMPLETE_DATA_SET_REGISTRATION_IMPORT"
-            | "PROGRAM_DATA_SYNC";
-        lastExecuted: string;
-        lastExecutedStatus:
-            | "RUNNING"
-            | "COMPLETED"
-            | "STOPPED"
-            | "SCHEDULED"
-            | "DISABLED"
-            | "FAILED"
-            | "NOT_STARTED";
-        lastRuntimeExecution: string;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        leaderOnlyJob: boolean;
-        name: string;
-        nextExecutionTime: string;
-        publicAccess: string;
-        schedulingType: "CRON" | "FIXED_DELAY";
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        userUid: string;
-    };
-    fieldPresets: {
-        $all: Preset<D2JobConfiguration, keyof D2JobConfiguration>;
-        $identifiable: Preset<D2JobConfiguration, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2JobConfiguration, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2JobConfiguration,
-            | "jobStatus"
-            | "code"
-            | "enabled"
-            | "leaderOnlyJob"
-            | "lastUpdated"
-            | "id"
-            | "jobType"
-            | "lastUpdatedBy"
-            | "nextExecutionTime"
-            | "created"
-            | "cronExpression"
-            | "lastRuntimeExecution"
-            | "delay"
-            | "lastExecutedStatus"
-            | "name"
-            | "jobParameters"
-            | "lastExecuted"
-        >;
-        $owner: Preset<
-            D2JobConfiguration,
-            | "jobStatus"
-            | "code"
-            | "enabled"
-            | "leaderOnlyJob"
-            | "lastUpdated"
-            | "id"
-            | "jobType"
-            | "lastUpdatedBy"
-            | "nextExecutionTime"
-            | "created"
-            | "cronExpression"
-            | "lastRuntimeExecution"
-            | "delay"
-            | "lastExecutedStatus"
-            | "name"
-            | "jobParameters"
-            | "lastExecuted"
-        >;
-    };
-}
-
-export interface D2OptionSetSchema {
-    name: "D2OptionSet";
-    model: D2OptionSet;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        options: D2OptionSchema[];
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        valueType:
-            | "TEXT"
-            | "LONG_TEXT"
-            | "LETTER"
-            | "PHONE_NUMBER"
-            | "EMAIL"
-            | "BOOLEAN"
-            | "TRUE_ONLY"
-            | "DATE"
-            | "DATETIME"
-            | "TIME"
-            | "NUMBER"
-            | "UNIT_INTERVAL"
-            | "PERCENTAGE"
-            | "INTEGER"
-            | "INTEGER_POSITIVE"
-            | "INTEGER_NEGATIVE"
-            | "INTEGER_ZERO_OR_POSITIVE"
-            | "TRACKER_ASSOCIATE"
-            | "USERNAME"
-            | "COORDINATE"
-            | "ORGANISATION_UNIT"
-            | "AGE"
-            | "URL"
-            | "FILE_RESOURCE"
-            | "IMAGE";
-        version: number;
-    };
-    fieldPresets: {
-        $all: Preset<D2OptionSet, keyof D2OptionSet>;
-        $identifiable: Preset<D2OptionSet, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OptionSet, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2OptionSet,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "version"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "valueType"
-            | "name"
-            | "options"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2OptionSet,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "version"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "valueType"
-            | "name"
-            | "options"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
-export interface D2OptionGroupSetSchema {
-    name: "D2OptionGroupSet";
-    model: D2OptionGroupSet;
+export interface D2CategorySchema {
+    name: "D2Category";
+    model: D2Category;
     fields: {
         access: D2Access;
         aggregationType:
@@ -5786,6 +5096,8 @@ export interface D2OptionGroupSetSchema {
             | "DEFAULT";
         allItems: boolean;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        categoryCombos: D2CategoryComboSchema[];
+        categoryOptions: D2CategoryOptionSchema[];
         code: Id;
         created: string;
         dataDimension: boolean;
@@ -5828,8 +5140,6 @@ export interface D2OptionGroupSetSchema {
         lastUpdatedBy: D2UserSchema;
         legendSet: D2LegendSetSchema;
         name: string;
-        optionGroups: D2OptionGroupSchema[];
-        optionSet: D2OptionSetSchema;
         programStage: D2ProgramStageSchema;
         publicAccess: string;
         shortName: string;
@@ -5839,40 +5149,41 @@ export interface D2OptionGroupSetSchema {
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2OptionGroupSet, keyof D2OptionGroupSet>;
-        $identifiable: Preset<D2OptionGroupSet, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OptionGroupSet, FieldPresets["nameable"]>;
+        $all: Preset<D2Category, keyof D2Category>;
+        $identifiable: Preset<D2Category, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Category, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2OptionGroupSet,
+            D2Category,
+            | "dataDimensionType"
             | "code"
             | "publicAccess"
-            | "description"
-            | "optionGroups"
             | "lastUpdated"
-            | "optionSet"
             | "translations"
+            | "categoryCombos"
             | "id"
+            | "categoryOptions"
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "created"
+            | "attributeValues"
             | "userAccesses"
             | "name"
             | "dataDimension"
             | "user"
         >;
         $owner: Preset<
-            D2OptionGroupSet,
+            D2Category,
+            | "dataDimensionType"
             | "code"
             | "publicAccess"
-            | "description"
-            | "optionGroups"
             | "lastUpdated"
-            | "optionSet"
             | "translations"
             | "id"
+            | "categoryOptions"
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "created"
+            | "attributeValues"
             | "userAccesses"
             | "name"
             | "dataDimension"
@@ -5881,672 +5192,86 @@ export interface D2OptionGroupSetSchema {
     };
 }
 
-export interface D2OptionGroupSchema {
-    name: "D2OptionGroup";
-    model: D2OptionGroup;
-    fields: {
-        access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "FIRST"
-            | "FIRST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        description: string;
-        dimensionItem: string;
-        dimensionItemType:
-            | "DATA_ELEMENT"
-            | "DATA_ELEMENT_OPERAND"
-            | "INDICATOR"
-            | "REPORTING_RATE"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION"
-            | "OPTION_GROUP"
-            | "DATA_ELEMENT_GROUP"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY_OPTION_GROUP";
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        legendSet: D2LegendSetSchema;
-        legendSets: D2LegendSetSchema[];
-        name: string;
-        optionSet: D2OptionSetSchema;
-        options: D2OptionSchema[];
-        publicAccess: string;
-        shortName: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2OptionGroup, keyof D2OptionGroup>;
-        $identifiable: Preset<D2OptionGroup, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OptionGroup, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2OptionGroup,
-            | "code"
-            | "publicAccess"
-            | "lastUpdated"
-            | "optionSet"
-            | "translations"
-            | "options"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "userAccesses"
-            | "name"
-            | "shortName"
-            | "user"
-        >;
-        $owner: Preset<
-            D2OptionGroup,
-            | "code"
-            | "publicAccess"
-            | "lastUpdated"
-            | "optionSet"
-            | "translations"
-            | "options"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "userAccesses"
-            | "name"
-            | "shortName"
-            | "user"
-        >;
-    };
-}
-
-export interface D2LegendSetSchema {
-    name: "D2LegendSet";
-    model: D2LegendSet;
+export interface D2CategoryComboSchema {
+    name: "D2CategoryCombo";
+    model: D2CategoryCombo;
     fields: {
         access: D2Access;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        categories: D2CategorySchema[];
+        categoryOptionCombos: D2CategoryOptionComboSchema[];
         code: Id;
         created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        legends: D2LegendSchema[];
-        name: string;
-        publicAccess: string;
-        symbolizer: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2LegendSet, keyof D2LegendSet>;
-        $identifiable: Preset<D2LegendSet, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2LegendSet, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2LegendSet,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "symbolizer"
-            | "lastUpdated"
-            | "legends"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2LegendSet,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "symbolizer"
-            | "lastUpdated"
-            | "legends"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
-export interface D2ColorSetSchema {
-    name: "D2ColorSet";
-    model: D2ColorSet;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        colors: D2ColorSchema[];
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ColorSet, keyof D2ColorSet>;
-        $identifiable: Preset<D2ColorSet, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ColorSet, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ColorSet,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "colors"
-            | "lastUpdated"
-            | "translations"
-            | "name"
-            | "id"
-        >;
-        $owner: Preset<
-            D2ColorSet,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "colors"
-            | "lastUpdated"
-            | "translations"
-            | "name"
-            | "id"
-        >;
-    };
-}
-
-export interface D2OrganisationUnitSchema {
-    name: "D2OrganisationUnit";
-    model: D2OrganisationUnit;
-    fields: {
-        access: D2Access;
-        address: string;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "FIRST"
-            | "FIRST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
-        ancestors: D2OrganisationUnitSchema[];
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        children: D2OrganisationUnitSchema[];
-        closedDate: string;
-        code: Id;
-        comment: string;
-        contactPerson: string;
-        created: string;
-        dataSets: D2DataSetSchema[];
-        description: string;
-        dimensionItem: string;
-        dimensionItemType:
-            | "DATA_ELEMENT"
-            | "DATA_ELEMENT_OPERAND"
-            | "INDICATOR"
-            | "REPORTING_RATE"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION"
-            | "OPTION_GROUP"
-            | "DATA_ELEMENT_GROUP"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY_OPTION_GROUP";
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        email: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        geometry: D2Geometry;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        leaf: boolean;
-        legendSet: D2LegendSetSchema;
-        legendSets: D2LegendSetSchema[];
-        level: number;
-        memberCount: number;
-        name: string;
-        openingDate: string;
-        organisationUnitGroups: D2OrganisationUnitGroupSchema[];
-        parent: D2OrganisationUnitSchema;
-        path: string;
-        phoneNumber: string;
-        programs: D2ProgramSchema[];
-        publicAccess: string;
-        shortName: string;
-        translations: D2Translation[];
-        type: string;
-        url: string;
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        users: D2UserSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2OrganisationUnit, keyof D2OrganisationUnit>;
-        $identifiable: Preset<D2OrganisationUnit, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OrganisationUnit, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2OrganisationUnit,
-            | "parent"
-            | "path"
-            | "lastUpdated"
-            | "children"
-            | "translations"
-            | "id"
-            | "organisationUnitGroups"
-            | "lastUpdatedBy"
-            | "level"
-            | "created"
-            | "attributeValues"
-            | "users"
-            | "phoneNumber"
-            | "name"
-            | "dataSets"
-            | "programs"
-            | "shortName"
-            | "code"
-            | "description"
-            | "contactPerson"
-            | "openingDate"
-            | "email"
-            | "address"
-            | "url"
-            | "closedDate"
-            | "geometry"
-            | "comment"
-            | "user"
-        >;
-        $owner: Preset<
-            D2OrganisationUnit,
-            | "parent"
-            | "path"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "level"
-            | "created"
-            | "attributeValues"
-            | "phoneNumber"
-            | "name"
-            | "shortName"
-            | "code"
-            | "description"
-            | "contactPerson"
-            | "openingDate"
-            | "email"
-            | "address"
-            | "url"
-            | "closedDate"
-            | "geometry"
-            | "comment"
-            | "user"
-        >;
-    };
-}
-
-export interface D2OrganisationUnitLevelSchema {
-    name: "D2OrganisationUnitLevel";
-    model: D2OrganisationUnitLevel;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        level: number;
-        name: string;
-        offlineLevels: number;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2OrganisationUnitLevel, keyof D2OrganisationUnitLevel>;
-        $identifiable: Preset<D2OrganisationUnitLevel, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OrganisationUnitLevel, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2OrganisationUnitLevel,
-            | "lastUpdatedBy"
-            | "offlineLevels"
-            | "code"
-            | "level"
-            | "created"
-            | "lastUpdated"
-            | "translations"
-            | "name"
-            | "id"
-        >;
-        $owner: Preset<
-            D2OrganisationUnitLevel,
-            | "lastUpdatedBy"
-            | "offlineLevels"
-            | "code"
-            | "level"
-            | "created"
-            | "lastUpdated"
-            | "translations"
-            | "name"
-            | "id"
-        >;
-    };
-}
-
-export interface D2OrganisationUnitGroupSchema {
-    name: "D2OrganisationUnitGroup";
-    model: D2OrganisationUnitGroup;
-    fields: {
-        access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "FIRST"
-            | "FIRST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        color: string;
-        created: string;
-        description: string;
-        dimensionItem: string;
-        dimensionItemType:
-            | "DATA_ELEMENT"
-            | "DATA_ELEMENT_OPERAND"
-            | "INDICATOR"
-            | "REPORTING_RATE"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION"
-            | "OPTION_GROUP"
-            | "DATA_ELEMENT_GROUP"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY_OPTION_GROUP";
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
-        formName: string;
-        geometry: D2Geometry;
-        groupSets: D2OrganisationUnitGroupSetSchema[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        legendSet: D2LegendSetSchema;
-        legendSets: D2LegendSetSchema[];
-        name: string;
-        organisationUnits: D2OrganisationUnitSchema[];
-        publicAccess: string;
-        shortName: string;
-        symbol: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2OrganisationUnitGroup, keyof D2OrganisationUnitGroup>;
-        $identifiable: Preset<D2OrganisationUnitGroup, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OrganisationUnitGroup, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2OrganisationUnitGroup,
-            | "symbol"
-            | "code"
-            | "color"
-            | "publicAccess"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "organisationUnits"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "groupSets"
-            | "userAccesses"
-            | "name"
-            | "geometry"
-            | "shortName"
-            | "user"
-        >;
-        $owner: Preset<
-            D2OrganisationUnitGroup,
-            | "symbol"
-            | "code"
-            | "color"
-            | "publicAccess"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "organisationUnits"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "userAccesses"
-            | "name"
-            | "geometry"
-            | "shortName"
-            | "user"
-        >;
-    };
-}
-
-export interface D2OrganisationUnitGroupSetSchema {
-    name: "D2OrganisationUnitGroupSet";
-    model: D2OrganisationUnitGroupSet;
-    fields: {
-        access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "FIRST"
-            | "FIRST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
-        allItems: boolean;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        compulsory: boolean;
-        created: string;
-        dataDimension: boolean;
         dataDimensionType: "DISAGGREGATION" | "ATTRIBUTE";
-        description: string;
-        dimension: string;
-        dimensionType:
-            | "DATA_X"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "DATA_COLLAPSED"
-            | "CATEGORY_OPTION_COMBO"
-            | "ATTRIBUTE_OPTION_COMBO"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION_GROUP_SET"
-            | "DATA_ELEMENT_GROUP_SET"
-            | "ORGANISATION_UNIT_GROUP_SET"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY"
-            | "OPTION_GROUP_SET"
-            | "VALIDATION_RULE"
-            | "STATIC"
-            | "ORGANISATION_UNIT_LEVEL";
-        dimensionalKeywords: D2DimensionalKeywords;
-        displayDescription: string;
-        displayFormName: string;
         displayName: string;
-        displayShortName: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
-        filter: string;
-        formName: string;
         href: string;
         id: Id;
-        includeSubhierarchyInAnalytics: boolean;
-        items: any[];
+        isDefault: boolean;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
-        legendSet: D2LegendSetSchema;
         name: string;
-        organisationUnitGroups: D2OrganisationUnitGroupSchema[];
-        programStage: D2ProgramStageSchema;
         publicAccess: string;
-        shortName: string;
+        skipTotal: boolean;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2OrganisationUnitGroupSet, keyof D2OrganisationUnitGroupSet>;
-        $identifiable: Preset<D2OrganisationUnitGroupSet, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OrganisationUnitGroupSet, FieldPresets["nameable"]>;
+        $all: Preset<D2CategoryCombo, keyof D2CategoryCombo>;
+        $identifiable: Preset<D2CategoryCombo, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2CategoryCombo, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2OrganisationUnitGroupSet,
+            D2CategoryCombo,
+            | "dataDimensionType"
             | "code"
             | "publicAccess"
-            | "description"
             | "lastUpdated"
             | "translations"
             | "id"
-            | "organisationUnitGroups"
+            | "categories"
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "created"
-            | "attributeValues"
-            | "compulsory"
-            | "includeSubhierarchyInAnalytics"
+            | "categoryOptionCombos"
             | "userAccesses"
             | "name"
-            | "dataDimension"
+            | "skipTotal"
             | "user"
         >;
         $owner: Preset<
-            D2OrganisationUnitGroupSet,
+            D2CategoryCombo,
+            | "dataDimensionType"
             | "code"
             | "publicAccess"
-            | "description"
             | "lastUpdated"
             | "translations"
             | "id"
-            | "organisationUnitGroups"
+            | "categories"
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "created"
-            | "attributeValues"
-            | "compulsory"
-            | "includeSubhierarchyInAnalytics"
             | "userAccesses"
             | "name"
-            | "dataDimension"
+            | "skipTotal"
             | "user"
         >;
+    };
+}
+
+export interface D2CategoryDimensionSchema {
+    name: "D2CategoryDimension";
+    model: D2CategoryDimension;
+    fields: { category: D2CategorySchema; categoryOptions: D2CategoryOptionSchema[] };
+    fieldPresets: {
+        $all: Preset<D2CategoryDimension, keyof D2CategoryDimension>;
+        $identifiable: Preset<D2CategoryDimension, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2CategoryDimension, FieldPresets["nameable"]>;
+        $persisted: Preset<D2CategoryDimension, "categoryOptions" | "category">;
+        $owner: Preset<D2CategoryDimension, "categoryOptions" | "category">;
     };
 }
 
@@ -6669,6 +5394,107 @@ export interface D2CategoryOptionSchema {
             | "shortName"
             | "user"
             | "startDate"
+        >;
+    };
+}
+
+export interface D2CategoryOptionComboSchema {
+    name: "D2CategoryOptionCombo";
+    model: D2CategoryOptionCombo;
+    fields: {
+        access: D2Access;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        categoryCombo: D2CategoryComboSchema;
+        categoryOptions: D2CategoryOptionSchema[];
+        code: Id;
+        created: string;
+        description: string;
+        dimensionItem: string;
+        dimensionItemType:
+            | "DATA_ELEMENT"
+            | "DATA_ELEMENT_OPERAND"
+            | "INDICATOR"
+            | "REPORTING_RATE"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION"
+            | "OPTION_GROUP"
+            | "DATA_ELEMENT_GROUP"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY_OPTION_GROUP";
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        ignoreApproval: boolean;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendSet: D2LegendSetSchema;
+        legendSets: D2LegendSetSchema[];
+        name: string;
+        publicAccess: string;
+        shortName: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2CategoryOptionCombo, keyof D2CategoryOptionCombo>;
+        $identifiable: Preset<D2CategoryOptionCombo, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2CategoryOptionCombo, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2CategoryOptionCombo,
+            | "code"
+            | "lastUpdated"
+            | "ignoreApproval"
+            | "categoryCombo"
+            | "translations"
+            | "id"
+            | "categoryOptions"
+            | "lastUpdatedBy"
+            | "created"
+            | "attributeValues"
+            | "name"
+        >;
+        $owner: Preset<
+            D2CategoryOptionCombo,
+            | "code"
+            | "lastUpdated"
+            | "ignoreApproval"
+            | "categoryCombo"
+            | "translations"
+            | "id"
+            | "categoryOptions"
+            | "lastUpdatedBy"
+            | "created"
+            | "attributeValues"
+            | "name"
         >;
     };
 }
@@ -6902,9 +5728,31 @@ export interface D2CategoryOptionGroupSetSchema {
     };
 }
 
-export interface D2CategorySchema {
-    name: "D2Category";
-    model: D2Category;
+export interface D2CategoryOptionGroupSetDimensionSchema {
+    name: "D2CategoryOptionGroupSetDimension";
+    model: D2CategoryOptionGroupSetDimension;
+    fields: {
+        categoryOptionGroupSet: D2CategoryOptionGroupSetSchema;
+        categoryOptionGroups: D2CategoryOptionGroupSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2CategoryOptionGroupSetDimension, keyof D2CategoryOptionGroupSetDimension>;
+        $identifiable: Preset<D2CategoryOptionGroupSetDimension, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2CategoryOptionGroupSetDimension, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2CategoryOptionGroupSetDimension,
+            "categoryOptionGroups" | "categoryOptionGroupSet"
+        >;
+        $owner: Preset<
+            D2CategoryOptionGroupSetDimension,
+            "categoryOptionGroups" | "categoryOptionGroupSet"
+        >;
+    };
+}
+
+export interface D2ChartSchema {
+    name: "D2Chart";
+    model: D2Chart;
     fields: {
         access: D2Access;
         aggregationType:
@@ -6923,36 +5771,233 @@ export interface D2CategorySchema {
             | "NONE"
             | "CUSTOM"
             | "DEFAULT";
-        allItems: boolean;
+        attributeDimensions: any[];
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        categoryCombos: D2CategoryComboSchema[];
-        categoryOptions: D2CategoryOptionSchema[];
+        baseLineLabel: string;
+        baseLineValue: number;
+        category: string;
+        categoryDimensions: D2CategoryDimensionSchema[];
+        categoryOptionGroupSetDimensions: D2CategoryOptionGroupSetDimensionSchema[];
+        code: Id;
+        colorSet: D2ColorSetSchema;
+        columns: any[];
+        completedOnly: boolean;
+        created: string;
+        cumulativeValues: boolean;
+        dataDimensionItems: any[];
+        dataElementDimensions: D2TrackedEntityDataElementDimensionSchema[];
+        dataElementGroupSetDimensions: D2DataElementGroupSetDimensionSchema[];
+        description: string;
+        digitGroupSeparator: "COMMA" | "SPACE" | "NONE";
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        domainAxisLabel: string;
+        endDate: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        filterDimensions: string[];
+        filters: any[];
+        formName: string;
+        hideEmptyRowItems:
+            | "NONE"
+            | "BEFORE_FIRST"
+            | "AFTER_LAST"
+            | "BEFORE_FIRST_AFTER_LAST"
+            | "ALL";
+        hideLegend: boolean;
+        hideSubtitle: boolean;
+        hideTitle: boolean;
+        href: string;
+        id: Id;
+        interpretations: D2InterpretationSchema[];
+        itemOrganisationUnitGroups: D2OrganisationUnitGroupSchema[];
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendDisplayStrategy: "FIXED" | "BY_DATA_ITEM";
+        legendSet: D2LegendSetSchema;
+        name: string;
+        noSpaceBetweenColumns: boolean;
+        orgUnitField: string;
+        organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimensionSchema[];
+        organisationUnitLevels: number[];
+        organisationUnits: D2OrganisationUnitSchema[];
+        parentGraphMap: D2MapSchema;
+        percentStackedValues: boolean;
+        periods: any[];
+        programIndicatorDimensions: D2TrackedEntityProgramIndicatorDimensionSchema[];
+        publicAccess: string;
+        rangeAxisDecimals: number;
+        rangeAxisLabel: string;
+        rangeAxisMaxValue: number;
+        rangeAxisMinValue: number;
+        rangeAxisSteps: number;
+        regressionType: "NONE" | "LINEAR" | "POLYNOMIAL" | "LOESS";
+        relativePeriods: any;
+        rows: any[];
+        series: string;
+        seriesItems: any[];
+        shortName: string;
+        showData: boolean;
+        sortOrder: number;
+        startDate: string;
+        subscribed: boolean;
+        subscribers: string[];
+        subtitle: string;
+        targetLineLabel: string;
+        targetLineValue: number;
+        timeField: string;
+        title: string;
+        topLimit: number;
+        translations: D2Translation[];
+        type:
+            | "COLUMN"
+            | "STACKED_COLUMN"
+            | "BAR"
+            | "STACKED_BAR"
+            | "LINE"
+            | "AREA"
+            | "PIE"
+            | "RADAR"
+            | "GAUGE"
+            | "YEAR_OVER_YEAR_LINE"
+            | "YEAR_OVER_YEAR_COLUMN"
+            | "SINGLE_VALUE";
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        userOrgUnitType: "DATA_CAPTURE" | "DATA_OUTPUT" | "TEI_SEARCH";
+        userOrganisationUnit: boolean;
+        userOrganisationUnitChildren: boolean;
+        userOrganisationUnitGrandChildren: boolean;
+        yearlySeries: string[];
+    };
+    fieldPresets: {
+        $all: Preset<D2Chart, keyof D2Chart>;
+        $identifiable: Preset<D2Chart, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Chart, FieldPresets["nameable"]>;
+        $persisted: Preset<D2Chart, never>;
+        $owner: Preset<D2Chart, never>;
+    };
+}
+
+export interface D2ColorSchema {
+    name: "D2Color";
+    model: D2Color;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        color: string;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2Color, keyof D2Color>;
+        $identifiable: Preset<D2Color, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Color, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Color,
+            | "lastUpdatedBy"
+            | "code"
+            | "color"
+            | "created"
+            | "lastUpdated"
+            | "translations"
+            | "name"
+            | "id"
+        >;
+        $owner: Preset<
+            D2Color,
+            | "lastUpdatedBy"
+            | "code"
+            | "color"
+            | "created"
+            | "lastUpdated"
+            | "translations"
+            | "name"
+            | "id"
+        >;
+    };
+}
+
+export interface D2ColorSetSchema {
+    name: "D2ColorSet";
+    model: D2ColorSet;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        colors: D2ColorSchema[];
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ColorSet, keyof D2ColorSet>;
+        $identifiable: Preset<D2ColorSet, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ColorSet, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ColorSet,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "colors"
+            | "lastUpdated"
+            | "translations"
+            | "name"
+            | "id"
+        >;
+        $owner: Preset<
+            D2ColorSet,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "colors"
+            | "lastUpdated"
+            | "translations"
+            | "name"
+            | "id"
+        >;
+    };
+}
+
+export interface D2ConstantSchema {
+    name: "D2Constant";
+    model: D2Constant;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
-        dataDimension: boolean;
-        dataDimensionType: "DISAGGREGATION" | "ATTRIBUTE";
         description: string;
-        dimension: string;
-        dimensionType:
-            | "DATA_X"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "DATA_COLLAPSED"
-            | "CATEGORY_OPTION_COMBO"
-            | "ATTRIBUTE_OPTION_COMBO"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION_GROUP_SET"
-            | "DATA_ELEMENT_GROUP_SET"
-            | "ORGANISATION_UNIT_GROUP_SET"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY"
-            | "OPTION_GROUP_SET"
-            | "VALIDATION_RULE"
-            | "STATIC"
-            | "ORGANISATION_UNIT_LEVEL";
-        dimensionalKeywords: D2DimensionalKeywords;
         displayDescription: string;
         displayFormName: string;
         displayName: string;
@@ -6960,16 +6005,87 @@ export interface D2CategorySchema {
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
-        filter: string;
         formName: string;
         href: string;
         id: Id;
-        items: any[];
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
-        legendSet: D2LegendSetSchema;
         name: string;
-        programStage: D2ProgramStageSchema;
+        publicAccess: string;
+        shortName: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        value: number;
+    };
+    fieldPresets: {
+        $all: Preset<D2Constant, keyof D2Constant>;
+        $identifiable: Preset<D2Constant, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Constant, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Constant,
+            | "code"
+            | "publicAccess"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "value"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "userAccesses"
+            | "name"
+            | "shortName"
+            | "user"
+        >;
+        $owner: Preset<
+            D2Constant,
+            | "code"
+            | "publicAccess"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "value"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "userAccesses"
+            | "name"
+            | "shortName"
+            | "user"
+        >;
+    };
+}
+
+export interface D2DashboardSchema {
+    name: "D2Dashboard";
+    model: D2Dashboard;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        dashboardItems: D2DashboardItemSchema[];
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        itemCount: number;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
         publicAccess: string;
         shortName: string;
         translations: D2Translation[];
@@ -6978,216 +6094,292 @@ export interface D2CategorySchema {
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2Category, keyof D2Category>;
-        $identifiable: Preset<D2Category, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Category, FieldPresets["nameable"]>;
+        $all: Preset<D2Dashboard, keyof D2Dashboard>;
+        $identifiable: Preset<D2Dashboard, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Dashboard, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2Category,
-            | "dataDimensionType"
+            D2Dashboard,
+            | "favorites"
             | "code"
             | "publicAccess"
+            | "description"
+            | "externalAccess"
             | "lastUpdated"
             | "translations"
-            | "categoryCombos"
             | "id"
-            | "categoryOptions"
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "created"
-            | "attributeValues"
+            | "dashboardItems"
             | "userAccesses"
             | "name"
-            | "dataDimension"
             | "user"
         >;
         $owner: Preset<
-            D2Category,
-            | "dataDimensionType"
+            D2Dashboard,
+            | "favorites"
             | "code"
             | "publicAccess"
+            | "description"
+            | "externalAccess"
             | "lastUpdated"
             | "translations"
             | "id"
-            | "categoryOptions"
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "created"
-            | "attributeValues"
+            | "dashboardItems"
             | "userAccesses"
             | "name"
-            | "dataDimension"
             | "user"
         >;
     };
 }
 
-export interface D2CategoryComboSchema {
-    name: "D2CategoryCombo";
-    model: D2CategoryCombo;
+export interface D2DashboardItemSchema {
+    name: "D2DashboardItem";
+    model: D2DashboardItem;
+    fields: {
+        access: D2Access;
+        appKey: string;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        chart: D2ChartSchema;
+        code: Id;
+        contentCount: number;
+        created: string;
+        displayName: string;
+        eventChart: D2EventChartSchema;
+        eventReport: D2EventReportSchema;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        height: number;
+        href: string;
+        id: Id;
+        interpretationCount: number;
+        interpretationLikeCount: number;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        map: D2MapSchema;
+        messages: boolean;
+        name: string;
+        publicAccess: string;
+        reportTable: D2ReportTableSchema;
+        reports: D2ReportSchema[];
+        resources: D2DocumentSchema[];
+        shape: "NORMAL" | "DOUBLE_WIDTH" | "FULL_WIDTH";
+        text: string;
+        translations: D2Translation[];
+        type:
+            | "VISUALIZATION"
+            | "CHART"
+            | "EVENT_CHART"
+            | "MAP"
+            | "REPORT_TABLE"
+            | "EVENT_REPORT"
+            | "USERS"
+            | "REPORTS"
+            | "RESOURCES"
+            | "TEXT"
+            | "MESSAGES"
+            | "APP";
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        users: D2UserSchema[];
+        visualization: D2VisualizationSchema;
+        width: number;
+        x: number;
+        y: number;
+    };
+    fieldPresets: {
+        $all: Preset<D2DashboardItem, keyof D2DashboardItem>;
+        $identifiable: Preset<D2DashboardItem, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2DashboardItem, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2DashboardItem,
+            | "reports"
+            | "visualization"
+            | "code"
+            | "lastUpdated"
+            | "translations"
+            | "appKey"
+            | "id"
+            | "text"
+            | "map"
+            | "height"
+            | "lastUpdatedBy"
+            | "shape"
+            | "created"
+            | "resources"
+            | "users"
+            | "eventReport"
+            | "eventChart"
+            | "width"
+            | "x"
+            | "messages"
+            | "y"
+        >;
+        $owner: Preset<
+            D2DashboardItem,
+            | "reports"
+            | "visualization"
+            | "code"
+            | "lastUpdated"
+            | "translations"
+            | "appKey"
+            | "id"
+            | "text"
+            | "map"
+            | "height"
+            | "lastUpdatedBy"
+            | "shape"
+            | "created"
+            | "resources"
+            | "users"
+            | "eventReport"
+            | "eventChart"
+            | "width"
+            | "x"
+            | "messages"
+            | "y"
+        >;
+    };
+}
+
+export interface D2DataApprovalLevelSchema {
+    name: "D2DataApprovalLevel";
+    model: D2DataApprovalLevel;
     fields: {
         access: D2Access;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        categories: D2CategorySchema[];
-        categoryOptionCombos: D2CategoryOptionComboSchema[];
+        categoryOptionGroupSet: D2CategoryOptionGroupSetSchema;
         code: Id;
         created: string;
-        dataDimensionType: "DISAGGREGATION" | "ATTRIBUTE";
         displayName: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
         href: string;
         id: Id;
-        isDefault: boolean;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
+        level: number;
         name: string;
+        orgUnitLevel: number;
+        orgUnitLevelName: string;
         publicAccess: string;
-        skipTotal: boolean;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2CategoryCombo, keyof D2CategoryCombo>;
-        $identifiable: Preset<D2CategoryCombo, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2CategoryCombo, FieldPresets["nameable"]>;
+        $all: Preset<D2DataApprovalLevel, keyof D2DataApprovalLevel>;
+        $identifiable: Preset<D2DataApprovalLevel, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2DataApprovalLevel, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2CategoryCombo,
-            | "dataDimensionType"
+            D2DataApprovalLevel,
+            | "lastUpdatedBy"
+            | "categoryOptionGroupSet"
+            | "userGroupAccesses"
             | "code"
+            | "level"
+            | "created"
             | "publicAccess"
             | "lastUpdated"
             | "translations"
-            | "id"
-            | "categories"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "categoryOptionCombos"
             | "userAccesses"
             | "name"
-            | "skipTotal"
+            | "orgUnitLevel"
+            | "id"
             | "user"
         >;
         $owner: Preset<
-            D2CategoryCombo,
-            | "dataDimensionType"
+            D2DataApprovalLevel,
+            | "lastUpdatedBy"
+            | "categoryOptionGroupSet"
+            | "userGroupAccesses"
             | "code"
+            | "level"
+            | "created"
             | "publicAccess"
             | "lastUpdated"
             | "translations"
-            | "id"
-            | "categories"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
             | "userAccesses"
             | "name"
-            | "skipTotal"
+            | "orgUnitLevel"
+            | "id"
             | "user"
         >;
     };
 }
 
-export interface D2CategoryOptionComboSchema {
-    name: "D2CategoryOptionCombo";
-    model: D2CategoryOptionCombo;
+export interface D2DataApprovalWorkflowSchema {
+    name: "D2DataApprovalWorkflow";
+    model: D2DataApprovalWorkflow;
     fields: {
         access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "FIRST"
-            | "FIRST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         categoryCombo: D2CategoryComboSchema;
-        categoryOptions: D2CategoryOptionSchema[];
         code: Id;
         created: string;
-        description: string;
-        dimensionItem: string;
-        dimensionItemType:
-            | "DATA_ELEMENT"
-            | "DATA_ELEMENT_OPERAND"
-            | "INDICATOR"
-            | "REPORTING_RATE"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION"
-            | "OPTION_GROUP"
-            | "DATA_ELEMENT_GROUP"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY_OPTION_GROUP";
-        displayDescription: string;
-        displayFormName: string;
+        dataApprovalLevels: D2DataApprovalLevelSchema[];
+        dataSets: D2DataSetSchema[];
         displayName: string;
-        displayShortName: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
-        formName: string;
         href: string;
         id: Id;
-        ignoreApproval: boolean;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
-        legendSet: D2LegendSetSchema;
-        legendSets: D2LegendSetSchema[];
         name: string;
+        periodType: string;
         publicAccess: string;
-        shortName: string;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2CategoryOptionCombo, keyof D2CategoryOptionCombo>;
-        $identifiable: Preset<D2CategoryOptionCombo, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2CategoryOptionCombo, FieldPresets["nameable"]>;
+        $all: Preset<D2DataApprovalWorkflow, keyof D2DataApprovalWorkflow>;
+        $identifiable: Preset<D2DataApprovalWorkflow, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2DataApprovalWorkflow, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2CategoryOptionCombo,
+            D2DataApprovalWorkflow,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
             | "code"
+            | "created"
+            | "publicAccess"
+            | "dataApprovalLevels"
             | "lastUpdated"
-            | "ignoreApproval"
+            | "periodType"
             | "categoryCombo"
             | "translations"
-            | "id"
-            | "categoryOptions"
-            | "lastUpdatedBy"
-            | "created"
-            | "attributeValues"
+            | "userAccesses"
             | "name"
+            | "dataSets"
+            | "id"
+            | "user"
         >;
         $owner: Preset<
-            D2CategoryOptionCombo,
+            D2DataApprovalWorkflow,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
             | "code"
+            | "created"
+            | "publicAccess"
+            | "dataApprovalLevels"
             | "lastUpdated"
-            | "ignoreApproval"
+            | "periodType"
             | "categoryCombo"
             | "translations"
-            | "id"
-            | "categoryOptions"
-            | "lastUpdatedBy"
-            | "created"
-            | "attributeValues"
+            | "userAccesses"
             | "name"
+            | "id"
+            | "user"
         >;
     };
 }
@@ -7589,149 +6781,30 @@ export interface D2DataElementGroupSetSchema {
     };
 }
 
-export interface D2AnalyticsTableHookSchema {
-    name: "D2AnalyticsTableHook";
-    model: D2AnalyticsTableHook;
+export interface D2DataElementGroupSetDimensionSchema {
+    name: "D2DataElementGroupSetDimension";
+    model: D2DataElementGroupSetDimension;
     fields: {
-        access: D2Access;
-        analyticsTableType:
-            | "DATA_VALUE"
-            | "COMPLETENESS"
-            | "COMPLETENESS_TARGET"
-            | "ORG_UNIT_TARGET"
-            | "EVENT"
-            | "ENROLLMENT"
-            | "VALIDATION_RESULT";
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        phase: "RESOURCE_TABLE_POPULATED" | "ANALYTICS_TABLE_POPULATED";
-        publicAccess: string;
-        resourceTableType:
-            | "ORG_UNIT_STRUCTURE"
-            | "DATA_SET_ORG_UNIT_CATEGORY"
-            | "CATEGORY_OPTION_COMBO_NAME"
-            | "DATA_ELEMENT_GROUP_SET_STRUCTURE"
-            | "INDICATOR_GROUP_SET_STRUCTURE"
-            | "ORG_UNIT_GROUP_SET_STRUCTURE"
-            | "CATEGORY_STRUCTURE"
-            | "DATA_ELEMENT_STRUCTURE"
-            | "PERIOD_STRUCTURE"
-            | "DATE_PERIOD_STRUCTURE"
-            | "DATA_ELEMENT_CATEGORY_OPTION_COMBO"
-            | "DATA_APPROVAL_REMAP_LEVEL"
-            | "DATA_APPROVAL_MIN_LEVEL";
-        sql: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
+        dataElementGroupSet: D2DataElementGroupSetSchema;
+        dataElementGroups: D2DataElementGroupSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2AnalyticsTableHook, keyof D2AnalyticsTableHook>;
-        $identifiable: Preset<D2AnalyticsTableHook, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2AnalyticsTableHook, FieldPresets["nameable"]>;
+        $all: Preset<D2DataElementGroupSetDimension, keyof D2DataElementGroupSetDimension>;
+        $identifiable: Preset<D2DataElementGroupSetDimension, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2DataElementGroupSetDimension, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2AnalyticsTableHook,
-            | "phase"
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "analyticsTableType"
-            | "sql"
-            | "lastUpdated"
-            | "name"
-            | "resourceTableType"
-            | "id"
+            D2DataElementGroupSetDimension,
+            "dataElementGroups" | "dataElementGroupSet"
         >;
-        $owner: Preset<
-            D2AnalyticsTableHook,
-            | "phase"
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "analyticsTableType"
-            | "sql"
-            | "lastUpdated"
-            | "name"
-            | "resourceTableType"
-            | "id"
-        >;
+        $owner: Preset<D2DataElementGroupSetDimension, "dataElementGroups" | "dataElementGroupSet">;
     };
 }
 
-export interface D2IndicatorTypeSchema {
-    name: "D2IndicatorType";
-    model: D2IndicatorType;
+export interface D2DataElementOperandSchema {
+    name: "D2DataElementOperand";
+    model: D2DataElementOperand;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        factor: number;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        number: boolean;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2IndicatorType, keyof D2IndicatorType>;
-        $identifiable: Preset<D2IndicatorType, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2IndicatorType, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2IndicatorType,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "lastUpdated"
-            | "number"
-            | "translations"
-            | "name"
-            | "id"
-            | "factor"
-        >;
-        $owner: Preset<
-            D2IndicatorType,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "lastUpdated"
-            | "number"
-            | "translations"
-            | "name"
-            | "id"
-            | "factor"
-        >;
-    };
-}
-
-export interface D2IndicatorSchema {
-    name: "D2Indicator";
-    model: D2Indicator;
-    fields: {
-        access: D2Access;
-        aggregateExportAttributeOptionCombo: string;
-        aggregateExportCategoryOptionCombo: string;
         aggregationType:
             | "SUM"
             | "AVERAGE"
@@ -7748,14 +6821,12 @@ export interface D2IndicatorSchema {
             | "NONE"
             | "CUSTOM"
             | "DEFAULT";
-        annualized: boolean;
+        attributeOptionCombo: D2CategoryOptionComboSchema;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        categoryOptionCombo: D2CategoryOptionComboSchema;
         code: Id;
         created: string;
-        dataSets: D2DataSetSchema[];
-        decimals: number;
-        denominator: string;
-        denominatorDescription: string;
+        dataElement: D2DataElementSchema;
         description: string;
         dimensionItem: string;
         dimensionItemType:
@@ -7773,11 +6844,9 @@ export interface D2IndicatorSchema {
             | "DATA_ELEMENT_GROUP"
             | "ORGANISATION_UNIT_GROUP"
             | "CATEGORY_OPTION_GROUP";
-        displayDenominatorDescription: string;
         displayDescription: string;
         displayFormName: string;
         displayName: string;
-        displayNumeratorDescription: string;
         displayShortName: string;
         externalAccess: boolean;
         favorite: boolean;
@@ -7785,223 +6854,24 @@ export interface D2IndicatorSchema {
         formName: string;
         href: string;
         id: Id;
-        indicatorGroups: D2IndicatorGroupSchema[];
-        indicatorType: D2IndicatorTypeSchema;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
         legendSet: D2LegendSetSchema;
         legendSets: D2LegendSetSchema[];
         name: string;
-        numerator: string;
-        numeratorDescription: string;
         publicAccess: string;
         shortName: string;
-        style: D2Style;
-        translations: D2Translation[];
-        url: string;
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Indicator, keyof D2Indicator>;
-        $identifiable: Preset<D2Indicator, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Indicator, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Indicator,
-            | "code"
-            | "publicAccess"
-            | "aggregateExportCategoryOptionCombo"
-            | "description"
-            | "lastUpdated"
-            | "denominatorDescription"
-            | "indicatorType"
-            | "translations"
-            | "formName"
-            | "id"
-            | "numeratorDescription"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "indicatorGroups"
-            | "url"
-            | "numerator"
-            | "denominator"
-            | "annualized"
-            | "userAccesses"
-            | "decimals"
-            | "name"
-            | "dataSets"
-            | "legendSets"
-            | "style"
-            | "shortName"
-            | "user"
-            | "aggregateExportAttributeOptionCombo"
-        >;
-        $owner: Preset<
-            D2Indicator,
-            | "code"
-            | "publicAccess"
-            | "aggregateExportCategoryOptionCombo"
-            | "description"
-            | "lastUpdated"
-            | "denominatorDescription"
-            | "indicatorType"
-            | "translations"
-            | "formName"
-            | "id"
-            | "numeratorDescription"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "url"
-            | "numerator"
-            | "denominator"
-            | "annualized"
-            | "userAccesses"
-            | "decimals"
-            | "name"
-            | "legendSets"
-            | "style"
-            | "shortName"
-            | "user"
-            | "aggregateExportAttributeOptionCombo"
-        >;
-    };
-}
-
-export interface D2IndicatorGroupSchema {
-    name: "D2IndicatorGroup";
-    model: D2IndicatorGroup;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        indicatorGroupSet: D2IndicatorGroupSetSchema;
-        indicators: D2IndicatorSchema[];
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2IndicatorGroup, keyof D2IndicatorGroup>;
-        $identifiable: Preset<D2IndicatorGroup, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2IndicatorGroup, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2IndicatorGroup,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "indicators"
-            | "indicatorGroupSet"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2IndicatorGroup,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "indicators"
-            | "indicatorGroupSet"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
-export interface D2IndicatorGroupSetSchema {
-    name: "D2IndicatorGroupSet";
-    model: D2IndicatorGroupSet;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        compulsory: boolean;
-        created: string;
-        description: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        indicatorGroups: D2IndicatorGroupSchema[];
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2IndicatorGroupSet, keyof D2IndicatorGroupSet>;
-        $identifiable: Preset<D2IndicatorGroupSet, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2IndicatorGroupSet, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2IndicatorGroupSet,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "description"
-            | "indicatorGroups"
-            | "lastUpdated"
-            | "compulsory"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2IndicatorGroupSet,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "description"
-            | "indicatorGroups"
-            | "lastUpdated"
-            | "compulsory"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
+        $all: Preset<D2DataElementOperand, keyof D2DataElementOperand>;
+        $identifiable: Preset<D2DataElementOperand, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2DataElementOperand, FieldPresets["nameable"]>;
+        $persisted: Preset<D2DataElementOperand, "categoryOptionCombo" | "dataElement">;
+        $owner: Preset<D2DataElementOperand, "categoryOptionCombo" | "dataElement">;
     };
 }
 
@@ -8061,6 +6931,19 @@ export interface D2DataEntryFormSchema {
             | "style"
             | "id"
         >;
+    };
+}
+
+export interface D2DataInputPeriodSchema {
+    name: "D2DataInputPeriod";
+    model: D2DataInputPeriod;
+    fields: { closingDate: string; openingDate: string; period: any };
+    fieldPresets: {
+        $all: Preset<D2DataInputPeriod, keyof D2DataInputPeriod>;
+        $identifiable: Preset<D2DataInputPeriod, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2DataInputPeriod, FieldPresets["nameable"]>;
+        $persisted: Preset<D2DataInputPeriod, "period" | "closingDate" | "openingDate">;
+        $owner: Preset<D2DataInputPeriod, "period" | "closingDate" | "openingDate">;
     };
 }
 
@@ -8255,6 +7138,23 @@ export interface D2DataSetSchema {
     };
 }
 
+export interface D2DataSetElementSchema {
+    name: "D2DataSetElement";
+    model: D2DataSetElement;
+    fields: {
+        categoryCombo: D2CategoryComboSchema;
+        dataElement: D2DataElementSchema;
+        dataSet: D2DataSetSchema;
+    };
+    fieldPresets: {
+        $all: Preset<D2DataSetElement, keyof D2DataSetElement>;
+        $identifiable: Preset<D2DataSetElement, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2DataSetElement, FieldPresets["nameable"]>;
+        $persisted: Preset<D2DataSetElement, "dataElement" | "categoryCombo" | "dataSet">;
+        $owner: Preset<D2DataSetElement, "dataElement" | "categoryCombo" | "dataSet">;
+    };
+}
+
 export interface D2DataSetNotificationTemplateSchema {
     name: "D2DataSetNotificationTemplate";
     model: D2DataSetNotificationTemplate;
@@ -8336,370 +7236,18 @@ export interface D2DataSetNotificationTemplateSchema {
     };
 }
 
-export interface D2SectionSchema {
-    name: "D2Section";
-    model: D2Section;
+export interface D2DocumentSchema {
+    name: "D2Document";
+    model: D2Document;
     fields: {
         access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        categoryCombos: D2CategoryComboSchema[];
-        code: Id;
-        created: string;
-        dataElements: D2DataElementSchema[];
-        dataSet: D2DataSetSchema;
-        description: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        greyedFields: D2DataElementOperandSchema[];
-        href: string;
-        id: Id;
-        indicators: D2IndicatorSchema[];
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        showColumnTotals: boolean;
-        showRowTotals: boolean;
-        sortOrder: number;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Section, keyof D2Section>;
-        $identifiable: Preset<D2Section, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Section, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Section,
-            | "code"
-            | "greyedFields"
-            | "description"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "dataSet"
-            | "dataElements"
-            | "showColumnTotals"
-            | "lastUpdatedBy"
-            | "created"
-            | "attributeValues"
-            | "indicators"
-            | "sortOrder"
-            | "name"
-            | "showRowTotals"
-        >;
-        $owner: Preset<
-            D2Section,
-            | "code"
-            | "greyedFields"
-            | "description"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "dataSet"
-            | "dataElements"
-            | "showColumnTotals"
-            | "lastUpdatedBy"
-            | "created"
-            | "attributeValues"
-            | "indicators"
-            | "sortOrder"
-            | "name"
-            | "showRowTotals"
-        >;
-    };
-}
-
-export interface D2DataApprovalLevelSchema {
-    name: "D2DataApprovalLevel";
-    model: D2DataApprovalLevel;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        categoryOptionGroupSet: D2CategoryOptionGroupSetSchema;
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        level: number;
-        name: string;
-        orgUnitLevel: number;
-        orgUnitLevelName: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2DataApprovalLevel, keyof D2DataApprovalLevel>;
-        $identifiable: Preset<D2DataApprovalLevel, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2DataApprovalLevel, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2DataApprovalLevel,
-            | "lastUpdatedBy"
-            | "categoryOptionGroupSet"
-            | "userGroupAccesses"
-            | "code"
-            | "level"
-            | "created"
-            | "publicAccess"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "orgUnitLevel"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2DataApprovalLevel,
-            | "lastUpdatedBy"
-            | "categoryOptionGroupSet"
-            | "userGroupAccesses"
-            | "code"
-            | "level"
-            | "created"
-            | "publicAccess"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "orgUnitLevel"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
-export interface D2DataApprovalWorkflowSchema {
-    name: "D2DataApprovalWorkflow";
-    model: D2DataApprovalWorkflow;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        categoryCombo: D2CategoryComboSchema;
-        code: Id;
-        created: string;
-        dataApprovalLevels: D2DataApprovalLevelSchema[];
-        dataSets: D2DataSetSchema[];
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        periodType: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2DataApprovalWorkflow, keyof D2DataApprovalWorkflow>;
-        $identifiable: Preset<D2DataApprovalWorkflow, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2DataApprovalWorkflow, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2DataApprovalWorkflow,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "dataApprovalLevels"
-            | "lastUpdated"
-            | "periodType"
-            | "categoryCombo"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "dataSets"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2DataApprovalWorkflow,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "dataApprovalLevels"
-            | "lastUpdated"
-            | "periodType"
-            | "categoryCombo"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
-export interface D2ValidationRuleSchema {
-    name: "D2ValidationRule";
-    model: D2ValidationRule;
-    fields: {
-        access: D2Access;
-        aggregateExportAttributeOptionCombo: string;
-        aggregateExportCategoryOptionCombo: string;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "FIRST"
-            | "FIRST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
+        attachment: boolean;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
+        contentType: string;
         created: string;
-        description: string;
-        dimensionItem: string;
-        dimensionItemType:
-            | "DATA_ELEMENT"
-            | "DATA_ELEMENT_OPERAND"
-            | "INDICATOR"
-            | "REPORTING_RATE"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION"
-            | "OPTION_GROUP"
-            | "DATA_ELEMENT_GROUP"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY_OPTION_GROUP";
-        displayDescription: string;
-        displayFormName: string;
         displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        importance: "HIGH" | "MEDIUM" | "LOW";
-        instruction: string;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        leftSide: D2ExpressionSchema;
-        legendSet: D2LegendSetSchema;
-        legendSets: D2LegendSetSchema[];
-        name: string;
-        notificationTemplates: D2ValidationNotificationTemplateSchema[];
-        operator:
-            | "equal_to"
-            | "not_equal_to"
-            | "greater_than"
-            | "greater_than_or_equal_to"
-            | "less_than"
-            | "less_than_or_equal_to"
-            | "compulsory_pair"
-            | "exclusive_pair";
-        organisationUnitLevels: number[];
-        periodType: string;
-        publicAccess: string;
-        rightSide: D2ExpressionSchema;
-        shortName: string;
-        skipFormValidation: boolean;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        validationRuleGroups: D2ValidationRuleGroupSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ValidationRule, keyof D2ValidationRule>;
-        $identifiable: Preset<D2ValidationRule, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ValidationRule, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ValidationRule,
-            | "validationRuleGroups"
-            | "code"
-            | "importance"
-            | "publicAccess"
-            | "description"
-            | "operator"
-            | "organisationUnitLevels"
-            | "lastUpdated"
-            | "leftSide"
-            | "notificationTemplates"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "rightSide"
-            | "periodType"
-            | "instruction"
-            | "userAccesses"
-            | "name"
-            | "skipFormValidation"
-            | "user"
-        >;
-        $owner: Preset<
-            D2ValidationRule,
-            | "code"
-            | "importance"
-            | "publicAccess"
-            | "description"
-            | "operator"
-            | "organisationUnitLevels"
-            | "lastUpdated"
-            | "leftSide"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "rightSide"
-            | "periodType"
-            | "instruction"
-            | "userAccesses"
-            | "name"
-            | "skipFormValidation"
-            | "user"
-        >;
-    };
-}
-
-export interface D2ValidationRuleGroupSchema {
-    name: "D2ValidationRuleGroup";
-    model: D2ValidationRuleGroup;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        description: string;
-        displayName: string;
+        external: boolean;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
@@ -8710,1383 +7258,54 @@ export interface D2ValidationRuleGroupSchema {
         name: string;
         publicAccess: string;
         translations: D2Translation[];
+        url: string;
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
-        validationRules: D2ValidationRuleSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2ValidationRuleGroup, keyof D2ValidationRuleGroup>;
-        $identifiable: Preset<D2ValidationRuleGroup, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ValidationRuleGroup, FieldPresets["nameable"]>;
+        $all: Preset<D2Document, keyof D2Document>;
+        $identifiable: Preset<D2Document, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Document, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2ValidationRuleGroup,
+            D2Document,
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "code"
-            | "validationRules"
             | "created"
             | "publicAccess"
             | "attributeValues"
-            | "description"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2ValidationRuleGroup,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "validationRules"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "description"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
-export interface D2ValidationNotificationTemplateSchema {
-    name: "D2ValidationNotificationTemplate";
-    model: D2ValidationNotificationTemplate;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        messageTemplate: string;
-        name: string;
-        notifyParentOrganisationUnitOnly: boolean;
-        notifyUsersInHierarchyOnly: boolean;
-        publicAccess: string;
-        recipientUserGroups: D2UserGroupSchema[];
-        sendStrategy: "COLLECTIVE_SUMMARY" | "SINGLE_NOTIFICATION";
-        subjectTemplate: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        validationRules: D2ValidationRuleSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ValidationNotificationTemplate, keyof D2ValidationNotificationTemplate>;
-        $identifiable: Preset<D2ValidationNotificationTemplate, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ValidationNotificationTemplate, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ValidationNotificationTemplate,
-            | "code"
-            | "recipientUserGroups"
-            | "lastUpdated"
-            | "subjectTemplate"
-            | "id"
-            | "sendStrategy"
-            | "lastUpdatedBy"
-            | "validationRules"
-            | "created"
-            | "notifyUsersInHierarchyOnly"
-            | "name"
-            | "messageTemplate"
-        >;
-        $owner: Preset<
-            D2ValidationNotificationTemplate,
-            | "code"
-            | "recipientUserGroups"
-            | "lastUpdated"
-            | "subjectTemplate"
-            | "id"
-            | "sendStrategy"
-            | "lastUpdatedBy"
-            | "validationRules"
-            | "created"
-            | "notifyUsersInHierarchyOnly"
-            | "name"
-            | "messageTemplate"
-        >;
-    };
-}
-
-export interface D2TrackedEntityAttributeSchema {
-    name: "D2TrackedEntityAttribute";
-    model: D2TrackedEntityAttribute;
-    fields: {
-        access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "FIRST"
-            | "FIRST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        confidential: boolean;
-        created: string;
-        description: string;
-        dimensionItem: string;
-        dimensionItemType:
-            | "DATA_ELEMENT"
-            | "DATA_ELEMENT_OPERAND"
-            | "INDICATOR"
-            | "REPORTING_RATE"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION"
-            | "OPTION_GROUP"
-            | "DATA_ELEMENT_GROUP"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY_OPTION_GROUP";
-        displayDescription: string;
-        displayFormName: string;
-        displayInListNoProgram: boolean;
-        displayName: string;
-        displayOnVisitSchedule: boolean;
-        displayShortName: string;
-        expression: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        fieldMask: string;
-        formName: string;
-        generated: boolean;
-        href: string;
-        id: Id;
-        inherit: boolean;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        legendSet: D2LegendSetSchema;
-        legendSets: D2LegendSetSchema[];
-        name: string;
-        optionSet: D2OptionSetSchema;
-        optionSetValue: boolean;
-        orgunitScope: boolean;
-        pattern: string;
-        publicAccess: string;
-        shortName: string;
-        skipSynchronization: boolean;
-        sortOrderInListNoProgram: number;
-        sortOrderInVisitSchedule: number;
-        style: D2Style;
-        translations: D2Translation[];
-        unique: boolean;
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        valueType:
-            | "TEXT"
-            | "LONG_TEXT"
-            | "LETTER"
-            | "PHONE_NUMBER"
-            | "EMAIL"
-            | "BOOLEAN"
-            | "TRUE_ONLY"
-            | "DATE"
-            | "DATETIME"
-            | "TIME"
-            | "NUMBER"
-            | "UNIT_INTERVAL"
-            | "PERCENTAGE"
-            | "INTEGER"
-            | "INTEGER_POSITIVE"
-            | "INTEGER_NEGATIVE"
-            | "INTEGER_ZERO_OR_POSITIVE"
-            | "TRACKER_ASSOCIATE"
-            | "USERNAME"
-            | "COORDINATE"
-            | "ORGANISATION_UNIT"
-            | "AGE"
-            | "URL"
-            | "FILE_RESOURCE"
-            | "IMAGE";
-    };
-    fieldPresets: {
-        $all: Preset<D2TrackedEntityAttribute, keyof D2TrackedEntityAttribute>;
-        $identifiable: Preset<D2TrackedEntityAttribute, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2TrackedEntityAttribute, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2TrackedEntityAttribute,
-            | "aggregationType"
-            | "code"
-            | "displayInListNoProgram"
-            | "publicAccess"
-            | "pattern"
-            | "description"
-            | "skipSynchronization"
-            | "sortOrderInListNoProgram"
-            | "lastUpdated"
-            | "optionSet"
-            | "generated"
-            | "displayOnVisitSchedule"
-            | "translations"
-            | "valueType"
-            | "formName"
-            | "sortOrderInVisitSchedule"
-            | "id"
-            | "orgunitScope"
-            | "confidential"
-            | "fieldMask"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "expression"
-            | "created"
-            | "attributeValues"
-            | "unique"
-            | "userAccesses"
-            | "inherit"
-            | "name"
-            | "legendSets"
-            | "style"
-            | "shortName"
-            | "user"
-        >;
-        $owner: Preset<
-            D2TrackedEntityAttribute,
-            | "aggregationType"
-            | "code"
-            | "displayInListNoProgram"
-            | "publicAccess"
-            | "pattern"
-            | "description"
-            | "skipSynchronization"
-            | "sortOrderInListNoProgram"
-            | "lastUpdated"
-            | "optionSet"
-            | "generated"
-            | "displayOnVisitSchedule"
-            | "translations"
-            | "valueType"
-            | "formName"
-            | "sortOrderInVisitSchedule"
-            | "id"
-            | "orgunitScope"
-            | "confidential"
-            | "fieldMask"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "expression"
-            | "created"
-            | "attributeValues"
-            | "unique"
-            | "userAccesses"
-            | "inherit"
-            | "name"
-            | "legendSets"
-            | "style"
-            | "shortName"
-            | "user"
-        >;
-    };
-}
-
-export interface D2TrackedEntityTypeSchema {
-    name: "D2TrackedEntityType";
-    model: D2TrackedEntityType;
-    fields: {
-        access: D2Access;
-        allowAuditLog: boolean;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        maxTeiCountToReturn: number;
-        minAttributesRequiredToSearch: number;
-        name: string;
-        publicAccess: string;
-        shortName: string;
-        style: D2Style;
-        trackedEntityTypeAttributes: D2TrackedEntityTypeAttributeSchema[];
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2TrackedEntityType, keyof D2TrackedEntityType>;
-        $identifiable: Preset<D2TrackedEntityType, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2TrackedEntityType, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2TrackedEntityType,
-            | "code"
-            | "publicAccess"
-            | "trackedEntityTypeAttributes"
-            | "description"
-            | "lastUpdated"
-            | "allowAuditLog"
-            | "translations"
-            | "formName"
-            | "featureType"
-            | "minAttributesRequiredToSearch"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "maxTeiCountToReturn"
-            | "userAccesses"
-            | "name"
-            | "style"
-            | "user"
-        >;
-        $owner: Preset<
-            D2TrackedEntityType,
-            | "code"
-            | "publicAccess"
-            | "trackedEntityTypeAttributes"
-            | "description"
-            | "lastUpdated"
-            | "allowAuditLog"
-            | "translations"
-            | "formName"
-            | "featureType"
-            | "minAttributesRequiredToSearch"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "maxTeiCountToReturn"
-            | "userAccesses"
-            | "name"
-            | "style"
-            | "user"
-        >;
-    };
-}
-
-export interface D2TrackedEntityTypeAttributeSchema {
-    name: "D2TrackedEntityTypeAttribute";
-    model: D2TrackedEntityTypeAttribute;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        displayInList: boolean;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        mandatory: boolean;
-        name: string;
-        publicAccess: string;
-        searchable: boolean;
-        trackedEntityAttribute: D2TrackedEntityAttributeSchema;
-        trackedEntityType: D2TrackedEntityTypeSchema;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        valueType:
-            | "TEXT"
-            | "LONG_TEXT"
-            | "LETTER"
-            | "PHONE_NUMBER"
-            | "EMAIL"
-            | "BOOLEAN"
-            | "TRUE_ONLY"
-            | "DATE"
-            | "DATETIME"
-            | "TIME"
-            | "NUMBER"
-            | "UNIT_INTERVAL"
-            | "PERCENTAGE"
-            | "INTEGER"
-            | "INTEGER_POSITIVE"
-            | "INTEGER_NEGATIVE"
-            | "INTEGER_ZERO_OR_POSITIVE"
-            | "TRACKER_ASSOCIATE"
-            | "USERNAME"
-            | "COORDINATE"
-            | "ORGANISATION_UNIT"
-            | "AGE"
-            | "URL"
-            | "FILE_RESOURCE"
-            | "IMAGE";
-    };
-    fieldPresets: {
-        $all: Preset<D2TrackedEntityTypeAttribute, keyof D2TrackedEntityTypeAttribute>;
-        $identifiable: Preset<D2TrackedEntityTypeAttribute, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2TrackedEntityTypeAttribute, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2TrackedEntityTypeAttribute,
-            | "code"
-            | "mandatory"
-            | "trackedEntityAttribute"
-            | "lastUpdated"
-            | "id"
-            | "lastUpdatedBy"
-            | "created"
-            | "searchable"
-            | "displayInList"
-            | "trackedEntityType"
-        >;
-        $owner: Preset<
-            D2TrackedEntityTypeAttribute,
-            | "code"
-            | "mandatory"
-            | "trackedEntityAttribute"
-            | "lastUpdated"
-            | "id"
-            | "lastUpdatedBy"
-            | "created"
-            | "searchable"
-            | "displayInList"
-            | "trackedEntityType"
-        >;
-    };
-}
-
-export interface D2ProgramTrackedEntityAttributeGroupSchema {
-    name: "D2ProgramTrackedEntityAttributeGroup";
-    model: D2ProgramTrackedEntityAttributeGroup;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        attributes: D2ProgramTrackedEntityAttributeSchema[];
-        code: Id;
-        created: string;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        shortName: string;
-        translations: D2Translation[];
-        uniqunessType: "NONE" | "STRICT" | "VALIDATION";
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<
-            D2ProgramTrackedEntityAttributeGroup,
-            keyof D2ProgramTrackedEntityAttributeGroup
-        >;
-        $identifiable: Preset<D2ProgramTrackedEntityAttributeGroup, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramTrackedEntityAttributeGroup, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramTrackedEntityAttributeGroup,
-            | "code"
-            | "uniqunessType"
-            | "description"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "created"
-            | "name"
-            | "attributes"
-            | "shortName"
-        >;
-        $owner: Preset<
-            D2ProgramTrackedEntityAttributeGroup,
-            | "code"
-            | "uniqunessType"
-            | "description"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "created"
-            | "name"
-            | "shortName"
-        >;
-    };
-}
-
-export interface D2ProgramStageSectionSchema {
-    name: "D2ProgramStageSection";
-    model: D2ProgramStageSection;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        dataElements: D2DataElementSchema[];
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        programIndicators: D2ProgramIndicatorSchema[];
-        programStage: D2ProgramStageSchema;
-        publicAccess: string;
-        renderType: any;
-        shortName: string;
-        sortOrder: number;
-        style: D2Style;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramStageSection, keyof D2ProgramStageSection>;
-        $identifiable: Preset<D2ProgramStageSection, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramStageSection, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramStageSection,
-            | "code"
-            | "description"
-            | "programIndicators"
-            | "lastUpdated"
-            | "translations"
-            | "formName"
-            | "id"
-            | "renderType"
-            | "dataElements"
-            | "lastUpdatedBy"
-            | "programStage"
-            | "created"
-            | "sortOrder"
-            | "name"
-            | "style"
-        >;
-        $owner: Preset<
-            D2ProgramStageSection,
-            | "code"
-            | "description"
-            | "programIndicators"
-            | "lastUpdated"
-            | "translations"
-            | "formName"
-            | "id"
-            | "renderType"
-            | "dataElements"
-            | "lastUpdatedBy"
-            | "programStage"
-            | "created"
-            | "sortOrder"
-            | "name"
-            | "style"
-        >;
-    };
-}
-
-export interface D2ProgramNotificationTemplateSchema {
-    name: "D2ProgramNotificationTemplate";
-    model: D2ProgramNotificationTemplate;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        deliveryChannels: never[];
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        messageTemplate: string;
-        name: string;
-        notificationRecipient:
-            | "TRACKED_ENTITY_INSTANCE"
-            | "ORGANISATION_UNIT_CONTACT"
-            | "USERS_AT_ORGANISATION_UNIT"
-            | "USER_GROUP"
-            | "PROGRAM_ATTRIBUTE"
-            | "DATA_ELEMENT";
-        notificationTrigger:
-            | "ENROLLMENT"
-            | "COMPLETION"
-            | "PROGRAM_RULE"
-            | "SCHEDULED_DAYS_DUE_DATE"
-            | "SCHEDULED_DAYS_INCIDENT_DATE"
-            | "SCHEDULED_DAYS_ENROLLMENT_DATE";
-        notifyParentOrganisationUnitOnly: boolean;
-        notifyUsersInHierarchyOnly: boolean;
-        publicAccess: string;
-        recipientDataElement: D2DataElementSchema;
-        recipientProgramAttribute: D2TrackedEntityAttributeSchema;
-        recipientUserGroup: D2UserGroupSchema;
-        relativeScheduledDays: number;
-        subjectTemplate: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramNotificationTemplate, keyof D2ProgramNotificationTemplate>;
-        $identifiable: Preset<D2ProgramNotificationTemplate, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramNotificationTemplate, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramNotificationTemplate,
-            | "code"
-            | "notificationTrigger"
-            | "lastUpdated"
-            | "relativeScheduledDays"
-            | "id"
-            | "subjectTemplate"
-            | "lastUpdatedBy"
-            | "deliveryChannels"
-            | "recipientDataElement"
-            | "created"
-            | "notifyUsersInHierarchyOnly"
-            | "notificationRecipient"
-            | "recipientProgramAttribute"
-            | "notifyParentOrganisationUnitOnly"
-            | "name"
-            | "recipientUserGroup"
-            | "messageTemplate"
-        >;
-        $owner: Preset<
-            D2ProgramNotificationTemplate,
-            | "code"
-            | "notificationTrigger"
-            | "lastUpdated"
-            | "relativeScheduledDays"
-            | "id"
-            | "subjectTemplate"
-            | "lastUpdatedBy"
-            | "deliveryChannels"
-            | "recipientDataElement"
-            | "created"
-            | "notifyUsersInHierarchyOnly"
-            | "notificationRecipient"
-            | "recipientProgramAttribute"
-            | "notifyParentOrganisationUnitOnly"
-            | "name"
-            | "recipientUserGroup"
-            | "messageTemplate"
-        >;
-    };
-}
-
-export interface D2SMSCommandSchema {
-    name: "D2SMSCommand";
-    model: D2SMSCommand;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        codeValueSeparator: string;
-        completenessMethod: "ALL_DATAVALUE" | "AT_LEAST_ONE_DATAVALUE" | "DO_NOT_MARK_COMPLETE";
-        created: string;
-        currentPeriodUsedForReporting: boolean;
-        dataset: D2DataSetSchema;
-        defaultMessage: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        moreThanOneOrgUnitMessage: string;
-        name: string;
-        noUserMessage: string;
-        parserType:
-            | "KEY_VALUE_PARSER"
-            | "J2ME_PARSER"
-            | "ALERT_PARSER"
-            | "UNREGISTERED_PARSER"
-            | "TRACKED_ENTITY_REGISTRATION_PARSER"
-            | "PROGRAM_STAGE_DATAENTRY_PARSER"
-            | "EVENT_REGISTRATION_PARSER";
-        program: D2ProgramSchema;
-        programStage: D2ProgramStageSchema;
-        publicAccess: string;
-        receivedMessage: string;
-        separator: string;
-        smsCodes: any[];
-        specialCharacters: any[];
-        successMessage: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroup: D2UserGroupSchema;
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        wrongFormatMessage: string;
-    };
-    fieldPresets: {
-        $all: Preset<D2SMSCommand, keyof D2SMSCommand>;
-        $identifiable: Preset<D2SMSCommand, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2SMSCommand, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2SMSCommand,
-            | "moreThanOneOrgUnitMessage"
-            | "smsCodes"
-            | "specialCharacters"
-            | "currentPeriodUsedForReporting"
-            | "program"
-            | "noUserMessage"
-            | "lastUpdated"
-            | "receivedMessage"
-            | "defaultMessage"
-            | "id"
-            | "userGroup"
-            | "programStage"
-            | "completenessMethod"
-            | "created"
-            | "wrongFormatMessage"
-            | "separator"
-            | "successMessage"
-            | "codeValueSeparator"
-            | "parserType"
-            | "name"
-            | "dataset"
-        >;
-        $owner: Preset<
-            D2SMSCommand,
-            | "moreThanOneOrgUnitMessage"
-            | "smsCodes"
-            | "specialCharacters"
-            | "currentPeriodUsedForReporting"
-            | "program"
-            | "noUserMessage"
-            | "lastUpdated"
-            | "receivedMessage"
-            | "defaultMessage"
-            | "id"
-            | "userGroup"
-            | "programStage"
-            | "completenessMethod"
-            | "created"
-            | "wrongFormatMessage"
-            | "separator"
-            | "successMessage"
-            | "codeValueSeparator"
-            | "parserType"
-            | "name"
-            | "dataset"
-        >;
-    };
-}
-
-export interface D2ProgramStageSchema {
-    name: "D2ProgramStage";
-    model: D2ProgramStage;
-    fields: {
-        access: D2Access;
-        allowGenerateNextVisit: boolean;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        autoGenerateEvent: boolean;
-        blockEntryForm: boolean;
-        code: Id;
-        created: string;
-        dataEntryForm: D2DataEntryFormSchema;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayGenerateEventBox: boolean;
-        displayName: string;
-        displayShortName: string;
-        dueDateLabel: string;
-        enableUserAssignment: boolean;
-        executionDateLabel: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
-        formName: string;
-        formType: "DEFAULT" | "CUSTOM" | "SECTION" | "SECTION_MULTIORG";
-        generatedByEnrollmentDate: boolean;
-        hideDueDate: boolean;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        minDaysFromStart: number;
-        name: string;
-        nextScheduleDate: D2DataElementSchema;
-        notificationTemplates: D2ProgramNotificationTemplateSchema[];
-        openAfterEnrollment: boolean;
-        periodType: string;
-        preGenerateUID: boolean;
-        program: D2ProgramSchema;
-        programStageDataElements: D2ProgramStageDataElementSchema[];
-        programStageSections: D2ProgramStageSectionSchema[];
-        publicAccess: string;
-        remindCompleted: boolean;
-        repeatable: boolean;
-        reportDateToUse: string;
-        shortName: string;
-        sortOrder: number;
-        standardInterval: number;
-        style: D2Style;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        validationStrategy: "ON_COMPLETE" | "ON_UPDATE_AND_INSERT";
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramStage, keyof D2ProgramStage>;
-        $identifiable: Preset<D2ProgramStage, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramStage, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramStage,
-            | "dataEntryForm"
-            | "allowGenerateNextVisit"
-            | "publicAccess"
-            | "reportDateToUse"
-            | "program"
-            | "lastUpdated"
-            | "programStageDataElements"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "generatedByEnrollmentDate"
-            | "created"
-            | "attributeValues"
-            | "sortOrder"
-            | "userAccesses"
-            | "name"
-            | "hideDueDate"
-            | "enableUserAssignment"
-            | "style"
-            | "minDaysFromStart"
-            | "standardInterval"
-            | "dueDateLabel"
-            | "executionDateLabel"
-            | "code"
-            | "preGenerateUID"
-            | "description"
-            | "notificationTemplates"
-            | "openAfterEnrollment"
-            | "repeatable"
-            | "formName"
-            | "featureType"
-            | "remindCompleted"
-            | "displayGenerateEventBox"
-            | "nextScheduleDate"
-            | "validationStrategy"
-            | "autoGenerateEvent"
-            | "periodType"
-            | "blockEntryForm"
-            | "user"
-            | "programStageSections"
-        >;
-        $owner: Preset<
-            D2ProgramStage,
-            | "dataEntryForm"
-            | "allowGenerateNextVisit"
-            | "publicAccess"
-            | "reportDateToUse"
-            | "program"
-            | "lastUpdated"
-            | "programStageDataElements"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "generatedByEnrollmentDate"
-            | "created"
-            | "attributeValues"
-            | "sortOrder"
-            | "userAccesses"
-            | "name"
-            | "hideDueDate"
-            | "enableUserAssignment"
-            | "style"
-            | "minDaysFromStart"
-            | "standardInterval"
-            | "dueDateLabel"
-            | "executionDateLabel"
-            | "code"
-            | "preGenerateUID"
-            | "description"
-            | "notificationTemplates"
-            | "openAfterEnrollment"
-            | "repeatable"
-            | "formName"
-            | "featureType"
-            | "remindCompleted"
-            | "displayGenerateEventBox"
-            | "nextScheduleDate"
-            | "validationStrategy"
-            | "autoGenerateEvent"
-            | "periodType"
-            | "blockEntryForm"
-            | "user"
-            | "programStageSections"
-        >;
-    };
-}
-
-export interface D2ProgramSchema {
-    name: "D2Program";
-    model: D2Program;
-    fields: {
-        access: D2Access;
-        accessLevel: "OPEN" | "AUDITED" | "PROTECTED" | "CLOSED";
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        categoryCombo: D2CategoryComboSchema;
-        code: Id;
-        completeEventsExpiryDays: number;
-        created: string;
-        dataEntryForm: D2DataEntryFormSchema;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayFrontPageList: boolean;
-        displayIncidentDate: boolean;
-        displayName: string;
-        displayShortName: string;
-        enrollmentDateLabel: string;
-        expiryDays: number;
-        expiryPeriodType: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
-        formName: string;
-        href: string;
-        id: Id;
-        ignoreOverdueEvents: boolean;
-        incidentDateLabel: string;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        maxTeiCountToReturn: number;
-        minAttributesRequiredToSearch: number;
-        name: string;
-        notificationTemplates: D2ProgramNotificationTemplateSchema[];
-        onlyEnrollOnce: boolean;
-        organisationUnits: D2OrganisationUnitSchema[];
-        programIndicators: D2ProgramIndicatorSchema[];
-        programRuleVariables: D2ProgramRuleVariableSchema[];
-        programSections: D2ProgramSectionSchema[];
-        programStages: D2ProgramStageSchema[];
-        programTrackedEntityAttributes: D2ProgramTrackedEntityAttributeSchema[];
-        programType: "WITH_REGISTRATION" | "WITHOUT_REGISTRATION";
-        publicAccess: string;
-        registration: boolean;
-        relatedProgram: D2ProgramSchema;
-        selectEnrollmentDatesInFuture: boolean;
-        selectIncidentDatesInFuture: boolean;
-        shortName: string;
-        skipOffline: boolean;
-        style: D2Style;
-        trackedEntityType: D2TrackedEntityTypeSchema;
-        translations: D2Translation[];
-        useFirstStageDuringRegistration: boolean;
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        userRoles: D2UserAuthorityGroupSchema[];
-        version: number;
-        withoutRegistration: boolean;
-    };
-    fieldPresets: {
-        $all: Preset<D2Program, keyof D2Program>;
-        $identifiable: Preset<D2Program, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Program, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Program,
-            | "dataEntryForm"
-            | "publicAccess"
-            | "ignoreOverdueEvents"
-            | "skipOffline"
-            | "programIndicators"
-            | "lastUpdated"
-            | "categoryCombo"
-            | "translations"
-            | "id"
-            | "enrollmentDateLabel"
-            | "lastUpdatedBy"
-            | "onlyEnrollOnce"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "version"
-            | "maxTeiCountToReturn"
-            | "selectIncidentDatesInFuture"
-            | "incidentDateLabel"
-            | "userRoles"
-            | "expiryPeriodType"
-            | "userAccesses"
-            | "name"
-            | "selectEnrollmentDatesInFuture"
-            | "style"
-            | "shortName"
-            | "useFirstStageDuringRegistration"
-            | "code"
-            | "programRuleVariables"
-            | "programTrackedEntityAttributes"
-            | "completeEventsExpiryDays"
-            | "description"
-            | "relatedProgram"
-            | "notificationTemplates"
-            | "formName"
-            | "featureType"
-            | "minAttributesRequiredToSearch"
-            | "displayFrontPageList"
-            | "organisationUnits"
-            | "programType"
-            | "accessLevel"
-            | "programSections"
-            | "programStages"
-            | "trackedEntityType"
-            | "displayIncidentDate"
-            | "expiryDays"
-            | "user"
-        >;
-        $owner: Preset<
-            D2Program,
-            | "dataEntryForm"
-            | "publicAccess"
-            | "ignoreOverdueEvents"
-            | "skipOffline"
-            | "lastUpdated"
-            | "categoryCombo"
-            | "translations"
-            | "id"
-            | "enrollmentDateLabel"
-            | "lastUpdatedBy"
-            | "onlyEnrollOnce"
-            | "userGroupAccesses"
-            | "created"
-            | "attributeValues"
-            | "version"
-            | "maxTeiCountToReturn"
-            | "selectIncidentDatesInFuture"
-            | "incidentDateLabel"
-            | "expiryPeriodType"
-            | "userAccesses"
-            | "name"
-            | "selectEnrollmentDatesInFuture"
-            | "style"
-            | "shortName"
-            | "useFirstStageDuringRegistration"
-            | "code"
-            | "programTrackedEntityAttributes"
-            | "completeEventsExpiryDays"
-            | "description"
-            | "relatedProgram"
-            | "notificationTemplates"
-            | "formName"
-            | "featureType"
-            | "minAttributesRequiredToSearch"
-            | "displayFrontPageList"
-            | "organisationUnits"
-            | "programType"
-            | "accessLevel"
-            | "programSections"
-            | "programStages"
-            | "trackedEntityType"
-            | "displayIncidentDate"
-            | "expiryDays"
-            | "user"
-        >;
-    };
-}
-
-export interface D2EventReportSchema {
-    name: "D2EventReport";
-    model: D2EventReport;
-    fields: {
-        access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "FIRST"
-            | "FIRST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
-        attributeDimensions: any[];
-        attributeValueDimension: D2TrackedEntityAttributeSchema;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        categoryDimensions: D2CategoryDimensionSchema[];
-        categoryOptionGroupSetDimensions: D2CategoryOptionGroupSetDimensionSchema[];
-        code: Id;
-        colSubTotals: boolean;
-        colTotals: boolean;
-        collapseDataDimensions: boolean;
-        columnDimensions: string[];
-        columns: any[];
-        completedOnly: boolean;
-        created: string;
-        dataDimensionItems: any[];
-        dataElementDimensions: D2TrackedEntityDataElementDimensionSchema[];
-        dataElementGroupSetDimensions: D2DataElementGroupSetDimensionSchema[];
-        dataElementValueDimension: D2DataElementSchema;
-        dataType: "AGGREGATED_VALUES" | "EVENTS";
-        description: string;
-        digitGroupSeparator: "COMMA" | "SPACE" | "NONE";
-        displayDensity: "COMFORTABLE" | "NORMAL" | "COMPACT" | "NONE";
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        endDate: string;
-        eventStatus: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        filterDimensions: string[];
-        filters: any[];
-        fontSize: "LARGE" | "NORMAL" | "SMALL";
-        formName: string;
-        hideEmptyRows: boolean;
-        hideNaData: boolean;
-        hideSubtitle: boolean;
-        hideTitle: boolean;
-        href: string;
-        id: Id;
-        interpretations: D2InterpretationSchema[];
-        itemOrganisationUnitGroups: D2OrganisationUnitGroupSchema[];
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        orgUnitField: string;
-        organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimensionSchema[];
-        organisationUnitLevels: number[];
-        organisationUnits: D2OrganisationUnitSchema[];
-        outputType: "EVENT" | "ENROLLMENT" | "TRACKED_ENTITY_INSTANCE";
-        parentGraphMap: D2MapSchema;
-        periods: any[];
-        program: D2ProgramSchema;
-        programIndicatorDimensions: D2TrackedEntityProgramIndicatorDimensionSchema[];
-        programStage: D2ProgramStageSchema;
-        programStatus: "ACTIVE" | "COMPLETED" | "CANCELLED";
-        publicAccess: string;
-        relativePeriods: any;
-        rowDimensions: string[];
-        rowSubTotals: boolean;
-        rowTotals: boolean;
-        rows: any[];
-        shortName: string;
-        showDimensionLabels: boolean;
-        showHierarchy: boolean;
-        sortOrder: number;
-        startDate: string;
-        subscribed: boolean;
-        subscribers: string[];
-        subtitle: string;
-        timeField: string;
-        title: string;
-        topLimit: number;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        userOrgUnitType: "DATA_CAPTURE" | "DATA_OUTPUT" | "TEI_SEARCH";
-        userOrganisationUnit: boolean;
-        userOrganisationUnitChildren: boolean;
-        userOrganisationUnitGrandChildren: boolean;
-        value: any;
-    };
-    fieldPresets: {
-        $all: Preset<D2EventReport, keyof D2EventReport>;
-        $identifiable: Preset<D2EventReport, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2EventReport, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2EventReport,
-            | "orgUnitField"
-            | "endDate"
-            | "publicAccess"
-            | "userOrganisationUnitChildren"
-            | "program"
-            | "lastUpdated"
-            | "hideEmptyRows"
-            | "attributeDimensions"
-            | "translations"
-            | "userOrganisationUnit"
-            | "filterDimensions"
-            | "id"
-            | "rowSubTotals"
-            | "hideNaData"
-            | "interpretations"
-            | "itemOrganisationUnitGroups"
-            | "displayDensity"
-            | "attributeValueDimension"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "programIndicatorDimensions"
-            | "created"
-            | "subscribers"
-            | "dataType"
-            | "columnDimensions"
-            | "completedOnly"
-            | "colTotals"
-            | "showDimensionLabels"
-            | "subtitle"
-            | "sortOrder"
-            | "userAccesses"
-            | "name"
-            | "fontSize"
-            | "topLimit"
-            | "startDate"
-            | "collapseDataDimensions"
-            | "programStatus"
-            | "favorites"
-            | "aggregationType"
-            | "code"
-            | "categoryOptionGroupSetDimensions"
-            | "userOrganisationUnitGrandChildren"
-            | "hideSubtitle"
-            | "outputType"
-            | "description"
-            | "organisationUnitGroupSetDimensions"
-            | "title"
-            | "organisationUnitLevels"
+            | "url"
             | "externalAccess"
-            | "colSubTotals"
-            | "dataElementValueDimension"
-            | "relativePeriods"
-            | "dataElementDimensions"
-            | "periods"
-            | "organisationUnits"
-            | "categoryDimensions"
-            | "showHierarchy"
-            | "programStage"
-            | "rowTotals"
-            | "timeField"
-            | "digitGroupSeparator"
-            | "hideTitle"
-            | "rowDimensions"
-            | "eventStatus"
-            | "userOrgUnitType"
-            | "user"
-        >;
-        $owner: Preset<
-            D2EventReport,
-            | "orgUnitField"
-            | "endDate"
-            | "publicAccess"
-            | "userOrganisationUnitChildren"
-            | "program"
             | "lastUpdated"
-            | "hideEmptyRows"
-            | "attributeDimensions"
+            | "external"
+            | "attachment"
             | "translations"
-            | "userOrganisationUnit"
-            | "filterDimensions"
-            | "id"
-            | "rowSubTotals"
-            | "hideNaData"
-            | "itemOrganisationUnitGroups"
-            | "displayDensity"
-            | "attributeValueDimension"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "programIndicatorDimensions"
-            | "created"
-            | "subscribers"
-            | "dataType"
-            | "columnDimensions"
-            | "completedOnly"
-            | "colTotals"
-            | "showDimensionLabels"
-            | "subtitle"
-            | "sortOrder"
             | "userAccesses"
             | "name"
-            | "fontSize"
-            | "topLimit"
-            | "startDate"
-            | "collapseDataDimensions"
-            | "programStatus"
-            | "favorites"
-            | "aggregationType"
-            | "code"
-            | "categoryOptionGroupSetDimensions"
-            | "userOrganisationUnitGrandChildren"
-            | "hideSubtitle"
-            | "outputType"
-            | "description"
-            | "organisationUnitGroupSetDimensions"
-            | "title"
-            | "organisationUnitLevels"
-            | "externalAccess"
-            | "colSubTotals"
-            | "dataElementValueDimension"
-            | "relativePeriods"
-            | "dataElementDimensions"
-            | "periods"
-            | "organisationUnits"
-            | "categoryDimensions"
-            | "showHierarchy"
-            | "programStage"
-            | "rowTotals"
-            | "timeField"
-            | "digitGroupSeparator"
-            | "hideTitle"
-            | "rowDimensions"
-            | "eventStatus"
-            | "userOrgUnitType"
+            | "id"
             | "user"
+            | "contentType"
+        >;
+        $owner: Preset<
+            D2Document,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "attributeValues"
+            | "url"
+            | "externalAccess"
+            | "lastUpdated"
+            | "external"
+            | "attachment"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+            | "contentType"
         >;
     };
 }
@@ -10380,84 +7599,481 @@ export interface D2EventChartSchema {
     };
 }
 
-export interface D2ProgramSectionSchema {
-    name: "D2ProgramSection";
-    model: D2ProgramSection;
+export interface D2EventReportSchema {
+    name: "D2EventReport";
+    model: D2EventReport;
+    fields: {
+        access: D2Access;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        attributeDimensions: any[];
+        attributeValueDimension: D2TrackedEntityAttributeSchema;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        categoryDimensions: D2CategoryDimensionSchema[];
+        categoryOptionGroupSetDimensions: D2CategoryOptionGroupSetDimensionSchema[];
+        code: Id;
+        colSubTotals: boolean;
+        colTotals: boolean;
+        collapseDataDimensions: boolean;
+        columnDimensions: string[];
+        columns: any[];
+        completedOnly: boolean;
+        created: string;
+        dataDimensionItems: any[];
+        dataElementDimensions: D2TrackedEntityDataElementDimensionSchema[];
+        dataElementGroupSetDimensions: D2DataElementGroupSetDimensionSchema[];
+        dataElementValueDimension: D2DataElementSchema;
+        dataType: "AGGREGATED_VALUES" | "EVENTS";
+        description: string;
+        digitGroupSeparator: "COMMA" | "SPACE" | "NONE";
+        displayDensity: "COMFORTABLE" | "NORMAL" | "COMPACT" | "NONE";
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        endDate: string;
+        eventStatus: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        filterDimensions: string[];
+        filters: any[];
+        fontSize: "LARGE" | "NORMAL" | "SMALL";
+        formName: string;
+        hideEmptyRows: boolean;
+        hideNaData: boolean;
+        hideSubtitle: boolean;
+        hideTitle: boolean;
+        href: string;
+        id: Id;
+        interpretations: D2InterpretationSchema[];
+        itemOrganisationUnitGroups: D2OrganisationUnitGroupSchema[];
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        orgUnitField: string;
+        organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimensionSchema[];
+        organisationUnitLevels: number[];
+        organisationUnits: D2OrganisationUnitSchema[];
+        outputType: "EVENT" | "ENROLLMENT" | "TRACKED_ENTITY_INSTANCE";
+        parentGraphMap: D2MapSchema;
+        periods: any[];
+        program: D2ProgramSchema;
+        programIndicatorDimensions: D2TrackedEntityProgramIndicatorDimensionSchema[];
+        programStage: D2ProgramStageSchema;
+        programStatus: "ACTIVE" | "COMPLETED" | "CANCELLED";
+        publicAccess: string;
+        relativePeriods: any;
+        rowDimensions: string[];
+        rowSubTotals: boolean;
+        rowTotals: boolean;
+        rows: any[];
+        shortName: string;
+        showDimensionLabels: boolean;
+        showHierarchy: boolean;
+        sortOrder: number;
+        startDate: string;
+        subscribed: boolean;
+        subscribers: string[];
+        subtitle: string;
+        timeField: string;
+        title: string;
+        topLimit: number;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        userOrgUnitType: "DATA_CAPTURE" | "DATA_OUTPUT" | "TEI_SEARCH";
+        userOrganisationUnit: boolean;
+        userOrganisationUnitChildren: boolean;
+        userOrganisationUnitGrandChildren: boolean;
+        value: any;
+    };
+    fieldPresets: {
+        $all: Preset<D2EventReport, keyof D2EventReport>;
+        $identifiable: Preset<D2EventReport, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2EventReport, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2EventReport,
+            | "orgUnitField"
+            | "endDate"
+            | "publicAccess"
+            | "userOrganisationUnitChildren"
+            | "program"
+            | "lastUpdated"
+            | "hideEmptyRows"
+            | "attributeDimensions"
+            | "translations"
+            | "userOrganisationUnit"
+            | "filterDimensions"
+            | "id"
+            | "rowSubTotals"
+            | "hideNaData"
+            | "interpretations"
+            | "itemOrganisationUnitGroups"
+            | "displayDensity"
+            | "attributeValueDimension"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "programIndicatorDimensions"
+            | "created"
+            | "subscribers"
+            | "dataType"
+            | "columnDimensions"
+            | "completedOnly"
+            | "colTotals"
+            | "showDimensionLabels"
+            | "subtitle"
+            | "sortOrder"
+            | "userAccesses"
+            | "name"
+            | "fontSize"
+            | "topLimit"
+            | "startDate"
+            | "collapseDataDimensions"
+            | "programStatus"
+            | "favorites"
+            | "aggregationType"
+            | "code"
+            | "categoryOptionGroupSetDimensions"
+            | "userOrganisationUnitGrandChildren"
+            | "hideSubtitle"
+            | "outputType"
+            | "description"
+            | "organisationUnitGroupSetDimensions"
+            | "title"
+            | "organisationUnitLevels"
+            | "externalAccess"
+            | "colSubTotals"
+            | "dataElementValueDimension"
+            | "relativePeriods"
+            | "dataElementDimensions"
+            | "periods"
+            | "organisationUnits"
+            | "categoryDimensions"
+            | "showHierarchy"
+            | "programStage"
+            | "rowTotals"
+            | "timeField"
+            | "digitGroupSeparator"
+            | "hideTitle"
+            | "rowDimensions"
+            | "eventStatus"
+            | "userOrgUnitType"
+            | "user"
+        >;
+        $owner: Preset<
+            D2EventReport,
+            | "orgUnitField"
+            | "endDate"
+            | "publicAccess"
+            | "userOrganisationUnitChildren"
+            | "program"
+            | "lastUpdated"
+            | "hideEmptyRows"
+            | "attributeDimensions"
+            | "translations"
+            | "userOrganisationUnit"
+            | "filterDimensions"
+            | "id"
+            | "rowSubTotals"
+            | "hideNaData"
+            | "itemOrganisationUnitGroups"
+            | "displayDensity"
+            | "attributeValueDimension"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "programIndicatorDimensions"
+            | "created"
+            | "subscribers"
+            | "dataType"
+            | "columnDimensions"
+            | "completedOnly"
+            | "colTotals"
+            | "showDimensionLabels"
+            | "subtitle"
+            | "sortOrder"
+            | "userAccesses"
+            | "name"
+            | "fontSize"
+            | "topLimit"
+            | "startDate"
+            | "collapseDataDimensions"
+            | "programStatus"
+            | "favorites"
+            | "aggregationType"
+            | "code"
+            | "categoryOptionGroupSetDimensions"
+            | "userOrganisationUnitGrandChildren"
+            | "hideSubtitle"
+            | "outputType"
+            | "description"
+            | "organisationUnitGroupSetDimensions"
+            | "title"
+            | "organisationUnitLevels"
+            | "externalAccess"
+            | "colSubTotals"
+            | "dataElementValueDimension"
+            | "relativePeriods"
+            | "dataElementDimensions"
+            | "periods"
+            | "organisationUnits"
+            | "categoryDimensions"
+            | "showHierarchy"
+            | "programStage"
+            | "rowTotals"
+            | "timeField"
+            | "digitGroupSeparator"
+            | "hideTitle"
+            | "rowDimensions"
+            | "eventStatus"
+            | "userOrgUnitType"
+            | "user"
+        >;
+    };
+}
+
+export interface D2ExpressionSchema {
+    name: "D2Expression";
+    model: D2Expression;
+    fields: {
+        description: string;
+        expression: string;
+        missingValueStrategy:
+            | "SKIP_IF_ANY_VALUE_MISSING"
+            | "SKIP_IF_ALL_VALUES_MISSING"
+            | "NEVER_SKIP";
+        slidingWindow: boolean;
+    };
+    fieldPresets: {
+        $all: Preset<D2Expression, keyof D2Expression>;
+        $identifiable: Preset<D2Expression, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Expression, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Expression,
+            "description" | "expression" | "missingValueStrategy" | "slidingWindow"
+        >;
+        $owner: Preset<
+            D2Expression,
+            "description" | "expression" | "missingValueStrategy" | "slidingWindow"
+        >;
+    };
+}
+
+export interface D2ExternalFileResourceSchema {
+    name: "D2ExternalFileResource";
+    model: D2ExternalFileResource;
     fields: {
         access: D2Access;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
         displayName: string;
-        displayShortName: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
-        formName: string;
         href: string;
         id: Id;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
         name: string;
-        program: D2ProgramSchema;
         publicAccess: string;
-        renderType: any;
-        shortName: string;
-        sortOrder: number;
-        style: D2Style;
-        trackedEntityAttributes: D2TrackedEntityAttributeSchema[];
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2ProgramSection, keyof D2ProgramSection>;
-        $identifiable: Preset<D2ProgramSection, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramSection, FieldPresets["nameable"]>;
+        $all: Preset<D2ExternalFileResource, keyof D2ExternalFileResource>;
+        $identifiable: Preset<D2ExternalFileResource, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ExternalFileResource, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2ProgramSection,
-            | "code"
-            | "description"
-            | "program"
-            | "lastUpdated"
-            | "translations"
-            | "formName"
-            | "id"
-            | "renderType"
-            | "lastUpdatedBy"
-            | "created"
-            | "sortOrder"
-            | "name"
-            | "trackedEntityAttributes"
-            | "style"
+            D2ExternalFileResource,
+            "lastUpdatedBy" | "code" | "created" | "lastUpdated" | "id"
         >;
         $owner: Preset<
-            D2ProgramSection,
-            | "code"
-            | "description"
-            | "program"
-            | "lastUpdated"
-            | "translations"
-            | "formName"
-            | "id"
-            | "renderType"
-            | "lastUpdatedBy"
-            | "created"
-            | "sortOrder"
-            | "name"
-            | "trackedEntityAttributes"
-            | "style"
+            D2ExternalFileResource,
+            "lastUpdatedBy" | "code" | "created" | "lastUpdated" | "id"
         >;
     };
 }
 
-export interface D2ProgramIndicatorSchema {
-    name: "D2ProgramIndicator";
-    model: D2ProgramIndicator;
+export interface D2ExternalMapLayerSchema {
+    name: "D2ExternalMapLayer";
+    model: D2ExternalMapLayer;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        attribution: string;
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        imageFormat: "PNG" | "JPG";
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        layers: string;
+        legendSet: D2LegendSetSchema;
+        legendSetUrl: string;
+        mapLayerPosition: "BASEMAP" | "OVERLAY";
+        mapService: "WMS" | "TMS" | "XYZ";
+        name: string;
+        publicAccess: string;
+        translations: D2Translation[];
+        url: string;
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ExternalMapLayer, keyof D2ExternalMapLayer>;
+        $identifiable: Preset<D2ExternalMapLayer, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ExternalMapLayer, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ExternalMapLayer,
+            | "imageFormat"
+            | "code"
+            | "publicAccess"
+            | "legendSetUrl"
+            | "mapService"
+            | "lastUpdated"
+            | "layers"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "mapLayerPosition"
+            | "url"
+            | "userAccesses"
+            | "name"
+            | "legendSet"
+            | "attribution"
+            | "user"
+        >;
+        $owner: Preset<
+            D2ExternalMapLayer,
+            | "imageFormat"
+            | "code"
+            | "publicAccess"
+            | "legendSetUrl"
+            | "mapService"
+            | "lastUpdated"
+            | "layers"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "mapLayerPosition"
+            | "url"
+            | "userAccesses"
+            | "name"
+            | "legendSet"
+            | "attribution"
+            | "user"
+        >;
+    };
+}
+
+export interface D2FileResourceSchema {
+    name: "D2FileResource";
+    model: D2FileResource;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        contentLength: string;
+        contentMd5: string;
+        contentType: string;
+        created: string;
+        displayName: string;
+        domain: "DATA_VALUE" | "PUSH_ANALYSIS" | "DOCUMENT" | "MESSAGE_ATTACHMENT" | "USER_AVATAR";
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        hasMultipleStorageFiles: boolean;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        storageStatus: "NONE" | "PENDING" | "FAILED" | "STORED";
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2FileResource, keyof D2FileResource>;
+        $identifiable: Preset<D2FileResource, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2FileResource, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2FileResource,
+            | "contentMd5"
+            | "code"
+            | "lastUpdated"
+            | "id"
+            | "contentType"
+            | "lastUpdatedBy"
+            | "created"
+            | "domain"
+            | "hasMultipleStorageFiles"
+            | "name"
+            | "contentLength"
+            | "user"
+        >;
+        $owner: Preset<
+            D2FileResource,
+            | "contentMd5"
+            | "code"
+            | "lastUpdated"
+            | "id"
+            | "contentType"
+            | "lastUpdatedBy"
+            | "created"
+            | "domain"
+            | "hasMultipleStorageFiles"
+            | "name"
+            | "contentLength"
+            | "user"
+        >;
+    };
+}
+
+export interface D2IconSchema {
+    name: "D2Icon";
+    model: D2Icon;
+    fields: {};
+    fieldPresets: {
+        $all: Preset<D2Icon, keyof D2Icon>;
+        $identifiable: Preset<D2Icon, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Icon, FieldPresets["nameable"]>;
+        $persisted: Preset<D2Icon, never>;
+        $owner: Preset<D2Icon, never>;
+    };
+}
+
+export interface D2IndicatorSchema {
+    name: "D2Indicator";
+    model: D2Indicator;
     fields: {
         access: D2Access;
         aggregateExportAttributeOptionCombo: string;
@@ -10478,12 +8094,14 @@ export interface D2ProgramIndicatorSchema {
             | "NONE"
             | "CUSTOM"
             | "DEFAULT";
-        analyticsPeriodBoundaries: D2AnalyticsPeriodBoundarySchema[];
-        analyticsType: "EVENT" | "ENROLLMENT";
+        annualized: boolean;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
+        dataSets: D2DataSetSchema[];
         decimals: number;
+        denominator: string;
+        denominatorDescription: string;
         description: string;
         dimensionItem: string;
         dimensionItemType:
@@ -10501,63 +8119,66 @@ export interface D2ProgramIndicatorSchema {
             | "DATA_ELEMENT_GROUP"
             | "ORGANISATION_UNIT_GROUP"
             | "CATEGORY_OPTION_GROUP";
+        displayDenominatorDescription: string;
         displayDescription: string;
         displayFormName: string;
-        displayInForm: boolean;
         displayName: string;
+        displayNumeratorDescription: string;
         displayShortName: string;
-        expression: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
-        filter: string;
         formName: string;
         href: string;
         id: Id;
+        indicatorGroups: D2IndicatorGroupSchema[];
+        indicatorType: D2IndicatorTypeSchema;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
         legendSet: D2LegendSetSchema;
         legendSets: D2LegendSetSchema[];
         name: string;
-        program: D2ProgramSchema;
-        programIndicatorGroups: D2ProgramIndicatorGroupSchema[];
+        numerator: string;
+        numeratorDescription: string;
         publicAccess: string;
         shortName: string;
         style: D2Style;
         translations: D2Translation[];
+        url: string;
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2ProgramIndicator, keyof D2ProgramIndicator>;
-        $identifiable: Preset<D2ProgramIndicator, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramIndicator, FieldPresets["nameable"]>;
+        $all: Preset<D2Indicator, keyof D2Indicator>;
+        $identifiable: Preset<D2Indicator, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Indicator, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2ProgramIndicator,
-            | "aggregationType"
+            D2Indicator,
             | "code"
-            | "displayInForm"
             | "publicAccess"
             | "aggregateExportCategoryOptionCombo"
             | "description"
-            | "program"
             | "lastUpdated"
+            | "denominatorDescription"
+            | "indicatorType"
             | "translations"
             | "formName"
             | "id"
-            | "programIndicatorGroups"
-            | "analyticsPeriodBoundaries"
+            | "numeratorDescription"
             | "lastUpdatedBy"
             | "userGroupAccesses"
-            | "expression"
             | "created"
             | "attributeValues"
-            | "filter"
+            | "indicatorGroups"
+            | "url"
+            | "numerator"
+            | "denominator"
+            | "annualized"
             | "userAccesses"
             | "decimals"
             | "name"
-            | "analyticsType"
+            | "dataSets"
             | "legendSets"
             | "style"
             | "shortName"
@@ -10565,29 +8186,29 @@ export interface D2ProgramIndicatorSchema {
             | "aggregateExportAttributeOptionCombo"
         >;
         $owner: Preset<
-            D2ProgramIndicator,
-            | "aggregationType"
+            D2Indicator,
             | "code"
-            | "displayInForm"
             | "publicAccess"
             | "aggregateExportCategoryOptionCombo"
             | "description"
-            | "program"
             | "lastUpdated"
+            | "denominatorDescription"
+            | "indicatorType"
             | "translations"
             | "formName"
             | "id"
-            | "analyticsPeriodBoundaries"
+            | "numeratorDescription"
             | "lastUpdatedBy"
             | "userGroupAccesses"
-            | "expression"
             | "created"
             | "attributeValues"
-            | "filter"
+            | "url"
+            | "numerator"
+            | "denominator"
+            | "annualized"
             | "userAccesses"
             | "decimals"
             | "name"
-            | "analyticsType"
             | "legendSets"
             | "style"
             | "shortName"
@@ -10597,91 +8218,80 @@ export interface D2ProgramIndicatorSchema {
     };
 }
 
-export interface D2RelationshipTypeSchema {
-    name: "D2RelationshipType";
-    model: D2RelationshipType;
+export interface D2IndicatorGroupSchema {
+    name: "D2IndicatorGroup";
+    model: D2IndicatorGroup;
     fields: {
         access: D2Access;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        bidirectional: boolean;
         code: Id;
         created: string;
-        description: string;
-        displayFromToName: string;
         displayName: string;
-        displayToFromName: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
-        fromConstraint: D2RelationshipConstraint;
-        fromToName: string;
         href: string;
         id: Id;
+        indicatorGroupSet: D2IndicatorGroupSetSchema;
+        indicators: D2IndicatorSchema[];
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
         name: string;
         publicAccess: string;
-        toConstraint: D2RelationshipConstraint;
-        toFromName: string;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2RelationshipType, keyof D2RelationshipType>;
-        $identifiable: Preset<D2RelationshipType, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2RelationshipType, FieldPresets["nameable"]>;
+        $all: Preset<D2IndicatorGroup, keyof D2IndicatorGroup>;
+        $identifiable: Preset<D2IndicatorGroup, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2IndicatorGroup, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2RelationshipType,
-            | "bidirectional"
-            | "code"
-            | "publicAccess"
-            | "description"
-            | "fromToName"
-            | "lastUpdated"
-            | "translations"
-            | "toConstraint"
-            | "id"
+            D2IndicatorGroup,
             | "lastUpdatedBy"
             | "userGroupAccesses"
+            | "code"
             | "created"
-            | "toFromName"
-            | "fromConstraint"
+            | "publicAccess"
+            | "attributeValues"
+            | "indicators"
+            | "indicatorGroupSet"
+            | "lastUpdated"
+            | "translations"
             | "userAccesses"
             | "name"
+            | "id"
             | "user"
         >;
         $owner: Preset<
-            D2RelationshipType,
-            | "bidirectional"
-            | "code"
-            | "publicAccess"
-            | "description"
-            | "fromToName"
-            | "lastUpdated"
-            | "translations"
-            | "toConstraint"
-            | "id"
+            D2IndicatorGroup,
             | "lastUpdatedBy"
             | "userGroupAccesses"
+            | "code"
             | "created"
-            | "toFromName"
-            | "fromConstraint"
+            | "publicAccess"
+            | "attributeValues"
+            | "indicators"
+            | "indicatorGroupSet"
+            | "lastUpdated"
+            | "translations"
             | "userAccesses"
             | "name"
+            | "id"
             | "user"
         >;
     };
 }
 
-export interface D2ProgramIndicatorGroupSchema {
-    name: "D2ProgramIndicatorGroup";
-    model: D2ProgramIndicatorGroup;
+export interface D2IndicatorGroupSetSchema {
+    name: "D2IndicatorGroupSet";
+    model: D2IndicatorGroupSet;
     fields: {
         access: D2Access;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
+        compulsory: boolean;
         created: string;
         description: string;
         displayName: string;
@@ -10690,10 +8300,10 @@ export interface D2ProgramIndicatorGroupSchema {
         favorites: string[];
         href: string;
         id: Id;
+        indicatorGroups: D2IndicatorGroupSchema[];
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
         name: string;
-        programIndicators: D2ProgramIndicatorSchema[];
         publicAccess: string;
         translations: D2Translation[];
         user: D2UserSchema;
@@ -10701,19 +8311,20 @@ export interface D2ProgramIndicatorGroupSchema {
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2ProgramIndicatorGroup, keyof D2ProgramIndicatorGroup>;
-        $identifiable: Preset<D2ProgramIndicatorGroup, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramIndicatorGroup, FieldPresets["nameable"]>;
+        $all: Preset<D2IndicatorGroupSet, keyof D2IndicatorGroupSet>;
+        $identifiable: Preset<D2IndicatorGroupSet, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2IndicatorGroupSet, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2ProgramIndicatorGroup,
+            D2IndicatorGroupSet,
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "code"
             | "created"
             | "publicAccess"
             | "description"
-            | "programIndicators"
+            | "indicatorGroups"
             | "lastUpdated"
+            | "compulsory"
             | "translations"
             | "userAccesses"
             | "name"
@@ -10721,15 +8332,16 @@ export interface D2ProgramIndicatorGroupSchema {
             | "user"
         >;
         $owner: Preset<
-            D2ProgramIndicatorGroup,
+            D2IndicatorGroupSet,
             | "lastUpdatedBy"
             | "userGroupAccesses"
             | "code"
             | "created"
             | "publicAccess"
             | "description"
-            | "programIndicators"
+            | "indicatorGroups"
             | "lastUpdated"
+            | "compulsory"
             | "translations"
             | "userAccesses"
             | "name"
@@ -10739,15 +8351,166 @@ export interface D2ProgramIndicatorGroupSchema {
     };
 }
 
-export interface D2ProgramRuleVariableSchema {
-    name: "D2ProgramRuleVariable";
-    model: D2ProgramRuleVariable;
+export interface D2IndicatorTypeSchema {
+    name: "D2IndicatorType";
+    model: D2IndicatorType;
     fields: {
         access: D2Access;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
         created: string;
-        dataElement: D2DataElementSchema;
+        displayName: string;
+        externalAccess: boolean;
+        factor: number;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        number: boolean;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2IndicatorType, keyof D2IndicatorType>;
+        $identifiable: Preset<D2IndicatorType, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2IndicatorType, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2IndicatorType,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "lastUpdated"
+            | "number"
+            | "translations"
+            | "name"
+            | "id"
+            | "factor"
+        >;
+        $owner: Preset<
+            D2IndicatorType,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "lastUpdated"
+            | "number"
+            | "translations"
+            | "name"
+            | "id"
+            | "factor"
+        >;
+    };
+}
+
+export interface D2InterpretationSchema {
+    name: "D2Interpretation";
+    model: D2Interpretation;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        chart: D2ChartSchema;
+        code: Id;
+        comments: D2InterpretationCommentSchema[];
+        created: string;
+        dataSet: D2DataSetSchema;
+        displayName: string;
+        eventChart: D2EventChartSchema;
+        eventReport: D2EventReportSchema;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        likedBy: D2UserSchema[];
+        likes: number;
+        map: D2MapSchema;
+        mentions: any[];
+        name: string;
+        organisationUnit: D2OrganisationUnitSchema;
+        period: any;
+        publicAccess: string;
+        reportTable: D2ReportTableSchema;
+        text: string;
+        translations: D2Translation[];
+        type:
+            | "VISUALIZATION"
+            | "REPORT_TABLE"
+            | "CHART"
+            | "MAP"
+            | "EVENT_REPORT"
+            | "EVENT_CHART"
+            | "DATASET_REPORT";
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        visualization: D2VisualizationSchema;
+    };
+    fieldPresets: {
+        $all: Preset<D2Interpretation, keyof D2Interpretation>;
+        $identifiable: Preset<D2Interpretation, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Interpretation, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Interpretation,
+            | "visualization"
+            | "likedBy"
+            | "organisationUnit"
+            | "publicAccess"
+            | "lastUpdated"
+            | "id"
+            | "text"
+            | "map"
+            | "dataSet"
+            | "likes"
+            | "period"
+            | "userGroupAccesses"
+            | "comments"
+            | "created"
+            | "eventReport"
+            | "userAccesses"
+            | "mentions"
+            | "eventChart"
+            | "user"
+        >;
+        $owner: Preset<
+            D2Interpretation,
+            | "visualization"
+            | "likedBy"
+            | "organisationUnit"
+            | "publicAccess"
+            | "lastUpdated"
+            | "id"
+            | "text"
+            | "map"
+            | "dataSet"
+            | "likes"
+            | "period"
+            | "userGroupAccesses"
+            | "comments"
+            | "created"
+            | "eventReport"
+            | "userAccesses"
+            | "mentions"
+            | "eventChart"
+            | "user"
+        >;
+    };
+}
+
+export interface D2InterpretationCommentSchema {
+    name: "D2InterpretationComment";
+    model: D2InterpretationComment;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
         displayName: string;
         externalAccess: boolean;
         favorite: boolean;
@@ -10756,75 +8519,297 @@ export interface D2ProgramRuleVariableSchema {
         id: Id;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
+        mentions: any[];
         name: string;
-        program: D2ProgramSchema;
-        programRuleVariableSourceType:
-            | "DATAELEMENT_NEWEST_EVENT_PROGRAM_STAGE"
-            | "DATAELEMENT_NEWEST_EVENT_PROGRAM"
-            | "DATAELEMENT_CURRENT_EVENT"
-            | "DATAELEMENT_PREVIOUS_EVENT"
-            | "CALCULATED_VALUE"
-            | "TEI_ATTRIBUTE";
-        programStage: D2ProgramStageSchema;
         publicAccess: string;
-        trackedEntityAttribute: D2TrackedEntityAttributeSchema;
+        text: string;
         translations: D2Translation[];
-        useCodeForOptionSet: boolean;
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2ProgramRuleVariable, keyof D2ProgramRuleVariable>;
-        $identifiable: Preset<D2ProgramRuleVariable, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramRuleVariable, FieldPresets["nameable"]>;
+        $all: Preset<D2InterpretationComment, keyof D2InterpretationComment>;
+        $identifiable: Preset<D2InterpretationComment, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2InterpretationComment, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2ProgramRuleVariable,
-            | "code"
-            | "programRuleVariableSourceType"
-            | "program"
-            | "trackedEntityAttribute"
-            | "lastUpdated"
-            | "id"
-            | "lastUpdatedBy"
-            | "programStage"
-            | "created"
-            | "useCodeForOptionSet"
-            | "dataElement"
-            | "name"
+            D2InterpretationComment,
+            "created" | "lastUpdated" | "mentions" | "text" | "id" | "user"
         >;
         $owner: Preset<
-            D2ProgramRuleVariable,
-            | "code"
-            | "programRuleVariableSourceType"
-            | "program"
-            | "trackedEntityAttribute"
-            | "lastUpdated"
-            | "id"
-            | "lastUpdatedBy"
-            | "programStage"
-            | "created"
-            | "useCodeForOptionSet"
-            | "dataElement"
-            | "name"
+            D2InterpretationComment,
+            "created" | "lastUpdated" | "mentions" | "text" | "id" | "user"
         >;
     };
 }
 
-export interface D2ProgramRuleActionSchema {
-    name: "D2ProgramRuleAction";
-    model: D2ProgramRuleAction;
+export interface D2JobConfigurationSchema {
+    name: "D2JobConfiguration";
+    model: D2JobConfiguration;
     fields: {
         access: D2Access;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
         code: Id;
-        content: string;
+        configurable: boolean;
         created: string;
-        data: string;
-        dataElement: D2DataElementSchema;
+        cronExpression: string;
+        delay: number;
         displayName: string;
-        evaluationEnvironments: never[];
-        evaluationTime: "ON_DATA_ENTRY" | "ON_COMPLETE" | "ALWAYS";
+        enabled: boolean;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        jobParameters: string;
+        jobStatus:
+            | "RUNNING"
+            | "COMPLETED"
+            | "STOPPED"
+            | "SCHEDULED"
+            | "DISABLED"
+            | "FAILED"
+            | "NOT_STARTED";
+        jobType:
+            | "DATA_STATISTICS"
+            | "DATA_INTEGRITY"
+            | "RESOURCE_TABLE"
+            | "ANALYTICS_TABLE"
+            | "CONTINUOUS_ANALYTICS_TABLE"
+            | "DATA_SYNC"
+            | "TRACKER_PROGRAMS_DATA_SYNC"
+            | "EVENT_PROGRAMS_DATA_SYNC"
+            | "FILE_RESOURCE_CLEANUP"
+            | "IMAGE_PROCESSING"
+            | "META_DATA_SYNC"
+            | "SMS_SEND"
+            | "SEND_SCHEDULED_MESSAGE"
+            | "PROGRAM_NOTIFICATIONS"
+            | "VALIDATION_RESULTS_NOTIFICATION"
+            | "CREDENTIALS_EXPIRY_ALERT"
+            | "MONITORING"
+            | "PUSH_ANALYSIS"
+            | "PREDICTOR"
+            | "DATA_SET_NOTIFICATION"
+            | "REMOVE_EXPIRED_RESERVED_VALUES"
+            | "TRACKER_IMPORT_JOB"
+            | "TRACKER_IMPORT_NOTIFICATION_JOB"
+            | "TRACKER_IMPORT_RULE_ENGINE_JOB"
+            | "MOCK"
+            | "DATAVALUE_IMPORT"
+            | "ANALYTICSTABLE_UPDATE"
+            | "METADATA_IMPORT"
+            | "GML_IMPORT"
+            | "DATAVALUE_IMPORT_INTERNAL"
+            | "EVENT_IMPORT"
+            | "ENROLLMENT_IMPORT"
+            | "TEI_IMPORT"
+            | "LEADER_ELECTION"
+            | "LEADER_RENEWAL"
+            | "COMPLETE_DATA_SET_REGISTRATION_IMPORT"
+            | "PROGRAM_DATA_SYNC";
+        lastExecuted: string;
+        lastExecutedStatus:
+            | "RUNNING"
+            | "COMPLETED"
+            | "STOPPED"
+            | "SCHEDULED"
+            | "DISABLED"
+            | "FAILED"
+            | "NOT_STARTED";
+        lastRuntimeExecution: string;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        leaderOnlyJob: boolean;
+        name: string;
+        nextExecutionTime: string;
+        publicAccess: string;
+        schedulingType: "CRON" | "FIXED_DELAY";
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        userUid: string;
+    };
+    fieldPresets: {
+        $all: Preset<D2JobConfiguration, keyof D2JobConfiguration>;
+        $identifiable: Preset<D2JobConfiguration, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2JobConfiguration, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2JobConfiguration,
+            | "jobStatus"
+            | "code"
+            | "enabled"
+            | "leaderOnlyJob"
+            | "lastUpdated"
+            | "id"
+            | "jobType"
+            | "lastUpdatedBy"
+            | "nextExecutionTime"
+            | "created"
+            | "cronExpression"
+            | "lastRuntimeExecution"
+            | "delay"
+            | "lastExecutedStatus"
+            | "name"
+            | "jobParameters"
+            | "lastExecuted"
+        >;
+        $owner: Preset<
+            D2JobConfiguration,
+            | "jobStatus"
+            | "code"
+            | "enabled"
+            | "leaderOnlyJob"
+            | "lastUpdated"
+            | "id"
+            | "jobType"
+            | "lastUpdatedBy"
+            | "nextExecutionTime"
+            | "created"
+            | "cronExpression"
+            | "lastRuntimeExecution"
+            | "delay"
+            | "lastExecutedStatus"
+            | "name"
+            | "jobParameters"
+            | "lastExecuted"
+        >;
+    };
+}
+
+export interface D2KeyJsonValueSchema {
+    name: "D2KeyJsonValue";
+    model: D2KeyJsonValue;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        key: string;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        namespace: string;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        value: string;
+    };
+    fieldPresets: {
+        $all: Preset<D2KeyJsonValue, keyof D2KeyJsonValue>;
+        $identifiable: Preset<D2KeyJsonValue, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2KeyJsonValue, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2KeyJsonValue,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "lastUpdated"
+            | "userAccesses"
+            | "namespace"
+            | "id"
+            | "user"
+            | "key"
+        >;
+        $owner: Preset<
+            D2KeyJsonValue,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "lastUpdated"
+            | "userAccesses"
+            | "namespace"
+            | "id"
+            | "user"
+            | "key"
+        >;
+    };
+}
+
+export interface D2LegendSchema {
+    name: "D2Legend";
+    model: D2Legend;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        color: string;
+        created: string;
+        displayName: string;
+        endValue: number;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        image: string;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        startValue: number;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2Legend, keyof D2Legend>;
+        $identifiable: Preset<D2Legend, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Legend, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Legend,
+            | "lastUpdatedBy"
+            | "image"
+            | "code"
+            | "endValue"
+            | "color"
+            | "created"
+            | "lastUpdated"
+            | "translations"
+            | "name"
+            | "startValue"
+            | "id"
+        >;
+        $owner: Preset<
+            D2Legend,
+            | "lastUpdatedBy"
+            | "image"
+            | "code"
+            | "endValue"
+            | "color"
+            | "created"
+            | "lastUpdated"
+            | "translations"
+            | "name"
+            | "startValue"
+            | "id"
+        >;
+    };
+}
+
+export interface D2LegendSetSchema {
+    name: "D2LegendSet";
+    model: D2LegendSet;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        displayName: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
@@ -10832,157 +8817,146 @@ export interface D2ProgramRuleActionSchema {
         id: Id;
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
-        location: string;
+        legends: D2LegendSchema[];
         name: string;
-        option: D2OptionSchema;
-        optionGroup: D2OptionGroupSchema;
-        programIndicator: D2ProgramIndicatorSchema;
-        programRule: D2ProgramRuleSchema;
-        programRuleActionType:
-            | "DISPLAYTEXT"
-            | "DISPLAYKEYVALUEPAIR"
-            | "HIDEFIELD"
-            | "HIDESECTION"
-            | "HIDEPROGRAMSTAGE"
-            | "ASSIGN"
-            | "SHOWWARNING"
-            | "WARNINGONCOMPLETE"
-            | "SHOWERROR"
-            | "ERRORONCOMPLETE"
-            | "CREATEEVENT"
-            | "SETMANDATORYFIELD"
-            | "SENDMESSAGE"
-            | "SCHEDULEMESSAGE"
-            | "HIDEOPTION"
-            | "SHOWOPTIONGROUP"
-            | "HIDEOPTIONGROUP";
-        programStage: D2ProgramStageSchema;
-        programStageSection: D2ProgramStageSectionSchema;
         publicAccess: string;
-        templateUid: string;
-        trackedEntityAttribute: D2TrackedEntityAttributeSchema;
+        symbolizer: string;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
     };
     fieldPresets: {
-        $all: Preset<D2ProgramRuleAction, keyof D2ProgramRuleAction>;
-        $identifiable: Preset<D2ProgramRuleAction, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramRuleAction, FieldPresets["nameable"]>;
+        $all: Preset<D2LegendSet, keyof D2LegendSet>;
+        $identifiable: Preset<D2LegendSet, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2LegendSet, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2ProgramRuleAction,
-            | "evaluationEnvironments"
-            | "code"
-            | "data"
-            | "optionGroup"
-            | "templateUid"
-            | "content"
-            | "trackedEntityAttribute"
-            | "lastUpdated"
-            | "programIndicator"
-            | "id"
-            | "programRule"
-            | "programStageSection"
-            | "programRuleActionType"
+            D2LegendSet,
             | "lastUpdatedBy"
-            | "programStage"
+            | "userGroupAccesses"
+            | "code"
             | "created"
-            | "dataElement"
-            | "evaluationTime"
-            | "location"
-            | "option"
+            | "publicAccess"
+            | "attributeValues"
+            | "symbolizer"
+            | "lastUpdated"
+            | "legends"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
         >;
         $owner: Preset<
-            D2ProgramRuleAction,
-            | "evaluationEnvironments"
-            | "code"
-            | "data"
-            | "optionGroup"
-            | "templateUid"
-            | "content"
-            | "trackedEntityAttribute"
-            | "lastUpdated"
-            | "programIndicator"
-            | "id"
-            | "programRule"
-            | "programStageSection"
-            | "programRuleActionType"
+            D2LegendSet,
             | "lastUpdatedBy"
-            | "programStage"
+            | "userGroupAccesses"
+            | "code"
             | "created"
-            | "dataElement"
-            | "evaluationTime"
-            | "location"
-            | "option"
+            | "publicAccess"
+            | "attributeValues"
+            | "symbolizer"
+            | "lastUpdated"
+            | "legends"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
         >;
     };
 }
 
-export interface D2ProgramRuleSchema {
-    name: "D2ProgramRule";
-    model: D2ProgramRule;
+export interface D2MapSchema {
+    name: "D2Map";
+    model: D2Map;
     fields: {
         access: D2Access;
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        basemap: string;
         code: Id;
-        condition: string;
         created: string;
         description: string;
+        displayDescription: string;
+        displayFormName: string;
         displayName: string;
+        displayShortName: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
+        formName: string;
         href: string;
         id: Id;
+        interpretations: D2InterpretationSchema[];
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
+        latitude: number;
+        longitude: number;
+        mapViews: D2MapViewSchema[];
         name: string;
-        priority: number;
-        program: D2ProgramSchema;
-        programRuleActions: D2ProgramRuleActionSchema[];
-        programStage: D2ProgramStageSchema;
         publicAccess: string;
+        shortName: string;
+        subscribed: boolean;
+        subscribers: string[];
+        title: string;
         translations: D2Translation[];
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
+        zoom: number;
     };
     fieldPresets: {
-        $all: Preset<D2ProgramRule, keyof D2ProgramRule>;
-        $identifiable: Preset<D2ProgramRule, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramRule, FieldPresets["nameable"]>;
+        $all: Preset<D2Map, keyof D2Map>;
+        $identifiable: Preset<D2Map, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Map, FieldPresets["nameable"]>;
         $persisted: Preset<
-            D2ProgramRule,
+            D2Map,
+            | "favorites"
             | "code"
+            | "publicAccess"
+            | "basemap"
+            | "latitude"
             | "description"
-            | "program"
+            | "title"
+            | "externalAccess"
             | "lastUpdated"
             | "translations"
+            | "mapViews"
             | "id"
+            | "interpretations"
+            | "longitude"
             | "lastUpdatedBy"
-            | "programStage"
+            | "userGroupAccesses"
+            | "subscribers"
             | "created"
-            | "priority"
-            | "condition"
-            | "programRuleActions"
+            | "zoom"
+            | "userAccesses"
             | "name"
+            | "user"
         >;
         $owner: Preset<
-            D2ProgramRule,
+            D2Map,
+            | "favorites"
             | "code"
+            | "publicAccess"
+            | "basemap"
+            | "latitude"
             | "description"
-            | "program"
+            | "title"
+            | "externalAccess"
             | "lastUpdated"
             | "translations"
+            | "mapViews"
             | "id"
+            | "longitude"
             | "lastUpdatedBy"
-            | "programStage"
+            | "userGroupAccesses"
+            | "subscribers"
             | "created"
-            | "priority"
-            | "condition"
-            | "programRuleActions"
+            | "zoom"
+            | "userAccesses"
             | "name"
+            | "user"
         >;
     };
 }
@@ -11238,6 +9212,3148 @@ export interface D2MapViewSchema {
     };
 }
 
+export interface D2MessageConversationSchema {
+    name: "D2MessageConversation";
+    model: D2MessageConversation;
+    fields: {
+        access: D2Access;
+        assignee: D2UserSchema;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        followUp: boolean;
+        href: string;
+        id: Id;
+        lastMessage: string;
+        lastSender: D2UserSchema;
+        lastSenderFirstname: string;
+        lastSenderSurname: string;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        messageCount: number;
+        messageType: "PRIVATE" | "SYSTEM" | "VALIDATION_RESULT" | "TICKET";
+        messages: any[];
+        name: string;
+        priority: "NONE" | "LOW" | "MEDIUM" | "HIGH";
+        publicAccess: string;
+        read: boolean;
+        status: "NONE" | "OPEN" | "PENDING" | "INVALID" | "SOLVED";
+        subject: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userFirstname: string;
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        userMessages: any[];
+        userSurname: string;
+    };
+    fieldPresets: {
+        $all: Preset<D2MessageConversation, keyof D2MessageConversation>;
+        $identifiable: Preset<D2MessageConversation, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2MessageConversation, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2MessageConversation,
+            | "messageCount"
+            | "subject"
+            | "lastUpdated"
+            | "messageType"
+            | "userMessages"
+            | "id"
+            | "lastSender"
+            | "created"
+            | "lastMessage"
+            | "priority"
+            | "messages"
+            | "assignee"
+            | "user"
+            | "status"
+        >;
+        $owner: Preset<
+            D2MessageConversation,
+            | "messageCount"
+            | "subject"
+            | "lastUpdated"
+            | "messageType"
+            | "userMessages"
+            | "id"
+            | "lastSender"
+            | "created"
+            | "lastMessage"
+            | "priority"
+            | "messages"
+            | "assignee"
+            | "user"
+            | "status"
+        >;
+    };
+}
+
+export interface D2MetadataVersionSchema {
+    name: "D2MetadataVersion";
+    model: D2MetadataVersion;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        hashCode: string;
+        href: string;
+        id: Id;
+        importDate: string;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        translations: D2Translation[];
+        type: "BEST_EFFORT" | "ATOMIC";
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2MetadataVersion, keyof D2MetadataVersion>;
+        $identifiable: Preset<D2MetadataVersion, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2MetadataVersion, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2MetadataVersion,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "type"
+            | "lastUpdated"
+            | "importDate"
+            | "hashCode"
+            | "name"
+            | "id"
+        >;
+        $owner: Preset<
+            D2MetadataVersion,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "type"
+            | "lastUpdated"
+            | "importDate"
+            | "hashCode"
+            | "name"
+            | "id"
+        >;
+    };
+}
+
+export interface D2MinMaxDataElementSchema {
+    name: "D2MinMaxDataElement";
+    model: D2MinMaxDataElement;
+    fields: {
+        dataElement: D2DataElementSchema;
+        generated: boolean;
+        max: number;
+        min: number;
+        optionCombo: D2CategoryOptionComboSchema;
+        source: D2OrganisationUnitSchema;
+    };
+    fieldPresets: {
+        $all: Preset<D2MinMaxDataElement, keyof D2MinMaxDataElement>;
+        $identifiable: Preset<D2MinMaxDataElement, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2MinMaxDataElement, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2MinMaxDataElement,
+            "min" | "generated" | "max" | "dataElement" | "source" | "optionCombo"
+        >;
+        $owner: Preset<
+            D2MinMaxDataElement,
+            "min" | "generated" | "max" | "dataElement" | "source" | "optionCombo"
+        >;
+    };
+}
+
+export interface D2OAuth2ClientSchema {
+    name: "D2OAuth2Client";
+    model: D2OAuth2Client;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        cid: Id;
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        grantTypes: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        redirectUris: string[];
+        secret: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2OAuth2Client, keyof D2OAuth2Client>;
+        $identifiable: Preset<D2OAuth2Client, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OAuth2Client, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2OAuth2Client,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "secret"
+            | "redirectUris"
+            | "lastUpdated"
+            | "grantTypes"
+            | "name"
+            | "id"
+            | "cid"
+        >;
+        $owner: Preset<
+            D2OAuth2Client,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "secret"
+            | "redirectUris"
+            | "lastUpdated"
+            | "grantTypes"
+            | "name"
+            | "id"
+            | "cid"
+        >;
+    };
+}
+
+export interface D2OptionSchema {
+    name: "D2Option";
+    model: D2Option;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: string;
+        created: string;
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        optionSet: D2OptionSetSchema;
+        publicAccess: string;
+        shortName: string;
+        sortOrder: number;
+        style: D2Style;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2Option, keyof D2Option>;
+        $identifiable: Preset<D2Option, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Option, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Option,
+            | "code"
+            | "description"
+            | "lastUpdated"
+            | "optionSet"
+            | "translations"
+            | "formName"
+            | "id"
+            | "created"
+            | "attributeValues"
+            | "sortOrder"
+            | "name"
+            | "style"
+        >;
+        $owner: Preset<
+            D2Option,
+            | "code"
+            | "description"
+            | "lastUpdated"
+            | "optionSet"
+            | "translations"
+            | "formName"
+            | "id"
+            | "created"
+            | "attributeValues"
+            | "sortOrder"
+            | "name"
+            | "style"
+        >;
+    };
+}
+
+export interface D2OptionGroupSchema {
+    name: "D2OptionGroup";
+    model: D2OptionGroup;
+    fields: {
+        access: D2Access;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        description: string;
+        dimensionItem: string;
+        dimensionItemType:
+            | "DATA_ELEMENT"
+            | "DATA_ELEMENT_OPERAND"
+            | "INDICATOR"
+            | "REPORTING_RATE"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION"
+            | "OPTION_GROUP"
+            | "DATA_ELEMENT_GROUP"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY_OPTION_GROUP";
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendSet: D2LegendSetSchema;
+        legendSets: D2LegendSetSchema[];
+        name: string;
+        optionSet: D2OptionSetSchema;
+        options: D2OptionSchema[];
+        publicAccess: string;
+        shortName: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2OptionGroup, keyof D2OptionGroup>;
+        $identifiable: Preset<D2OptionGroup, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OptionGroup, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2OptionGroup,
+            | "code"
+            | "publicAccess"
+            | "lastUpdated"
+            | "optionSet"
+            | "translations"
+            | "options"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "userAccesses"
+            | "name"
+            | "shortName"
+            | "user"
+        >;
+        $owner: Preset<
+            D2OptionGroup,
+            | "code"
+            | "publicAccess"
+            | "lastUpdated"
+            | "optionSet"
+            | "translations"
+            | "options"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "userAccesses"
+            | "name"
+            | "shortName"
+            | "user"
+        >;
+    };
+}
+
+export interface D2OptionGroupSetSchema {
+    name: "D2OptionGroupSet";
+    model: D2OptionGroupSet;
+    fields: {
+        access: D2Access;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        allItems: boolean;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        dataDimension: boolean;
+        dataDimensionType: "DISAGGREGATION" | "ATTRIBUTE";
+        description: string;
+        dimension: string;
+        dimensionType:
+            | "DATA_X"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "DATA_COLLAPSED"
+            | "CATEGORY_OPTION_COMBO"
+            | "ATTRIBUTE_OPTION_COMBO"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION_GROUP_SET"
+            | "DATA_ELEMENT_GROUP_SET"
+            | "ORGANISATION_UNIT_GROUP_SET"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY"
+            | "OPTION_GROUP_SET"
+            | "VALIDATION_RULE"
+            | "STATIC"
+            | "ORGANISATION_UNIT_LEVEL";
+        dimensionalKeywords: D2DimensionalKeywords;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        filter: string;
+        formName: string;
+        href: string;
+        id: Id;
+        items: any[];
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendSet: D2LegendSetSchema;
+        name: string;
+        optionGroups: D2OptionGroupSchema[];
+        optionSet: D2OptionSetSchema;
+        programStage: D2ProgramStageSchema;
+        publicAccess: string;
+        shortName: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2OptionGroupSet, keyof D2OptionGroupSet>;
+        $identifiable: Preset<D2OptionGroupSet, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OptionGroupSet, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2OptionGroupSet,
+            | "code"
+            | "publicAccess"
+            | "description"
+            | "optionGroups"
+            | "lastUpdated"
+            | "optionSet"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "userAccesses"
+            | "name"
+            | "dataDimension"
+            | "user"
+        >;
+        $owner: Preset<
+            D2OptionGroupSet,
+            | "code"
+            | "publicAccess"
+            | "description"
+            | "optionGroups"
+            | "lastUpdated"
+            | "optionSet"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "userAccesses"
+            | "name"
+            | "dataDimension"
+            | "user"
+        >;
+    };
+}
+
+export interface D2OptionSetSchema {
+    name: "D2OptionSet";
+    model: D2OptionSet;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        options: D2OptionSchema[];
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        valueType:
+            | "TEXT"
+            | "LONG_TEXT"
+            | "LETTER"
+            | "PHONE_NUMBER"
+            | "EMAIL"
+            | "BOOLEAN"
+            | "TRUE_ONLY"
+            | "DATE"
+            | "DATETIME"
+            | "TIME"
+            | "NUMBER"
+            | "UNIT_INTERVAL"
+            | "PERCENTAGE"
+            | "INTEGER"
+            | "INTEGER_POSITIVE"
+            | "INTEGER_NEGATIVE"
+            | "INTEGER_ZERO_OR_POSITIVE"
+            | "TRACKER_ASSOCIATE"
+            | "USERNAME"
+            | "COORDINATE"
+            | "ORGANISATION_UNIT"
+            | "AGE"
+            | "URL"
+            | "FILE_RESOURCE"
+            | "IMAGE";
+        version: number;
+    };
+    fieldPresets: {
+        $all: Preset<D2OptionSet, keyof D2OptionSet>;
+        $identifiable: Preset<D2OptionSet, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OptionSet, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2OptionSet,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "attributeValues"
+            | "version"
+            | "lastUpdated"
+            | "translations"
+            | "userAccesses"
+            | "valueType"
+            | "name"
+            | "options"
+            | "id"
+            | "user"
+        >;
+        $owner: Preset<
+            D2OptionSet,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "attributeValues"
+            | "version"
+            | "lastUpdated"
+            | "translations"
+            | "userAccesses"
+            | "valueType"
+            | "name"
+            | "options"
+            | "id"
+            | "user"
+        >;
+    };
+}
+
+export interface D2OrganisationUnitSchema {
+    name: "D2OrganisationUnit";
+    model: D2OrganisationUnit;
+    fields: {
+        access: D2Access;
+        address: string;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        ancestors: D2OrganisationUnitSchema[];
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        children: D2OrganisationUnitSchema[];
+        closedDate: string;
+        code: Id;
+        comment: string;
+        contactPerson: string;
+        created: string;
+        dataSets: D2DataSetSchema[];
+        description: string;
+        dimensionItem: string;
+        dimensionItemType:
+            | "DATA_ELEMENT"
+            | "DATA_ELEMENT_OPERAND"
+            | "INDICATOR"
+            | "REPORTING_RATE"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION"
+            | "OPTION_GROUP"
+            | "DATA_ELEMENT_GROUP"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY_OPTION_GROUP";
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        email: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        geometry: D2Geometry;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        leaf: boolean;
+        legendSet: D2LegendSetSchema;
+        legendSets: D2LegendSetSchema[];
+        level: number;
+        memberCount: number;
+        name: string;
+        openingDate: string;
+        organisationUnitGroups: D2OrganisationUnitGroupSchema[];
+        parent: D2OrganisationUnitSchema;
+        path: string;
+        phoneNumber: string;
+        programs: D2ProgramSchema[];
+        publicAccess: string;
+        shortName: string;
+        translations: D2Translation[];
+        type: string;
+        url: string;
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        users: D2UserSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2OrganisationUnit, keyof D2OrganisationUnit>;
+        $identifiable: Preset<D2OrganisationUnit, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OrganisationUnit, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2OrganisationUnit,
+            | "parent"
+            | "path"
+            | "lastUpdated"
+            | "children"
+            | "translations"
+            | "id"
+            | "organisationUnitGroups"
+            | "lastUpdatedBy"
+            | "level"
+            | "created"
+            | "attributeValues"
+            | "users"
+            | "phoneNumber"
+            | "name"
+            | "dataSets"
+            | "programs"
+            | "shortName"
+            | "code"
+            | "description"
+            | "contactPerson"
+            | "openingDate"
+            | "email"
+            | "address"
+            | "url"
+            | "closedDate"
+            | "geometry"
+            | "comment"
+            | "user"
+        >;
+        $owner: Preset<
+            D2OrganisationUnit,
+            | "parent"
+            | "path"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "level"
+            | "created"
+            | "attributeValues"
+            | "phoneNumber"
+            | "name"
+            | "shortName"
+            | "code"
+            | "description"
+            | "contactPerson"
+            | "openingDate"
+            | "email"
+            | "address"
+            | "url"
+            | "closedDate"
+            | "geometry"
+            | "comment"
+            | "user"
+        >;
+    };
+}
+
+export interface D2OrganisationUnitGroupSchema {
+    name: "D2OrganisationUnitGroup";
+    model: D2OrganisationUnitGroup;
+    fields: {
+        access: D2Access;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        color: string;
+        created: string;
+        description: string;
+        dimensionItem: string;
+        dimensionItemType:
+            | "DATA_ELEMENT"
+            | "DATA_ELEMENT_OPERAND"
+            | "INDICATOR"
+            | "REPORTING_RATE"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION"
+            | "OPTION_GROUP"
+            | "DATA_ELEMENT_GROUP"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY_OPTION_GROUP";
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
+        formName: string;
+        geometry: D2Geometry;
+        groupSets: D2OrganisationUnitGroupSetSchema[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendSet: D2LegendSetSchema;
+        legendSets: D2LegendSetSchema[];
+        name: string;
+        organisationUnits: D2OrganisationUnitSchema[];
+        publicAccess: string;
+        shortName: string;
+        symbol: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2OrganisationUnitGroup, keyof D2OrganisationUnitGroup>;
+        $identifiable: Preset<D2OrganisationUnitGroup, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OrganisationUnitGroup, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2OrganisationUnitGroup,
+            | "symbol"
+            | "code"
+            | "color"
+            | "publicAccess"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "organisationUnits"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "groupSets"
+            | "userAccesses"
+            | "name"
+            | "geometry"
+            | "shortName"
+            | "user"
+        >;
+        $owner: Preset<
+            D2OrganisationUnitGroup,
+            | "symbol"
+            | "code"
+            | "color"
+            | "publicAccess"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "organisationUnits"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "userAccesses"
+            | "name"
+            | "geometry"
+            | "shortName"
+            | "user"
+        >;
+    };
+}
+
+export interface D2OrganisationUnitGroupSetSchema {
+    name: "D2OrganisationUnitGroupSet";
+    model: D2OrganisationUnitGroupSet;
+    fields: {
+        access: D2Access;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        allItems: boolean;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        compulsory: boolean;
+        created: string;
+        dataDimension: boolean;
+        dataDimensionType: "DISAGGREGATION" | "ATTRIBUTE";
+        description: string;
+        dimension: string;
+        dimensionType:
+            | "DATA_X"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "DATA_COLLAPSED"
+            | "CATEGORY_OPTION_COMBO"
+            | "ATTRIBUTE_OPTION_COMBO"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION_GROUP_SET"
+            | "DATA_ELEMENT_GROUP_SET"
+            | "ORGANISATION_UNIT_GROUP_SET"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY"
+            | "OPTION_GROUP_SET"
+            | "VALIDATION_RULE"
+            | "STATIC"
+            | "ORGANISATION_UNIT_LEVEL";
+        dimensionalKeywords: D2DimensionalKeywords;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        filter: string;
+        formName: string;
+        href: string;
+        id: Id;
+        includeSubhierarchyInAnalytics: boolean;
+        items: any[];
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendSet: D2LegendSetSchema;
+        name: string;
+        organisationUnitGroups: D2OrganisationUnitGroupSchema[];
+        programStage: D2ProgramStageSchema;
+        publicAccess: string;
+        shortName: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2OrganisationUnitGroupSet, keyof D2OrganisationUnitGroupSet>;
+        $identifiable: Preset<D2OrganisationUnitGroupSet, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OrganisationUnitGroupSet, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2OrganisationUnitGroupSet,
+            | "code"
+            | "publicAccess"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "organisationUnitGroups"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "compulsory"
+            | "includeSubhierarchyInAnalytics"
+            | "userAccesses"
+            | "name"
+            | "dataDimension"
+            | "user"
+        >;
+        $owner: Preset<
+            D2OrganisationUnitGroupSet,
+            | "code"
+            | "publicAccess"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "organisationUnitGroups"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "compulsory"
+            | "includeSubhierarchyInAnalytics"
+            | "userAccesses"
+            | "name"
+            | "dataDimension"
+            | "user"
+        >;
+    };
+}
+
+export interface D2OrganisationUnitGroupSetDimensionSchema {
+    name: "D2OrganisationUnitGroupSetDimension";
+    model: D2OrganisationUnitGroupSetDimension;
+    fields: {
+        organisationUnitGroupSet: D2OrganisationUnitGroupSetSchema;
+        organisationUnitGroups: D2OrganisationUnitGroupSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<
+            D2OrganisationUnitGroupSetDimension,
+            keyof D2OrganisationUnitGroupSetDimension
+        >;
+        $identifiable: Preset<D2OrganisationUnitGroupSetDimension, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OrganisationUnitGroupSetDimension, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2OrganisationUnitGroupSetDimension,
+            "organisationUnitGroupSet" | "organisationUnitGroups"
+        >;
+        $owner: Preset<
+            D2OrganisationUnitGroupSetDimension,
+            "organisationUnitGroupSet" | "organisationUnitGroups"
+        >;
+    };
+}
+
+export interface D2OrganisationUnitLevelSchema {
+    name: "D2OrganisationUnitLevel";
+    model: D2OrganisationUnitLevel;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        level: number;
+        name: string;
+        offlineLevels: number;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2OrganisationUnitLevel, keyof D2OrganisationUnitLevel>;
+        $identifiable: Preset<D2OrganisationUnitLevel, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2OrganisationUnitLevel, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2OrganisationUnitLevel,
+            | "lastUpdatedBy"
+            | "offlineLevels"
+            | "code"
+            | "level"
+            | "created"
+            | "lastUpdated"
+            | "translations"
+            | "name"
+            | "id"
+        >;
+        $owner: Preset<
+            D2OrganisationUnitLevel,
+            | "lastUpdatedBy"
+            | "offlineLevels"
+            | "code"
+            | "level"
+            | "created"
+            | "lastUpdated"
+            | "translations"
+            | "name"
+            | "id"
+        >;
+    };
+}
+
+export interface D2PredictorSchema {
+    name: "D2Predictor";
+    model: D2Predictor;
+    fields: {
+        access: D2Access;
+        annualSampleCount: number;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        generator: D2ExpressionSchema;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        organisationUnitLevels: D2OrganisationUnitLevelSchema[];
+        output: D2DataElementSchema;
+        outputCombo: D2CategoryOptionComboSchema;
+        periodType: string;
+        predictorGroups: D2PredictorGroupSchema[];
+        publicAccess: string;
+        sampleSkipTest: D2ExpressionSchema;
+        sequentialSampleCount: number;
+        sequentialSkipCount: number;
+        shortName: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2Predictor, keyof D2Predictor>;
+        $identifiable: Preset<D2Predictor, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Predictor, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Predictor,
+            | "outputCombo"
+            | "code"
+            | "description"
+            | "generator"
+            | "organisationUnitLevels"
+            | "output"
+            | "lastUpdated"
+            | "sampleSkipTest"
+            | "id"
+            | "sequentialSampleCount"
+            | "annualSampleCount"
+            | "lastUpdatedBy"
+            | "created"
+            | "sequentialSkipCount"
+            | "predictorGroups"
+            | "periodType"
+            | "name"
+        >;
+        $owner: Preset<
+            D2Predictor,
+            | "outputCombo"
+            | "code"
+            | "description"
+            | "generator"
+            | "organisationUnitLevels"
+            | "output"
+            | "lastUpdated"
+            | "sampleSkipTest"
+            | "id"
+            | "sequentialSampleCount"
+            | "annualSampleCount"
+            | "lastUpdatedBy"
+            | "created"
+            | "sequentialSkipCount"
+            | "periodType"
+            | "name"
+        >;
+    };
+}
+
+export interface D2PredictorGroupSchema {
+    name: "D2PredictorGroup";
+    model: D2PredictorGroup;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        description: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        predictors: D2PredictorSchema[];
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2PredictorGroup, keyof D2PredictorGroup>;
+        $identifiable: Preset<D2PredictorGroup, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2PredictorGroup, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2PredictorGroup,
+            | "predictors"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+        >;
+        $owner: Preset<
+            D2PredictorGroup,
+            | "predictors"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+        >;
+    };
+}
+
+export interface D2ProgramSchema {
+    name: "D2Program";
+    model: D2Program;
+    fields: {
+        access: D2Access;
+        accessLevel: "OPEN" | "AUDITED" | "PROTECTED" | "CLOSED";
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        categoryCombo: D2CategoryComboSchema;
+        code: Id;
+        completeEventsExpiryDays: number;
+        created: string;
+        dataEntryForm: D2DataEntryFormSchema;
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayFrontPageList: boolean;
+        displayIncidentDate: boolean;
+        displayName: string;
+        displayShortName: string;
+        enrollmentDateLabel: string;
+        expiryDays: number;
+        expiryPeriodType: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
+        formName: string;
+        href: string;
+        id: Id;
+        ignoreOverdueEvents: boolean;
+        incidentDateLabel: string;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        maxTeiCountToReturn: number;
+        minAttributesRequiredToSearch: number;
+        name: string;
+        notificationTemplates: D2ProgramNotificationTemplateSchema[];
+        onlyEnrollOnce: boolean;
+        organisationUnits: D2OrganisationUnitSchema[];
+        programIndicators: D2ProgramIndicatorSchema[];
+        programRuleVariables: D2ProgramRuleVariableSchema[];
+        programSections: D2ProgramSectionSchema[];
+        programStages: D2ProgramStageSchema[];
+        programTrackedEntityAttributes: D2ProgramTrackedEntityAttributeSchema[];
+        programType: "WITH_REGISTRATION" | "WITHOUT_REGISTRATION";
+        publicAccess: string;
+        registration: boolean;
+        relatedProgram: D2ProgramSchema;
+        selectEnrollmentDatesInFuture: boolean;
+        selectIncidentDatesInFuture: boolean;
+        shortName: string;
+        skipOffline: boolean;
+        style: D2Style;
+        trackedEntityType: D2TrackedEntityTypeSchema;
+        translations: D2Translation[];
+        useFirstStageDuringRegistration: boolean;
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        userRoles: D2UserAuthorityGroupSchema[];
+        version: number;
+        withoutRegistration: boolean;
+    };
+    fieldPresets: {
+        $all: Preset<D2Program, keyof D2Program>;
+        $identifiable: Preset<D2Program, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Program, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Program,
+            | "dataEntryForm"
+            | "publicAccess"
+            | "ignoreOverdueEvents"
+            | "skipOffline"
+            | "programIndicators"
+            | "lastUpdated"
+            | "categoryCombo"
+            | "translations"
+            | "id"
+            | "enrollmentDateLabel"
+            | "lastUpdatedBy"
+            | "onlyEnrollOnce"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "version"
+            | "maxTeiCountToReturn"
+            | "selectIncidentDatesInFuture"
+            | "incidentDateLabel"
+            | "userRoles"
+            | "expiryPeriodType"
+            | "userAccesses"
+            | "name"
+            | "selectEnrollmentDatesInFuture"
+            | "style"
+            | "shortName"
+            | "useFirstStageDuringRegistration"
+            | "code"
+            | "programRuleVariables"
+            | "programTrackedEntityAttributes"
+            | "completeEventsExpiryDays"
+            | "description"
+            | "relatedProgram"
+            | "notificationTemplates"
+            | "formName"
+            | "featureType"
+            | "minAttributesRequiredToSearch"
+            | "displayFrontPageList"
+            | "organisationUnits"
+            | "programType"
+            | "accessLevel"
+            | "programSections"
+            | "programStages"
+            | "trackedEntityType"
+            | "displayIncidentDate"
+            | "expiryDays"
+            | "user"
+        >;
+        $owner: Preset<
+            D2Program,
+            | "dataEntryForm"
+            | "publicAccess"
+            | "ignoreOverdueEvents"
+            | "skipOffline"
+            | "lastUpdated"
+            | "categoryCombo"
+            | "translations"
+            | "id"
+            | "enrollmentDateLabel"
+            | "lastUpdatedBy"
+            | "onlyEnrollOnce"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "version"
+            | "maxTeiCountToReturn"
+            | "selectIncidentDatesInFuture"
+            | "incidentDateLabel"
+            | "expiryPeriodType"
+            | "userAccesses"
+            | "name"
+            | "selectEnrollmentDatesInFuture"
+            | "style"
+            | "shortName"
+            | "useFirstStageDuringRegistration"
+            | "code"
+            | "programTrackedEntityAttributes"
+            | "completeEventsExpiryDays"
+            | "description"
+            | "relatedProgram"
+            | "notificationTemplates"
+            | "formName"
+            | "featureType"
+            | "minAttributesRequiredToSearch"
+            | "displayFrontPageList"
+            | "organisationUnits"
+            | "programType"
+            | "accessLevel"
+            | "programSections"
+            | "programStages"
+            | "trackedEntityType"
+            | "displayIncidentDate"
+            | "expiryDays"
+            | "user"
+        >;
+    };
+}
+
+export interface D2ProgramDataElementDimensionItemSchema {
+    name: "D2ProgramDataElementDimensionItem";
+    model: D2ProgramDataElementDimensionItem;
+    fields: {
+        access: D2Access;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        dataElement: D2DataElementSchema;
+        description: string;
+        dimensionItem: string;
+        dimensionItemType:
+            | "DATA_ELEMENT"
+            | "DATA_ELEMENT_OPERAND"
+            | "INDICATOR"
+            | "REPORTING_RATE"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION"
+            | "OPTION_GROUP"
+            | "DATA_ELEMENT_GROUP"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY_OPTION_GROUP";
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendSet: D2LegendSetSchema;
+        legendSets: D2LegendSetSchema[];
+        name: string;
+        program: D2ProgramSchema;
+        publicAccess: string;
+        shortName: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        valueType:
+            | "TEXT"
+            | "LONG_TEXT"
+            | "LETTER"
+            | "PHONE_NUMBER"
+            | "EMAIL"
+            | "BOOLEAN"
+            | "TRUE_ONLY"
+            | "DATE"
+            | "DATETIME"
+            | "TIME"
+            | "NUMBER"
+            | "UNIT_INTERVAL"
+            | "PERCENTAGE"
+            | "INTEGER"
+            | "INTEGER_POSITIVE"
+            | "INTEGER_NEGATIVE"
+            | "INTEGER_ZERO_OR_POSITIVE"
+            | "TRACKER_ASSOCIATE"
+            | "USERNAME"
+            | "COORDINATE"
+            | "ORGANISATION_UNIT"
+            | "AGE"
+            | "URL"
+            | "FILE_RESOURCE"
+            | "IMAGE";
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramDataElementDimensionItem, keyof D2ProgramDataElementDimensionItem>;
+        $identifiable: Preset<D2ProgramDataElementDimensionItem, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramDataElementDimensionItem, FieldPresets["nameable"]>;
+        $persisted: Preset<D2ProgramDataElementDimensionItem, never>;
+        $owner: Preset<D2ProgramDataElementDimensionItem, never>;
+    };
+}
+
+export interface D2ProgramIndicatorSchema {
+    name: "D2ProgramIndicator";
+    model: D2ProgramIndicator;
+    fields: {
+        access: D2Access;
+        aggregateExportAttributeOptionCombo: string;
+        aggregateExportCategoryOptionCombo: string;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        analyticsPeriodBoundaries: D2AnalyticsPeriodBoundarySchema[];
+        analyticsType: "EVENT" | "ENROLLMENT";
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        decimals: number;
+        description: string;
+        dimensionItem: string;
+        dimensionItemType:
+            | "DATA_ELEMENT"
+            | "DATA_ELEMENT_OPERAND"
+            | "INDICATOR"
+            | "REPORTING_RATE"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION"
+            | "OPTION_GROUP"
+            | "DATA_ELEMENT_GROUP"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY_OPTION_GROUP";
+        displayDescription: string;
+        displayFormName: string;
+        displayInForm: boolean;
+        displayName: string;
+        displayShortName: string;
+        expression: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        filter: string;
+        formName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendSet: D2LegendSetSchema;
+        legendSets: D2LegendSetSchema[];
+        name: string;
+        program: D2ProgramSchema;
+        programIndicatorGroups: D2ProgramIndicatorGroupSchema[];
+        publicAccess: string;
+        shortName: string;
+        style: D2Style;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramIndicator, keyof D2ProgramIndicator>;
+        $identifiable: Preset<D2ProgramIndicator, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramIndicator, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramIndicator,
+            | "aggregationType"
+            | "code"
+            | "displayInForm"
+            | "publicAccess"
+            | "aggregateExportCategoryOptionCombo"
+            | "description"
+            | "program"
+            | "lastUpdated"
+            | "translations"
+            | "formName"
+            | "id"
+            | "programIndicatorGroups"
+            | "analyticsPeriodBoundaries"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "expression"
+            | "created"
+            | "attributeValues"
+            | "filter"
+            | "userAccesses"
+            | "decimals"
+            | "name"
+            | "analyticsType"
+            | "legendSets"
+            | "style"
+            | "shortName"
+            | "user"
+            | "aggregateExportAttributeOptionCombo"
+        >;
+        $owner: Preset<
+            D2ProgramIndicator,
+            | "aggregationType"
+            | "code"
+            | "displayInForm"
+            | "publicAccess"
+            | "aggregateExportCategoryOptionCombo"
+            | "description"
+            | "program"
+            | "lastUpdated"
+            | "translations"
+            | "formName"
+            | "id"
+            | "analyticsPeriodBoundaries"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "expression"
+            | "created"
+            | "attributeValues"
+            | "filter"
+            | "userAccesses"
+            | "decimals"
+            | "name"
+            | "analyticsType"
+            | "legendSets"
+            | "style"
+            | "shortName"
+            | "user"
+            | "aggregateExportAttributeOptionCombo"
+        >;
+    };
+}
+
+export interface D2ProgramIndicatorGroupSchema {
+    name: "D2ProgramIndicatorGroup";
+    model: D2ProgramIndicatorGroup;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        description: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        programIndicators: D2ProgramIndicatorSchema[];
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramIndicatorGroup, keyof D2ProgramIndicatorGroup>;
+        $identifiable: Preset<D2ProgramIndicatorGroup, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramIndicatorGroup, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramIndicatorGroup,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "description"
+            | "programIndicators"
+            | "lastUpdated"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+        >;
+        $owner: Preset<
+            D2ProgramIndicatorGroup,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "description"
+            | "programIndicators"
+            | "lastUpdated"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+        >;
+    };
+}
+
+export interface D2ProgramInstanceSchema {
+    name: "D2ProgramInstance";
+    model: D2ProgramInstance;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        completedBy: string;
+        created: string;
+        createdAtClient: string;
+        deleted: boolean;
+        displayName: string;
+        endDate: string;
+        enrollmentDate: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        followup: boolean;
+        geometry: D2Geometry;
+        href: string;
+        id: Id;
+        incidentDate: string;
+        lastUpdated: string;
+        lastUpdatedAtClient: string;
+        lastUpdatedBy: D2UserSchema;
+        messageConversations: D2MessageConversationSchema[];
+        name: string;
+        organisationUnit: D2OrganisationUnitSchema;
+        program: D2ProgramSchema;
+        programStageInstances: D2ProgramStageInstanceSchema[];
+        publicAccess: string;
+        relationshipItems: any[];
+        status: "ACTIVE" | "COMPLETED" | "CANCELLED";
+        storedBy: string;
+        trackedEntityComments: any[];
+        trackedEntityInstance: D2TrackedEntityInstanceSchema;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramInstance, keyof D2ProgramInstance>;
+        $identifiable: Preset<D2ProgramInstance, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramInstance, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramInstance,
+            | "storedBy"
+            | "endDate"
+            | "organisationUnit"
+            | "enrollmentDate"
+            | "createdAtClient"
+            | "program"
+            | "messageConversations"
+            | "trackedEntityComments"
+            | "lastUpdated"
+            | "relationshipItems"
+            | "id"
+            | "created"
+            | "programStageInstances"
+            | "trackedEntityInstance"
+            | "followup"
+            | "deleted"
+            | "geometry"
+            | "incidentDate"
+            | "completedBy"
+            | "status"
+            | "lastUpdatedAtClient"
+        >;
+        $owner: Preset<
+            D2ProgramInstance,
+            | "storedBy"
+            | "endDate"
+            | "organisationUnit"
+            | "enrollmentDate"
+            | "createdAtClient"
+            | "program"
+            | "messageConversations"
+            | "trackedEntityComments"
+            | "lastUpdated"
+            | "id"
+            | "created"
+            | "trackedEntityInstance"
+            | "followup"
+            | "deleted"
+            | "geometry"
+            | "incidentDate"
+            | "completedBy"
+            | "status"
+            | "lastUpdatedAtClient"
+        >;
+    };
+}
+
+export interface D2ProgramNotificationTemplateSchema {
+    name: "D2ProgramNotificationTemplate";
+    model: D2ProgramNotificationTemplate;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        deliveryChannels: never[];
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        messageTemplate: string;
+        name: string;
+        notificationRecipient:
+            | "TRACKED_ENTITY_INSTANCE"
+            | "ORGANISATION_UNIT_CONTACT"
+            | "USERS_AT_ORGANISATION_UNIT"
+            | "USER_GROUP"
+            | "PROGRAM_ATTRIBUTE"
+            | "DATA_ELEMENT";
+        notificationTrigger:
+            | "ENROLLMENT"
+            | "COMPLETION"
+            | "PROGRAM_RULE"
+            | "SCHEDULED_DAYS_DUE_DATE"
+            | "SCHEDULED_DAYS_INCIDENT_DATE"
+            | "SCHEDULED_DAYS_ENROLLMENT_DATE";
+        notifyParentOrganisationUnitOnly: boolean;
+        notifyUsersInHierarchyOnly: boolean;
+        publicAccess: string;
+        recipientDataElement: D2DataElementSchema;
+        recipientProgramAttribute: D2TrackedEntityAttributeSchema;
+        recipientUserGroup: D2UserGroupSchema;
+        relativeScheduledDays: number;
+        subjectTemplate: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramNotificationTemplate, keyof D2ProgramNotificationTemplate>;
+        $identifiable: Preset<D2ProgramNotificationTemplate, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramNotificationTemplate, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramNotificationTemplate,
+            | "code"
+            | "notificationTrigger"
+            | "lastUpdated"
+            | "relativeScheduledDays"
+            | "id"
+            | "subjectTemplate"
+            | "lastUpdatedBy"
+            | "deliveryChannels"
+            | "recipientDataElement"
+            | "created"
+            | "notifyUsersInHierarchyOnly"
+            | "notificationRecipient"
+            | "recipientProgramAttribute"
+            | "notifyParentOrganisationUnitOnly"
+            | "name"
+            | "recipientUserGroup"
+            | "messageTemplate"
+        >;
+        $owner: Preset<
+            D2ProgramNotificationTemplate,
+            | "code"
+            | "notificationTrigger"
+            | "lastUpdated"
+            | "relativeScheduledDays"
+            | "id"
+            | "subjectTemplate"
+            | "lastUpdatedBy"
+            | "deliveryChannels"
+            | "recipientDataElement"
+            | "created"
+            | "notifyUsersInHierarchyOnly"
+            | "notificationRecipient"
+            | "recipientProgramAttribute"
+            | "notifyParentOrganisationUnitOnly"
+            | "name"
+            | "recipientUserGroup"
+            | "messageTemplate"
+        >;
+    };
+}
+
+export interface D2ProgramRuleSchema {
+    name: "D2ProgramRule";
+    model: D2ProgramRule;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        condition: string;
+        created: string;
+        description: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        priority: number;
+        program: D2ProgramSchema;
+        programRuleActions: D2ProgramRuleActionSchema[];
+        programStage: D2ProgramStageSchema;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramRule, keyof D2ProgramRule>;
+        $identifiable: Preset<D2ProgramRule, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramRule, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramRule,
+            | "code"
+            | "description"
+            | "program"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "priority"
+            | "condition"
+            | "programRuleActions"
+            | "name"
+        >;
+        $owner: Preset<
+            D2ProgramRule,
+            | "code"
+            | "description"
+            | "program"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "priority"
+            | "condition"
+            | "programRuleActions"
+            | "name"
+        >;
+    };
+}
+
+export interface D2ProgramRuleActionSchema {
+    name: "D2ProgramRuleAction";
+    model: D2ProgramRuleAction;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        content: string;
+        created: string;
+        data: string;
+        dataElement: D2DataElementSchema;
+        displayName: string;
+        evaluationEnvironments: never[];
+        evaluationTime: "ON_DATA_ENTRY" | "ON_COMPLETE" | "ALWAYS";
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        location: string;
+        name: string;
+        option: D2OptionSchema;
+        optionGroup: D2OptionGroupSchema;
+        programIndicator: D2ProgramIndicatorSchema;
+        programRule: D2ProgramRuleSchema;
+        programRuleActionType:
+            | "DISPLAYTEXT"
+            | "DISPLAYKEYVALUEPAIR"
+            | "HIDEFIELD"
+            | "HIDESECTION"
+            | "HIDEPROGRAMSTAGE"
+            | "ASSIGN"
+            | "SHOWWARNING"
+            | "WARNINGONCOMPLETE"
+            | "SHOWERROR"
+            | "ERRORONCOMPLETE"
+            | "CREATEEVENT"
+            | "SETMANDATORYFIELD"
+            | "SENDMESSAGE"
+            | "SCHEDULEMESSAGE"
+            | "HIDEOPTION"
+            | "SHOWOPTIONGROUP"
+            | "HIDEOPTIONGROUP";
+        programStage: D2ProgramStageSchema;
+        programStageSection: D2ProgramStageSectionSchema;
+        publicAccess: string;
+        templateUid: string;
+        trackedEntityAttribute: D2TrackedEntityAttributeSchema;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramRuleAction, keyof D2ProgramRuleAction>;
+        $identifiable: Preset<D2ProgramRuleAction, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramRuleAction, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramRuleAction,
+            | "evaluationEnvironments"
+            | "code"
+            | "data"
+            | "optionGroup"
+            | "templateUid"
+            | "content"
+            | "trackedEntityAttribute"
+            | "lastUpdated"
+            | "programIndicator"
+            | "id"
+            | "programRule"
+            | "programStageSection"
+            | "programRuleActionType"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "dataElement"
+            | "evaluationTime"
+            | "location"
+            | "option"
+        >;
+        $owner: Preset<
+            D2ProgramRuleAction,
+            | "evaluationEnvironments"
+            | "code"
+            | "data"
+            | "optionGroup"
+            | "templateUid"
+            | "content"
+            | "trackedEntityAttribute"
+            | "lastUpdated"
+            | "programIndicator"
+            | "id"
+            | "programRule"
+            | "programStageSection"
+            | "programRuleActionType"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "dataElement"
+            | "evaluationTime"
+            | "location"
+            | "option"
+        >;
+    };
+}
+
+export interface D2ProgramRuleVariableSchema {
+    name: "D2ProgramRuleVariable";
+    model: D2ProgramRuleVariable;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        dataElement: D2DataElementSchema;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        program: D2ProgramSchema;
+        programRuleVariableSourceType:
+            | "DATAELEMENT_NEWEST_EVENT_PROGRAM_STAGE"
+            | "DATAELEMENT_NEWEST_EVENT_PROGRAM"
+            | "DATAELEMENT_CURRENT_EVENT"
+            | "DATAELEMENT_PREVIOUS_EVENT"
+            | "CALCULATED_VALUE"
+            | "TEI_ATTRIBUTE";
+        programStage: D2ProgramStageSchema;
+        publicAccess: string;
+        trackedEntityAttribute: D2TrackedEntityAttributeSchema;
+        translations: D2Translation[];
+        useCodeForOptionSet: boolean;
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramRuleVariable, keyof D2ProgramRuleVariable>;
+        $identifiable: Preset<D2ProgramRuleVariable, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramRuleVariable, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramRuleVariable,
+            | "code"
+            | "programRuleVariableSourceType"
+            | "program"
+            | "trackedEntityAttribute"
+            | "lastUpdated"
+            | "id"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "useCodeForOptionSet"
+            | "dataElement"
+            | "name"
+        >;
+        $owner: Preset<
+            D2ProgramRuleVariable,
+            | "code"
+            | "programRuleVariableSourceType"
+            | "program"
+            | "trackedEntityAttribute"
+            | "lastUpdated"
+            | "id"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "useCodeForOptionSet"
+            | "dataElement"
+            | "name"
+        >;
+    };
+}
+
+export interface D2ProgramSectionSchema {
+    name: "D2ProgramSection";
+    model: D2ProgramSection;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        program: D2ProgramSchema;
+        publicAccess: string;
+        renderType: any;
+        shortName: string;
+        sortOrder: number;
+        style: D2Style;
+        trackedEntityAttributes: D2TrackedEntityAttributeSchema[];
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramSection, keyof D2ProgramSection>;
+        $identifiable: Preset<D2ProgramSection, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramSection, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramSection,
+            | "code"
+            | "description"
+            | "program"
+            | "lastUpdated"
+            | "translations"
+            | "formName"
+            | "id"
+            | "renderType"
+            | "lastUpdatedBy"
+            | "created"
+            | "sortOrder"
+            | "name"
+            | "trackedEntityAttributes"
+            | "style"
+        >;
+        $owner: Preset<
+            D2ProgramSection,
+            | "code"
+            | "description"
+            | "program"
+            | "lastUpdated"
+            | "translations"
+            | "formName"
+            | "id"
+            | "renderType"
+            | "lastUpdatedBy"
+            | "created"
+            | "sortOrder"
+            | "name"
+            | "trackedEntityAttributes"
+            | "style"
+        >;
+    };
+}
+
+export interface D2ProgramStageSchema {
+    name: "D2ProgramStage";
+    model: D2ProgramStage;
+    fields: {
+        access: D2Access;
+        allowGenerateNextVisit: boolean;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        autoGenerateEvent: boolean;
+        blockEntryForm: boolean;
+        code: Id;
+        created: string;
+        dataEntryForm: D2DataEntryFormSchema;
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayGenerateEventBox: boolean;
+        displayName: string;
+        displayShortName: string;
+        dueDateLabel: string;
+        enableUserAssignment: boolean;
+        executionDateLabel: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
+        formName: string;
+        formType: "DEFAULT" | "CUSTOM" | "SECTION" | "SECTION_MULTIORG";
+        generatedByEnrollmentDate: boolean;
+        hideDueDate: boolean;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        minDaysFromStart: number;
+        name: string;
+        nextScheduleDate: D2DataElementSchema;
+        notificationTemplates: D2ProgramNotificationTemplateSchema[];
+        openAfterEnrollment: boolean;
+        periodType: string;
+        preGenerateUID: boolean;
+        program: D2ProgramSchema;
+        programStageDataElements: D2ProgramStageDataElementSchema[];
+        programStageSections: D2ProgramStageSectionSchema[];
+        publicAccess: string;
+        remindCompleted: boolean;
+        repeatable: boolean;
+        reportDateToUse: string;
+        shortName: string;
+        sortOrder: number;
+        standardInterval: number;
+        style: D2Style;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        validationStrategy: "ON_COMPLETE" | "ON_UPDATE_AND_INSERT";
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramStage, keyof D2ProgramStage>;
+        $identifiable: Preset<D2ProgramStage, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramStage, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramStage,
+            | "dataEntryForm"
+            | "allowGenerateNextVisit"
+            | "publicAccess"
+            | "reportDateToUse"
+            | "program"
+            | "lastUpdated"
+            | "programStageDataElements"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "generatedByEnrollmentDate"
+            | "created"
+            | "attributeValues"
+            | "sortOrder"
+            | "userAccesses"
+            | "name"
+            | "hideDueDate"
+            | "enableUserAssignment"
+            | "style"
+            | "minDaysFromStart"
+            | "standardInterval"
+            | "dueDateLabel"
+            | "executionDateLabel"
+            | "code"
+            | "preGenerateUID"
+            | "description"
+            | "notificationTemplates"
+            | "openAfterEnrollment"
+            | "repeatable"
+            | "formName"
+            | "featureType"
+            | "remindCompleted"
+            | "displayGenerateEventBox"
+            | "nextScheduleDate"
+            | "validationStrategy"
+            | "autoGenerateEvent"
+            | "periodType"
+            | "blockEntryForm"
+            | "user"
+            | "programStageSections"
+        >;
+        $owner: Preset<
+            D2ProgramStage,
+            | "dataEntryForm"
+            | "allowGenerateNextVisit"
+            | "publicAccess"
+            | "reportDateToUse"
+            | "program"
+            | "lastUpdated"
+            | "programStageDataElements"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "generatedByEnrollmentDate"
+            | "created"
+            | "attributeValues"
+            | "sortOrder"
+            | "userAccesses"
+            | "name"
+            | "hideDueDate"
+            | "enableUserAssignment"
+            | "style"
+            | "minDaysFromStart"
+            | "standardInterval"
+            | "dueDateLabel"
+            | "executionDateLabel"
+            | "code"
+            | "preGenerateUID"
+            | "description"
+            | "notificationTemplates"
+            | "openAfterEnrollment"
+            | "repeatable"
+            | "formName"
+            | "featureType"
+            | "remindCompleted"
+            | "displayGenerateEventBox"
+            | "nextScheduleDate"
+            | "validationStrategy"
+            | "autoGenerateEvent"
+            | "periodType"
+            | "blockEntryForm"
+            | "user"
+            | "programStageSections"
+        >;
+    };
+}
+
+export interface D2ProgramStageDataElementSchema {
+    name: "D2ProgramStageDataElement";
+    model: D2ProgramStageDataElement;
+    fields: {
+        access: D2Access;
+        allowFutureDate: boolean;
+        allowProvidedElsewhere: boolean;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        compulsory: boolean;
+        created: string;
+        dataElement: D2DataElementSchema;
+        displayInReports: boolean;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        programStage: D2ProgramStageSchema;
+        publicAccess: string;
+        renderOptionsAsRadio: boolean;
+        renderType: any;
+        skipSynchronization: boolean;
+        sortOrder: number;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramStageDataElement, keyof D2ProgramStageDataElement>;
+        $identifiable: Preset<D2ProgramStageDataElement, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramStageDataElement, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramStageDataElement,
+            | "displayInReports"
+            | "code"
+            | "skipSynchronization"
+            | "lastUpdated"
+            | "renderOptionsAsRadio"
+            | "id"
+            | "allowFutureDate"
+            | "renderType"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "dataElement"
+            | "compulsory"
+            | "allowProvidedElsewhere"
+            | "sortOrder"
+        >;
+        $owner: Preset<
+            D2ProgramStageDataElement,
+            | "displayInReports"
+            | "code"
+            | "skipSynchronization"
+            | "lastUpdated"
+            | "renderOptionsAsRadio"
+            | "id"
+            | "allowFutureDate"
+            | "renderType"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "dataElement"
+            | "compulsory"
+            | "allowProvidedElsewhere"
+            | "sortOrder"
+        >;
+    };
+}
+
+export interface D2ProgramStageInstanceSchema {
+    name: "D2ProgramStageInstance";
+    model: D2ProgramStageInstance;
+    fields: {
+        access: D2Access;
+        assignedUser: D2UserSchema;
+        attributeOptionCombo: D2CategoryOptionComboSchema;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        comments: any[];
+        completed: boolean;
+        completedBy: string;
+        completedDate: string;
+        creatableInSearchScope: boolean;
+        created: string;
+        createdAtClient: string;
+        deleted: boolean;
+        displayName: string;
+        dueDate: string;
+        eventDataValues: any[];
+        eventDate: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        geometry: D2Geometry;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedAtClient: string;
+        lastUpdatedBy: D2UserSchema;
+        messageConversations: D2MessageConversationSchema[];
+        name: string;
+        organisationUnit: D2OrganisationUnitSchema;
+        programInstance: D2ProgramInstanceSchema;
+        programStage: D2ProgramStageSchema;
+        publicAccess: string;
+        relationshipItems: any[];
+        status: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";
+        storedBy: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramStageInstance, keyof D2ProgramStageInstance>;
+        $identifiable: Preset<D2ProgramStageInstance, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramStageInstance, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramStageInstance,
+            | "code"
+            | "storedBy"
+            | "organisationUnit"
+            | "dueDate"
+            | "createdAtClient"
+            | "messageConversations"
+            | "lastUpdated"
+            | "eventDataValues"
+            | "relationshipItems"
+            | "id"
+            | "assignedUser"
+            | "programStage"
+            | "comments"
+            | "created"
+            | "completedDate"
+            | "programInstance"
+            | "deleted"
+            | "attributeOptionCombo"
+            | "geometry"
+            | "completedBy"
+            | "status"
+            | "lastUpdatedAtClient"
+            | "eventDate"
+        >;
+        $owner: Preset<
+            D2ProgramStageInstance,
+            | "code"
+            | "storedBy"
+            | "organisationUnit"
+            | "dueDate"
+            | "createdAtClient"
+            | "messageConversations"
+            | "lastUpdated"
+            | "eventDataValues"
+            | "id"
+            | "assignedUser"
+            | "programStage"
+            | "comments"
+            | "created"
+            | "completedDate"
+            | "programInstance"
+            | "deleted"
+            | "attributeOptionCombo"
+            | "geometry"
+            | "completedBy"
+            | "status"
+            | "lastUpdatedAtClient"
+            | "eventDate"
+        >;
+    };
+}
+
+export interface D2ProgramStageInstanceFilterSchema {
+    name: "D2ProgramStageInstanceFilter";
+    model: D2ProgramStageInstanceFilter;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        description: string;
+        displayName: string;
+        eventQueryCriteria: any;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        program: Id;
+        programStage: Id;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramStageInstanceFilter, keyof D2ProgramStageInstanceFilter>;
+        $identifiable: Preset<D2ProgramStageInstanceFilter, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramStageInstanceFilter, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramStageInstanceFilter,
+            | "lastUpdatedBy"
+            | "programStage"
+            | "eventQueryCriteria"
+            | "userGroupAccesses"
+            | "created"
+            | "publicAccess"
+            | "description"
+            | "program"
+            | "lastUpdated"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+        >;
+        $owner: Preset<
+            D2ProgramStageInstanceFilter,
+            | "lastUpdatedBy"
+            | "programStage"
+            | "eventQueryCriteria"
+            | "userGroupAccesses"
+            | "created"
+            | "publicAccess"
+            | "description"
+            | "program"
+            | "lastUpdated"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+        >;
+    };
+}
+
+export interface D2ProgramStageSectionSchema {
+    name: "D2ProgramStageSection";
+    model: D2ProgramStageSection;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        dataElements: D2DataElementSchema[];
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        programIndicators: D2ProgramIndicatorSchema[];
+        programStage: D2ProgramStageSchema;
+        publicAccess: string;
+        renderType: any;
+        shortName: string;
+        sortOrder: number;
+        style: D2Style;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramStageSection, keyof D2ProgramStageSection>;
+        $identifiable: Preset<D2ProgramStageSection, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramStageSection, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramStageSection,
+            | "code"
+            | "description"
+            | "programIndicators"
+            | "lastUpdated"
+            | "translations"
+            | "formName"
+            | "id"
+            | "renderType"
+            | "dataElements"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "sortOrder"
+            | "name"
+            | "style"
+        >;
+        $owner: Preset<
+            D2ProgramStageSection,
+            | "code"
+            | "description"
+            | "programIndicators"
+            | "lastUpdated"
+            | "translations"
+            | "formName"
+            | "id"
+            | "renderType"
+            | "dataElements"
+            | "lastUpdatedBy"
+            | "programStage"
+            | "created"
+            | "sortOrder"
+            | "name"
+            | "style"
+        >;
+    };
+}
+
+export interface D2ProgramTrackedEntityAttributeSchema {
+    name: "D2ProgramTrackedEntityAttribute";
+    model: D2ProgramTrackedEntityAttribute;
+    fields: {
+        access: D2Access;
+        allowFutureDate: boolean;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        displayInList: boolean;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        mandatory: boolean;
+        name: string;
+        program: D2ProgramSchema;
+        programTrackedEntityAttributeGroups: D2ProgramTrackedEntityAttributeGroupSchema[];
+        publicAccess: string;
+        renderOptionsAsRadio: boolean;
+        renderType: any;
+        searchable: boolean;
+        sortOrder: number;
+        trackedEntityAttribute: D2TrackedEntityAttributeSchema;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        valueType:
+            | "TEXT"
+            | "LONG_TEXT"
+            | "LETTER"
+            | "PHONE_NUMBER"
+            | "EMAIL"
+            | "BOOLEAN"
+            | "TRUE_ONLY"
+            | "DATE"
+            | "DATETIME"
+            | "TIME"
+            | "NUMBER"
+            | "UNIT_INTERVAL"
+            | "PERCENTAGE"
+            | "INTEGER"
+            | "INTEGER_POSITIVE"
+            | "INTEGER_NEGATIVE"
+            | "INTEGER_ZERO_OR_POSITIVE"
+            | "TRACKER_ASSOCIATE"
+            | "USERNAME"
+            | "COORDINATE"
+            | "ORGANISATION_UNIT"
+            | "AGE"
+            | "URL"
+            | "FILE_RESOURCE"
+            | "IMAGE";
+    };
+    fieldPresets: {
+        $all: Preset<D2ProgramTrackedEntityAttribute, keyof D2ProgramTrackedEntityAttribute>;
+        $identifiable: Preset<D2ProgramTrackedEntityAttribute, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramTrackedEntityAttribute, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramTrackedEntityAttribute,
+            | "code"
+            | "programTrackedEntityAttributeGroups"
+            | "program"
+            | "mandatory"
+            | "trackedEntityAttribute"
+            | "lastUpdated"
+            | "renderOptionsAsRadio"
+            | "id"
+            | "allowFutureDate"
+            | "renderType"
+            | "lastUpdatedBy"
+            | "created"
+            | "searchable"
+            | "displayInList"
+            | "sortOrder"
+        >;
+        $owner: Preset<
+            D2ProgramTrackedEntityAttribute,
+            | "code"
+            | "programTrackedEntityAttributeGroups"
+            | "program"
+            | "mandatory"
+            | "trackedEntityAttribute"
+            | "lastUpdated"
+            | "renderOptionsAsRadio"
+            | "id"
+            | "allowFutureDate"
+            | "renderType"
+            | "lastUpdatedBy"
+            | "created"
+            | "searchable"
+            | "displayInList"
+            | "sortOrder"
+        >;
+    };
+}
+
+export interface D2ProgramTrackedEntityAttributeDimensionItemSchema {
+    name: "D2ProgramTrackedEntityAttributeDimensionItem";
+    model: D2ProgramTrackedEntityAttributeDimensionItem;
+    fields: {
+        access: D2Access;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        attribute: D2TrackedEntityAttributeSchema;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        description: string;
+        dimensionItem: string;
+        dimensionItemType:
+            | "DATA_ELEMENT"
+            | "DATA_ELEMENT_OPERAND"
+            | "INDICATOR"
+            | "REPORTING_RATE"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION"
+            | "OPTION_GROUP"
+            | "DATA_ELEMENT_GROUP"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY_OPTION_GROUP";
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendSet: D2LegendSetSchema;
+        legendSets: D2LegendSetSchema[];
+        name: string;
+        program: D2ProgramSchema;
+        publicAccess: string;
+        shortName: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<
+            D2ProgramTrackedEntityAttributeDimensionItem,
+            keyof D2ProgramTrackedEntityAttributeDimensionItem
+        >;
+        $identifiable: Preset<
+            D2ProgramTrackedEntityAttributeDimensionItem,
+            FieldPresets["identifiable"]
+        >;
+        $nameable: Preset<D2ProgramTrackedEntityAttributeDimensionItem, FieldPresets["nameable"]>;
+        $persisted: Preset<D2ProgramTrackedEntityAttributeDimensionItem, never>;
+        $owner: Preset<D2ProgramTrackedEntityAttributeDimensionItem, never>;
+    };
+}
+
+export interface D2ProgramTrackedEntityAttributeGroupSchema {
+    name: "D2ProgramTrackedEntityAttributeGroup";
+    model: D2ProgramTrackedEntityAttributeGroup;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        attributes: D2ProgramTrackedEntityAttributeSchema[];
+        code: Id;
+        created: string;
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        shortName: string;
+        translations: D2Translation[];
+        uniqunessType: "NONE" | "STRICT" | "VALIDATION";
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<
+            D2ProgramTrackedEntityAttributeGroup,
+            keyof D2ProgramTrackedEntityAttributeGroup
+        >;
+        $identifiable: Preset<D2ProgramTrackedEntityAttributeGroup, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ProgramTrackedEntityAttributeGroup, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ProgramTrackedEntityAttributeGroup,
+            | "code"
+            | "uniqunessType"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "created"
+            | "name"
+            | "attributes"
+            | "shortName"
+        >;
+        $owner: Preset<
+            D2ProgramTrackedEntityAttributeGroup,
+            | "code"
+            | "uniqunessType"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "created"
+            | "name"
+            | "shortName"
+        >;
+    };
+}
+
+export interface D2PushAnalysisSchema {
+    name: "D2PushAnalysis";
+    model: D2PushAnalysis;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        dashboard: D2DashboardSchema;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        message: string;
+        name: string;
+        publicAccess: string;
+        recipientUserGroups: D2UserGroupSchema[];
+        title: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2PushAnalysis, keyof D2PushAnalysis>;
+        $identifiable: Preset<D2PushAnalysis, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2PushAnalysis, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2PushAnalysis,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "recipientUserGroups"
+            | "message"
+            | "title"
+            | "lastUpdated"
+            | "name"
+            | "id"
+            | "dashboard"
+        >;
+        $owner: Preset<
+            D2PushAnalysis,
+            | "lastUpdatedBy"
+            | "code"
+            | "created"
+            | "recipientUserGroups"
+            | "message"
+            | "title"
+            | "lastUpdated"
+            | "name"
+            | "id"
+            | "dashboard"
+        >;
+    };
+}
+
+export interface D2RelationshipSchema {
+    name: "D2Relationship";
+    model: D2Relationship;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        from: any;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        relationshipType: D2RelationshipTypeSchema;
+        shortName: string;
+        style: D2Style;
+        to: any;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2Relationship, keyof D2Relationship>;
+        $identifiable: Preset<D2Relationship, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Relationship, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Relationship,
+            | "code"
+            | "description"
+            | "lastUpdated"
+            | "formName"
+            | "from"
+            | "id"
+            | "lastUpdatedBy"
+            | "relationshipType"
+            | "created"
+            | "style"
+            | "to"
+        >;
+        $owner: Preset<
+            D2Relationship,
+            | "code"
+            | "description"
+            | "lastUpdated"
+            | "formName"
+            | "from"
+            | "id"
+            | "lastUpdatedBy"
+            | "relationshipType"
+            | "created"
+            | "style"
+            | "to"
+        >;
+    };
+}
+
+export interface D2RelationshipTypeSchema {
+    name: "D2RelationshipType";
+    model: D2RelationshipType;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        bidirectional: boolean;
+        code: Id;
+        created: string;
+        description: string;
+        displayFromToName: string;
+        displayName: string;
+        displayToFromName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        fromConstraint: D2RelationshipConstraint;
+        fromToName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        toConstraint: D2RelationshipConstraint;
+        toFromName: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2RelationshipType, keyof D2RelationshipType>;
+        $identifiable: Preset<D2RelationshipType, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2RelationshipType, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2RelationshipType,
+            | "bidirectional"
+            | "code"
+            | "publicAccess"
+            | "description"
+            | "fromToName"
+            | "lastUpdated"
+            | "translations"
+            | "toConstraint"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "toFromName"
+            | "fromConstraint"
+            | "userAccesses"
+            | "name"
+            | "user"
+        >;
+        $owner: Preset<
+            D2RelationshipType,
+            | "bidirectional"
+            | "code"
+            | "publicAccess"
+            | "description"
+            | "fromToName"
+            | "lastUpdated"
+            | "translations"
+            | "toConstraint"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "toFromName"
+            | "fromConstraint"
+            | "userAccesses"
+            | "name"
+            | "user"
+        >;
+    };
+}
+
 export interface D2ReportSchema {
     name: "D2Report";
     model: D2Report;
@@ -11269,7 +12385,7 @@ export interface D2ReportSchema {
         name: string;
         publicAccess: string;
         relativePeriods: any;
-        reportParams: any;
+        reportParams: D2ReportingParams;
         translations: D2Translation[];
         type: "JASPER_REPORT_TABLE" | "JASPER_JDBC" | "HTML";
         user: D2UserSchema;
@@ -11321,254 +12437,6 @@ export interface D2ReportSchema {
             | "userAccesses"
             | "name"
             | "cacheStrategy"
-            | "user"
-        >;
-    };
-}
-
-export interface D2MapSchema {
-    name: "D2Map";
-    model: D2Map;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        basemap: string;
-        code: Id;
-        created: string;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        interpretations: D2InterpretationSchema[];
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        latitude: number;
-        longitude: number;
-        mapViews: D2MapViewSchema[];
-        name: string;
-        publicAccess: string;
-        shortName: string;
-        subscribed: boolean;
-        subscribers: string[];
-        title: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        zoom: number;
-    };
-    fieldPresets: {
-        $all: Preset<D2Map, keyof D2Map>;
-        $identifiable: Preset<D2Map, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Map, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Map,
-            | "favorites"
-            | "code"
-            | "publicAccess"
-            | "basemap"
-            | "latitude"
-            | "description"
-            | "title"
-            | "externalAccess"
-            | "lastUpdated"
-            | "translations"
-            | "mapViews"
-            | "id"
-            | "interpretations"
-            | "longitude"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "subscribers"
-            | "created"
-            | "zoom"
-            | "userAccesses"
-            | "name"
-            | "user"
-        >;
-        $owner: Preset<
-            D2Map,
-            | "favorites"
-            | "code"
-            | "publicAccess"
-            | "basemap"
-            | "latitude"
-            | "description"
-            | "title"
-            | "externalAccess"
-            | "lastUpdated"
-            | "translations"
-            | "mapViews"
-            | "id"
-            | "longitude"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "subscribers"
-            | "created"
-            | "zoom"
-            | "userAccesses"
-            | "name"
-            | "user"
-        >;
-    };
-}
-
-export interface D2DocumentSchema {
-    name: "D2Document";
-    model: D2Document;
-    fields: {
-        access: D2Access;
-        attachment: boolean;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        contentType: string;
-        created: string;
-        displayName: string;
-        external: boolean;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        url: string;
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Document, keyof D2Document>;
-        $identifiable: Preset<D2Document, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Document, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Document,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "url"
-            | "externalAccess"
-            | "lastUpdated"
-            | "external"
-            | "attachment"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-            | "contentType"
-        >;
-        $owner: Preset<
-            D2Document,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "attributeValues"
-            | "url"
-            | "externalAccess"
-            | "lastUpdated"
-            | "external"
-            | "attachment"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-            | "contentType"
-        >;
-    };
-}
-
-export interface D2ExternalMapLayerSchema {
-    name: "D2ExternalMapLayer";
-    model: D2ExternalMapLayer;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        attribution: string;
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        imageFormat: "PNG" | "JPG";
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        layers: string;
-        legendSet: D2LegendSetSchema;
-        legendSetUrl: string;
-        mapLayerPosition: "BASEMAP" | "OVERLAY";
-        mapService: "WMS" | "TMS" | "XYZ";
-        name: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        url: string;
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ExternalMapLayer, keyof D2ExternalMapLayer>;
-        $identifiable: Preset<D2ExternalMapLayer, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ExternalMapLayer, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ExternalMapLayer,
-            | "imageFormat"
-            | "code"
-            | "publicAccess"
-            | "legendSetUrl"
-            | "mapService"
-            | "lastUpdated"
-            | "layers"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "mapLayerPosition"
-            | "url"
-            | "userAccesses"
-            | "name"
-            | "legendSet"
-            | "attribution"
-            | "user"
-        >;
-        $owner: Preset<
-            D2ExternalMapLayer,
-            | "imageFormat"
-            | "code"
-            | "publicAccess"
-            | "legendSetUrl"
-            | "mapService"
-            | "lastUpdated"
-            | "layers"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "mapLayerPosition"
-            | "url"
-            | "userAccesses"
-            | "name"
-            | "legendSet"
-            | "attribution"
             | "user"
         >;
     };
@@ -11686,9 +12554,9 @@ export interface D2ReportTableSchema {
     };
 }
 
-export interface D2ChartSchema {
-    name: "D2Chart";
-    model: D2Chart;
+export interface D2ReportingRateSchema {
+    name: "D2ReportingRate";
+    model: D2ReportingRate;
     fields: {
         access: D2Access;
         aggregationType:
@@ -11707,115 +12575,1583 @@ export interface D2ChartSchema {
             | "NONE"
             | "CUSTOM"
             | "DEFAULT";
-        attributeDimensions: any[];
         attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        baseLineLabel: string;
-        baseLineValue: number;
-        category: string;
-        categoryDimensions: D2CategoryDimensionSchema[];
-        categoryOptionGroupSetDimensions: D2CategoryOptionGroupSetDimensionSchema[];
         code: Id;
-        colorSet: D2ColorSetSchema;
-        columns: any[];
-        completedOnly: boolean;
         created: string;
-        cumulativeValues: boolean;
-        dataDimensionItems: any[];
-        dataElementDimensions: D2TrackedEntityDataElementDimensionSchema[];
-        dataElementGroupSetDimensions: D2DataElementGroupSetDimensionSchema[];
+        dataSet: D2DataSetSchema;
         description: string;
-        digitGroupSeparator: "COMMA" | "SPACE" | "NONE";
+        dimensionItem: string;
+        dimensionItemType:
+            | "DATA_ELEMENT"
+            | "DATA_ELEMENT_OPERAND"
+            | "INDICATOR"
+            | "REPORTING_RATE"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION"
+            | "OPTION_GROUP"
+            | "DATA_ELEMENT_GROUP"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY_OPTION_GROUP";
         displayDescription: string;
         displayFormName: string;
         displayName: string;
         displayShortName: string;
-        domainAxisLabel: string;
-        endDate: string;
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
-        filterDimensions: string[];
-        filters: any[];
         formName: string;
-        hideEmptyRowItems:
-            | "NONE"
-            | "BEFORE_FIRST"
-            | "AFTER_LAST"
-            | "BEFORE_FIRST_AFTER_LAST"
-            | "ALL";
-        hideLegend: boolean;
-        hideSubtitle: boolean;
-        hideTitle: boolean;
         href: string;
         id: Id;
-        interpretations: D2InterpretationSchema[];
-        itemOrganisationUnitGroups: D2OrganisationUnitGroupSchema[];
         lastUpdated: string;
         lastUpdatedBy: D2UserSchema;
-        legendDisplayStrategy: "FIXED" | "BY_DATA_ITEM";
         legendSet: D2LegendSetSchema;
+        legendSets: D2LegendSetSchema[];
+        metric:
+            | "REPORTING_RATE"
+            | "REPORTING_RATE_ON_TIME"
+            | "ACTUAL_REPORTS"
+            | "ACTUAL_REPORTS_ON_TIME"
+            | "EXPECTED_REPORTS";
         name: string;
-        noSpaceBetweenColumns: boolean;
-        orgUnitField: string;
-        organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimensionSchema[];
-        organisationUnitLevels: number[];
-        organisationUnits: D2OrganisationUnitSchema[];
-        parentGraphMap: D2MapSchema;
-        percentStackedValues: boolean;
-        periods: any[];
-        programIndicatorDimensions: D2TrackedEntityProgramIndicatorDimensionSchema[];
         publicAccess: string;
-        rangeAxisDecimals: number;
-        rangeAxisLabel: string;
-        rangeAxisMaxValue: number;
-        rangeAxisMinValue: number;
-        rangeAxisSteps: number;
-        regressionType: "NONE" | "LINEAR" | "POLYNOMIAL" | "LOESS";
-        relativePeriods: any;
-        rows: any[];
-        series: string;
-        seriesItems: any[];
         shortName: string;
-        showData: boolean;
-        sortOrder: number;
-        startDate: string;
-        subscribed: boolean;
-        subscribers: string[];
-        subtitle: string;
-        targetLineLabel: string;
-        targetLineValue: number;
-        timeField: string;
-        title: string;
-        topLimit: number;
         translations: D2Translation[];
-        type:
-            | "COLUMN"
-            | "STACKED_COLUMN"
-            | "BAR"
-            | "STACKED_BAR"
-            | "LINE"
-            | "AREA"
-            | "PIE"
-            | "RADAR"
-            | "GAUGE"
-            | "YEAR_OVER_YEAR_LINE"
-            | "YEAR_OVER_YEAR_COLUMN"
-            | "SINGLE_VALUE";
         user: D2UserSchema;
         userAccesses: D2UserAccessSchema[];
         userGroupAccesses: D2UserGroupAccessSchema[];
-        userOrgUnitType: "DATA_CAPTURE" | "DATA_OUTPUT" | "TEI_SEARCH";
-        userOrganisationUnit: boolean;
-        userOrganisationUnitChildren: boolean;
-        userOrganisationUnitGrandChildren: boolean;
-        yearlySeries: string[];
     };
     fieldPresets: {
-        $all: Preset<D2Chart, keyof D2Chart>;
-        $identifiable: Preset<D2Chart, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Chart, FieldPresets["nameable"]>;
-        $persisted: Preset<D2Chart, never>;
-        $owner: Preset<D2Chart, never>;
+        $all: Preset<D2ReportingRate, keyof D2ReportingRate>;
+        $identifiable: Preset<D2ReportingRate, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ReportingRate, FieldPresets["nameable"]>;
+        $persisted: Preset<D2ReportingRate, never>;
+        $owner: Preset<D2ReportingRate, never>;
+    };
+}
+
+export interface D2SMSCommandSchema {
+    name: "D2SMSCommand";
+    model: D2SMSCommand;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        codeValueSeparator: string;
+        completenessMethod: "ALL_DATAVALUE" | "AT_LEAST_ONE_DATAVALUE" | "DO_NOT_MARK_COMPLETE";
+        created: string;
+        currentPeriodUsedForReporting: boolean;
+        dataset: D2DataSetSchema;
+        defaultMessage: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        moreThanOneOrgUnitMessage: string;
+        name: string;
+        noUserMessage: string;
+        parserType:
+            | "KEY_VALUE_PARSER"
+            | "J2ME_PARSER"
+            | "ALERT_PARSER"
+            | "UNREGISTERED_PARSER"
+            | "TRACKED_ENTITY_REGISTRATION_PARSER"
+            | "PROGRAM_STAGE_DATAENTRY_PARSER"
+            | "EVENT_REGISTRATION_PARSER";
+        program: D2ProgramSchema;
+        programStage: D2ProgramStageSchema;
+        publicAccess: string;
+        receivedMessage: string;
+        separator: string;
+        smsCodes: any[];
+        specialCharacters: any[];
+        successMessage: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroup: D2UserGroupSchema;
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        wrongFormatMessage: string;
+    };
+    fieldPresets: {
+        $all: Preset<D2SMSCommand, keyof D2SMSCommand>;
+        $identifiable: Preset<D2SMSCommand, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2SMSCommand, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2SMSCommand,
+            | "moreThanOneOrgUnitMessage"
+            | "smsCodes"
+            | "specialCharacters"
+            | "currentPeriodUsedForReporting"
+            | "program"
+            | "noUserMessage"
+            | "lastUpdated"
+            | "receivedMessage"
+            | "defaultMessage"
+            | "id"
+            | "userGroup"
+            | "programStage"
+            | "completenessMethod"
+            | "created"
+            | "wrongFormatMessage"
+            | "separator"
+            | "successMessage"
+            | "codeValueSeparator"
+            | "parserType"
+            | "name"
+            | "dataset"
+        >;
+        $owner: Preset<
+            D2SMSCommand,
+            | "moreThanOneOrgUnitMessage"
+            | "smsCodes"
+            | "specialCharacters"
+            | "currentPeriodUsedForReporting"
+            | "program"
+            | "noUserMessage"
+            | "lastUpdated"
+            | "receivedMessage"
+            | "defaultMessage"
+            | "id"
+            | "userGroup"
+            | "programStage"
+            | "completenessMethod"
+            | "created"
+            | "wrongFormatMessage"
+            | "separator"
+            | "successMessage"
+            | "codeValueSeparator"
+            | "parserType"
+            | "name"
+            | "dataset"
+        >;
+    };
+}
+
+export interface D2SectionSchema {
+    name: "D2Section";
+    model: D2Section;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        categoryCombos: D2CategoryComboSchema[];
+        code: Id;
+        created: string;
+        dataElements: D2DataElementSchema[];
+        dataSet: D2DataSetSchema;
+        description: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        greyedFields: D2DataElementOperandSchema[];
+        href: string;
+        id: Id;
+        indicators: D2IndicatorSchema[];
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        showColumnTotals: boolean;
+        showRowTotals: boolean;
+        sortOrder: number;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2Section, keyof D2Section>;
+        $identifiable: Preset<D2Section, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2Section, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2Section,
+            | "code"
+            | "greyedFields"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "dataSet"
+            | "dataElements"
+            | "showColumnTotals"
+            | "lastUpdatedBy"
+            | "created"
+            | "attributeValues"
+            | "indicators"
+            | "sortOrder"
+            | "name"
+            | "showRowTotals"
+        >;
+        $owner: Preset<
+            D2Section,
+            | "code"
+            | "greyedFields"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "id"
+            | "dataSet"
+            | "dataElements"
+            | "showColumnTotals"
+            | "lastUpdatedBy"
+            | "created"
+            | "attributeValues"
+            | "indicators"
+            | "sortOrder"
+            | "name"
+            | "showRowTotals"
+        >;
+    };
+}
+
+export interface D2SqlViewSchema {
+    name: "D2SqlView";
+    model: D2SqlView;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        cacheStrategy:
+            | "NO_CACHE"
+            | "CACHE_1_MINUTE"
+            | "CACHE_5_MINUTES"
+            | "CACHE_10_MINUTES"
+            | "CACHE_15_MINUTES"
+            | "CACHE_30_MINUTES"
+            | "CACHE_1_HOUR"
+            | "CACHE_6AM_TOMORROW"
+            | "CACHE_TWO_WEEKS"
+            | "RESPECT_SYSTEM_SETTING";
+        code: Id;
+        created: string;
+        description: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        sqlQuery: string;
+        translations: D2Translation[];
+        type: "VIEW" | "MATERIALIZED_VIEW" | "QUERY";
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2SqlView, keyof D2SqlView>;
+        $identifiable: Preset<D2SqlView, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2SqlView, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2SqlView,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "sqlQuery"
+            | "created"
+            | "publicAccess"
+            | "attributeValues"
+            | "description"
+            | "type"
+            | "externalAccess"
+            | "lastUpdated"
+            | "userAccesses"
+            | "name"
+            | "cacheStrategy"
+            | "id"
+            | "user"
+        >;
+        $owner: Preset<
+            D2SqlView,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "sqlQuery"
+            | "created"
+            | "publicAccess"
+            | "attributeValues"
+            | "description"
+            | "type"
+            | "externalAccess"
+            | "lastUpdated"
+            | "userAccesses"
+            | "name"
+            | "cacheStrategy"
+            | "id"
+            | "user"
+        >;
+    };
+}
+
+export interface D2TrackedEntityAttributeSchema {
+    name: "D2TrackedEntityAttribute";
+    model: D2TrackedEntityAttribute;
+    fields: {
+        access: D2Access;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        confidential: boolean;
+        created: string;
+        description: string;
+        dimensionItem: string;
+        dimensionItemType:
+            | "DATA_ELEMENT"
+            | "DATA_ELEMENT_OPERAND"
+            | "INDICATOR"
+            | "REPORTING_RATE"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION"
+            | "OPTION_GROUP"
+            | "DATA_ELEMENT_GROUP"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY_OPTION_GROUP";
+        displayDescription: string;
+        displayFormName: string;
+        displayInListNoProgram: boolean;
+        displayName: string;
+        displayOnVisitSchedule: boolean;
+        displayShortName: string;
+        expression: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        fieldMask: string;
+        formName: string;
+        generated: boolean;
+        href: string;
+        id: Id;
+        inherit: boolean;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        legendSet: D2LegendSetSchema;
+        legendSets: D2LegendSetSchema[];
+        name: string;
+        optionSet: D2OptionSetSchema;
+        optionSetValue: boolean;
+        orgunitScope: boolean;
+        pattern: string;
+        publicAccess: string;
+        shortName: string;
+        skipSynchronization: boolean;
+        sortOrderInListNoProgram: number;
+        sortOrderInVisitSchedule: number;
+        style: D2Style;
+        translations: D2Translation[];
+        unique: boolean;
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        valueType:
+            | "TEXT"
+            | "LONG_TEXT"
+            | "LETTER"
+            | "PHONE_NUMBER"
+            | "EMAIL"
+            | "BOOLEAN"
+            | "TRUE_ONLY"
+            | "DATE"
+            | "DATETIME"
+            | "TIME"
+            | "NUMBER"
+            | "UNIT_INTERVAL"
+            | "PERCENTAGE"
+            | "INTEGER"
+            | "INTEGER_POSITIVE"
+            | "INTEGER_NEGATIVE"
+            | "INTEGER_ZERO_OR_POSITIVE"
+            | "TRACKER_ASSOCIATE"
+            | "USERNAME"
+            | "COORDINATE"
+            | "ORGANISATION_UNIT"
+            | "AGE"
+            | "URL"
+            | "FILE_RESOURCE"
+            | "IMAGE";
+    };
+    fieldPresets: {
+        $all: Preset<D2TrackedEntityAttribute, keyof D2TrackedEntityAttribute>;
+        $identifiable: Preset<D2TrackedEntityAttribute, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2TrackedEntityAttribute, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2TrackedEntityAttribute,
+            | "aggregationType"
+            | "code"
+            | "displayInListNoProgram"
+            | "publicAccess"
+            | "pattern"
+            | "description"
+            | "skipSynchronization"
+            | "sortOrderInListNoProgram"
+            | "lastUpdated"
+            | "optionSet"
+            | "generated"
+            | "displayOnVisitSchedule"
+            | "translations"
+            | "valueType"
+            | "formName"
+            | "sortOrderInVisitSchedule"
+            | "id"
+            | "orgunitScope"
+            | "confidential"
+            | "fieldMask"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "expression"
+            | "created"
+            | "attributeValues"
+            | "unique"
+            | "userAccesses"
+            | "inherit"
+            | "name"
+            | "legendSets"
+            | "style"
+            | "shortName"
+            | "user"
+        >;
+        $owner: Preset<
+            D2TrackedEntityAttribute,
+            | "aggregationType"
+            | "code"
+            | "displayInListNoProgram"
+            | "publicAccess"
+            | "pattern"
+            | "description"
+            | "skipSynchronization"
+            | "sortOrderInListNoProgram"
+            | "lastUpdated"
+            | "optionSet"
+            | "generated"
+            | "displayOnVisitSchedule"
+            | "translations"
+            | "valueType"
+            | "formName"
+            | "sortOrderInVisitSchedule"
+            | "id"
+            | "orgunitScope"
+            | "confidential"
+            | "fieldMask"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "expression"
+            | "created"
+            | "attributeValues"
+            | "unique"
+            | "userAccesses"
+            | "inherit"
+            | "name"
+            | "legendSets"
+            | "style"
+            | "shortName"
+            | "user"
+        >;
+    };
+}
+
+export interface D2TrackedEntityAttributeValueSchema {
+    name: "D2TrackedEntityAttributeValue";
+    model: D2TrackedEntityAttributeValue;
+    fields: {
+        created: string;
+        lastUpdated: string;
+        storedBy: string;
+        trackedEntityAttribute: D2TrackedEntityAttributeSchema;
+        trackedEntityInstance: D2TrackedEntityInstanceSchema;
+        value: string;
+    };
+    fieldPresets: {
+        $all: Preset<D2TrackedEntityAttributeValue, keyof D2TrackedEntityAttributeValue>;
+        $identifiable: Preset<D2TrackedEntityAttributeValue, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2TrackedEntityAttributeValue, FieldPresets["nameable"]>;
+        $persisted: Preset<D2TrackedEntityAttributeValue, "lastUpdated" | "storedBy" | "created">;
+        $owner: Preset<D2TrackedEntityAttributeValue, "lastUpdated" | "storedBy" | "created">;
+    };
+}
+
+export interface D2TrackedEntityDataElementDimensionSchema {
+    name: "D2TrackedEntityDataElementDimension";
+    model: D2TrackedEntityDataElementDimension;
+    fields: {
+        dataElement: D2DataElementSchema;
+        filter: string;
+        legendSet: D2LegendSetSchema;
+        programStage: D2ProgramStageSchema;
+    };
+    fieldPresets: {
+        $all: Preset<
+            D2TrackedEntityDataElementDimension,
+            keyof D2TrackedEntityDataElementDimension
+        >;
+        $identifiable: Preset<D2TrackedEntityDataElementDimension, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2TrackedEntityDataElementDimension, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2TrackedEntityDataElementDimension,
+            "filter" | "legendSet" | "programStage" | "dataElement"
+        >;
+        $owner: Preset<
+            D2TrackedEntityDataElementDimension,
+            "filter" | "legendSet" | "programStage" | "dataElement"
+        >;
+    };
+}
+
+export interface D2TrackedEntityInstanceSchema {
+    name: "D2TrackedEntityInstance";
+    model: D2TrackedEntityInstance;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        createdAtClient: string;
+        deleted: boolean;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        geometry: D2Geometry;
+        href: string;
+        id: Id;
+        inactive: boolean;
+        lastUpdated: string;
+        lastUpdatedAtClient: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        organisationUnit: D2OrganisationUnitSchema;
+        programInstances: D2ProgramInstanceSchema[];
+        programOwners: any[];
+        publicAccess: string;
+        relationshipItems: any[];
+        trackedEntityAttributeValues: D2TrackedEntityAttributeValueSchema[];
+        trackedEntityType: D2TrackedEntityTypeSchema;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2TrackedEntityInstance, keyof D2TrackedEntityInstance>;
+        $identifiable: Preset<D2TrackedEntityInstance, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2TrackedEntityInstance, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2TrackedEntityInstance,
+            | "programOwners"
+            | "code"
+            | "programInstances"
+            | "organisationUnit"
+            | "createdAtClient"
+            | "lastUpdated"
+            | "inactive"
+            | "relationshipItems"
+            | "id"
+            | "lastUpdatedBy"
+            | "created"
+            | "deleted"
+            | "trackedEntityType"
+            | "geometry"
+            | "trackedEntityAttributeValues"
+            | "lastUpdatedAtClient"
+        >;
+        $owner: Preset<
+            D2TrackedEntityInstance,
+            | "code"
+            | "organisationUnit"
+            | "createdAtClient"
+            | "lastUpdated"
+            | "inactive"
+            | "id"
+            | "lastUpdatedBy"
+            | "created"
+            | "deleted"
+            | "trackedEntityType"
+            | "geometry"
+            | "lastUpdatedAtClient"
+        >;
+    };
+}
+
+export interface D2TrackedEntityInstanceFilterSchema {
+    name: "D2TrackedEntityInstanceFilter";
+    model: D2TrackedEntityInstanceFilter;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        description: string;
+        displayName: string;
+        enrollmentCreatedPeriod: any;
+        enrollmentStatus: "ACTIVE" | "COMPLETED" | "CANCELLED";
+        eventFilters: any[];
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        followup: boolean;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        program: D2ProgramSchema;
+        publicAccess: string;
+        sortOrder: number;
+        style: D2Style;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2TrackedEntityInstanceFilter, keyof D2TrackedEntityInstanceFilter>;
+        $identifiable: Preset<D2TrackedEntityInstanceFilter, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2TrackedEntityInstanceFilter, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2TrackedEntityInstanceFilter,
+            | "code"
+            | "description"
+            | "program"
+            | "enrollmentCreatedPeriod"
+            | "lastUpdated"
+            | "id"
+            | "lastUpdatedBy"
+            | "created"
+            | "followup"
+            | "eventFilters"
+            | "enrollmentStatus"
+            | "sortOrder"
+            | "name"
+            | "style"
+        >;
+        $owner: Preset<
+            D2TrackedEntityInstanceFilter,
+            | "code"
+            | "description"
+            | "program"
+            | "enrollmentCreatedPeriod"
+            | "lastUpdated"
+            | "id"
+            | "lastUpdatedBy"
+            | "created"
+            | "followup"
+            | "eventFilters"
+            | "enrollmentStatus"
+            | "sortOrder"
+            | "name"
+            | "style"
+        >;
+    };
+}
+
+export interface D2TrackedEntityProgramIndicatorDimensionSchema {
+    name: "D2TrackedEntityProgramIndicatorDimension";
+    model: D2TrackedEntityProgramIndicatorDimension;
+    fields: {
+        filter: string;
+        legendSet: D2LegendSetSchema;
+        programIndicator: D2ProgramIndicatorSchema;
+    };
+    fieldPresets: {
+        $all: Preset<
+            D2TrackedEntityProgramIndicatorDimension,
+            keyof D2TrackedEntityProgramIndicatorDimension
+        >;
+        $identifiable: Preset<
+            D2TrackedEntityProgramIndicatorDimension,
+            FieldPresets["identifiable"]
+        >;
+        $nameable: Preset<D2TrackedEntityProgramIndicatorDimension, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2TrackedEntityProgramIndicatorDimension,
+            "filter" | "legendSet" | "programIndicator"
+        >;
+        $owner: Preset<
+            D2TrackedEntityProgramIndicatorDimension,
+            "filter" | "legendSet" | "programIndicator"
+        >;
+    };
+}
+
+export interface D2TrackedEntityTypeSchema {
+    name: "D2TrackedEntityType";
+    model: D2TrackedEntityType;
+    fields: {
+        access: D2Access;
+        allowAuditLog: boolean;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        description: string;
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
+        formName: string;
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        maxTeiCountToReturn: number;
+        minAttributesRequiredToSearch: number;
+        name: string;
+        publicAccess: string;
+        shortName: string;
+        style: D2Style;
+        trackedEntityTypeAttributes: D2TrackedEntityTypeAttributeSchema[];
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2TrackedEntityType, keyof D2TrackedEntityType>;
+        $identifiable: Preset<D2TrackedEntityType, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2TrackedEntityType, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2TrackedEntityType,
+            | "code"
+            | "publicAccess"
+            | "trackedEntityTypeAttributes"
+            | "description"
+            | "lastUpdated"
+            | "allowAuditLog"
+            | "translations"
+            | "formName"
+            | "featureType"
+            | "minAttributesRequiredToSearch"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "maxTeiCountToReturn"
+            | "userAccesses"
+            | "name"
+            | "style"
+            | "user"
+        >;
+        $owner: Preset<
+            D2TrackedEntityType,
+            | "code"
+            | "publicAccess"
+            | "trackedEntityTypeAttributes"
+            | "description"
+            | "lastUpdated"
+            | "allowAuditLog"
+            | "translations"
+            | "formName"
+            | "featureType"
+            | "minAttributesRequiredToSearch"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "maxTeiCountToReturn"
+            | "userAccesses"
+            | "name"
+            | "style"
+            | "user"
+        >;
+    };
+}
+
+export interface D2TrackedEntityTypeAttributeSchema {
+    name: "D2TrackedEntityTypeAttribute";
+    model: D2TrackedEntityTypeAttribute;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        displayInList: boolean;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        mandatory: boolean;
+        name: string;
+        publicAccess: string;
+        searchable: boolean;
+        trackedEntityAttribute: D2TrackedEntityAttributeSchema;
+        trackedEntityType: D2TrackedEntityTypeSchema;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        valueType:
+            | "TEXT"
+            | "LONG_TEXT"
+            | "LETTER"
+            | "PHONE_NUMBER"
+            | "EMAIL"
+            | "BOOLEAN"
+            | "TRUE_ONLY"
+            | "DATE"
+            | "DATETIME"
+            | "TIME"
+            | "NUMBER"
+            | "UNIT_INTERVAL"
+            | "PERCENTAGE"
+            | "INTEGER"
+            | "INTEGER_POSITIVE"
+            | "INTEGER_NEGATIVE"
+            | "INTEGER_ZERO_OR_POSITIVE"
+            | "TRACKER_ASSOCIATE"
+            | "USERNAME"
+            | "COORDINATE"
+            | "ORGANISATION_UNIT"
+            | "AGE"
+            | "URL"
+            | "FILE_RESOURCE"
+            | "IMAGE";
+    };
+    fieldPresets: {
+        $all: Preset<D2TrackedEntityTypeAttribute, keyof D2TrackedEntityTypeAttribute>;
+        $identifiable: Preset<D2TrackedEntityTypeAttribute, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2TrackedEntityTypeAttribute, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2TrackedEntityTypeAttribute,
+            | "code"
+            | "mandatory"
+            | "trackedEntityAttribute"
+            | "lastUpdated"
+            | "id"
+            | "lastUpdatedBy"
+            | "created"
+            | "searchable"
+            | "displayInList"
+            | "trackedEntityType"
+        >;
+        $owner: Preset<
+            D2TrackedEntityTypeAttribute,
+            | "code"
+            | "mandatory"
+            | "trackedEntityAttribute"
+            | "lastUpdated"
+            | "id"
+            | "lastUpdatedBy"
+            | "created"
+            | "searchable"
+            | "displayInList"
+            | "trackedEntityType"
+        >;
+    };
+}
+
+export interface D2UserSchema {
+    name: "D2User";
+    model: D2User;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        avatar: D2FileResourceSchema;
+        birthday: string;
+        code: Id;
+        created: string;
+        dataViewOrganisationUnits: D2OrganisationUnitSchema[];
+        displayName: string;
+        education: string;
+        email: string;
+        employer: string;
+        externalAccess: boolean;
+        facebookMessenger: string;
+        favorite: boolean;
+        favorites: string[];
+        firstName: string;
+        gender: string;
+        href: string;
+        id: Id;
+        interests: string;
+        introduction: string;
+        jobTitle: string;
+        languages: string;
+        lastCheckedInterpretations: string;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        nationality: string;
+        organisationUnits: D2OrganisationUnitSchema[];
+        phoneNumber: string;
+        publicAccess: string;
+        skype: string;
+        surname: string;
+        teiSearchOrganisationUnits: D2OrganisationUnitSchema[];
+        telegram: string;
+        translations: D2Translation[];
+        twitter: string;
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userCredentials: D2UserCredentialsSchema;
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        userGroups: D2UserGroupSchema[];
+        welcomeMessage: string;
+        whatsApp: string;
+    };
+    fieldPresets: {
+        $all: Preset<D2User, keyof D2User>;
+        $identifiable: Preset<D2User, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2User, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2User,
+            | "birthday"
+            | "code"
+            | "education"
+            | "gender"
+            | "jobTitle"
+            | "skype"
+            | "lastUpdated"
+            | "teiSearchOrganisationUnits"
+            | "twitter"
+            | "surname"
+            | "employer"
+            | "id"
+            | "organisationUnits"
+            | "facebookMessenger"
+            | "introduction"
+            | "email"
+            | "dataViewOrganisationUnits"
+            | "whatsApp"
+            | "languages"
+            | "created"
+            | "welcomeMessage"
+            | "userCredentials"
+            | "attributeValues"
+            | "telegram"
+            | "avatar"
+            | "lastCheckedInterpretations"
+            | "userGroups"
+            | "firstName"
+            | "phoneNumber"
+            | "nationality"
+            | "interests"
+        >;
+        $owner: Preset<
+            D2User,
+            | "birthday"
+            | "code"
+            | "education"
+            | "gender"
+            | "jobTitle"
+            | "skype"
+            | "lastUpdated"
+            | "teiSearchOrganisationUnits"
+            | "twitter"
+            | "surname"
+            | "employer"
+            | "id"
+            | "organisationUnits"
+            | "facebookMessenger"
+            | "introduction"
+            | "email"
+            | "dataViewOrganisationUnits"
+            | "whatsApp"
+            | "languages"
+            | "created"
+            | "welcomeMessage"
+            | "userCredentials"
+            | "attributeValues"
+            | "telegram"
+            | "avatar"
+            | "lastCheckedInterpretations"
+            | "firstName"
+            | "phoneNumber"
+            | "nationality"
+            | "interests"
+        >;
+    };
+}
+
+export interface D2UserAccessSchema {
+    name: "D2UserAccess";
+    model: D2UserAccess;
+    fields: { access: string; displayName: string; id: string; userUid: string };
+    fieldPresets: {
+        $all: Preset<D2UserAccess, keyof D2UserAccess>;
+        $identifiable: Preset<D2UserAccess, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2UserAccess, FieldPresets["nameable"]>;
+        $persisted: Preset<D2UserAccess, "access">;
+        $owner: Preset<D2UserAccess, "access">;
+    };
+}
+
+export interface D2UserAuthorityGroupSchema {
+    name: "D2UserAuthorityGroup";
+    model: D2UserAuthorityGroup;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        authorities: string[];
+        code: Id;
+        created: string;
+        description: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        users: D2UserSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2UserAuthorityGroup, keyof D2UserAuthorityGroup>;
+        $identifiable: Preset<D2UserAuthorityGroup, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2UserAuthorityGroup, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2UserAuthorityGroup,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "description"
+            | "authorities"
+            | "lastUpdated"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+        >;
+        $owner: Preset<
+            D2UserAuthorityGroup,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "description"
+            | "authorities"
+            | "lastUpdated"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+        >;
+    };
+}
+
+export interface D2UserCredentialsSchema {
+    name: "D2UserCredentials";
+    model: D2UserCredentials;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        catDimensionConstraints: D2CategorySchema[];
+        code: Id;
+        cogsDimensionConstraints: D2CategoryOptionGroupSetSchema[];
+        created: string;
+        disabled: boolean;
+        displayName: string;
+        externalAccess: boolean;
+        externalAuth: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        invitation: boolean;
+        lastLogin: string;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        ldapId: string;
+        name: string;
+        openId: string;
+        password: string;
+        passwordLastUpdated: string;
+        publicAccess: string;
+        selfRegistered: boolean;
+        translations: D2Translation[];
+        twoFA: boolean;
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        userInfo: D2UserSchema;
+        userRoles: D2UserAuthorityGroupSchema[];
+        username: string;
+    };
+    fieldPresets: {
+        $all: Preset<D2UserCredentials, keyof D2UserCredentials>;
+        $identifiable: Preset<D2UserCredentials, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2UserCredentials, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2UserCredentials,
+            | "lastLogin"
+            | "userInfo"
+            | "code"
+            | "openId"
+            | "externalAuth"
+            | "cogsDimensionConstraints"
+            | "catDimensionConstraints"
+            | "lastUpdated"
+            | "password"
+            | "ldapId"
+            | "disabled"
+            | "id"
+            | "twoFA"
+            | "passwordLastUpdated"
+            | "lastUpdatedBy"
+            | "invitation"
+            | "created"
+            | "selfRegistered"
+            | "userRoles"
+            | "user"
+            | "username"
+        >;
+        $owner: Preset<
+            D2UserCredentials,
+            | "lastLogin"
+            | "userInfo"
+            | "code"
+            | "openId"
+            | "externalAuth"
+            | "cogsDimensionConstraints"
+            | "catDimensionConstraints"
+            | "lastUpdated"
+            | "password"
+            | "ldapId"
+            | "disabled"
+            | "id"
+            | "twoFA"
+            | "passwordLastUpdated"
+            | "lastUpdatedBy"
+            | "invitation"
+            | "created"
+            | "selfRegistered"
+            | "userRoles"
+            | "user"
+            | "username"
+        >;
+    };
+}
+
+export interface D2UserGroupSchema {
+    name: "D2UserGroup";
+    model: D2UserGroup;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        managedByGroups: D2UserGroupSchema[];
+        managedGroups: D2UserGroupSchema[];
+        name: string;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        users: D2UserSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2UserGroup, keyof D2UserGroup>;
+        $identifiable: Preset<D2UserGroup, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2UserGroup, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2UserGroup,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "managedByGroups"
+            | "attributeValues"
+            | "users"
+            | "managedGroups"
+            | "lastUpdated"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+        >;
+        $owner: Preset<
+            D2UserGroup,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "created"
+            | "publicAccess"
+            | "attributeValues"
+            | "users"
+            | "managedGroups"
+            | "lastUpdated"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+        >;
+    };
+}
+
+export interface D2UserGroupAccessSchema {
+    name: "D2UserGroupAccess";
+    model: D2UserGroupAccess;
+    fields: { access: string; displayName: string; id: string; userGroupUid: string };
+    fieldPresets: {
+        $all: Preset<D2UserGroupAccess, keyof D2UserGroupAccess>;
+        $identifiable: Preset<D2UserGroupAccess, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2UserGroupAccess, FieldPresets["nameable"]>;
+        $persisted: Preset<D2UserGroupAccess, "access">;
+        $owner: Preset<D2UserGroupAccess, "access">;
+    };
+}
+
+export interface D2ValidationNotificationTemplateSchema {
+    name: "D2ValidationNotificationTemplate";
+    model: D2ValidationNotificationTemplate;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        messageTemplate: string;
+        name: string;
+        notifyParentOrganisationUnitOnly: boolean;
+        notifyUsersInHierarchyOnly: boolean;
+        publicAccess: string;
+        recipientUserGroups: D2UserGroupSchema[];
+        sendStrategy: "COLLECTIVE_SUMMARY" | "SINGLE_NOTIFICATION";
+        subjectTemplate: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        validationRules: D2ValidationRuleSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ValidationNotificationTemplate, keyof D2ValidationNotificationTemplate>;
+        $identifiable: Preset<D2ValidationNotificationTemplate, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ValidationNotificationTemplate, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ValidationNotificationTemplate,
+            | "code"
+            | "recipientUserGroups"
+            | "lastUpdated"
+            | "subjectTemplate"
+            | "id"
+            | "sendStrategy"
+            | "lastUpdatedBy"
+            | "validationRules"
+            | "created"
+            | "notifyUsersInHierarchyOnly"
+            | "name"
+            | "messageTemplate"
+        >;
+        $owner: Preset<
+            D2ValidationNotificationTemplate,
+            | "code"
+            | "recipientUserGroups"
+            | "lastUpdated"
+            | "subjectTemplate"
+            | "id"
+            | "sendStrategy"
+            | "lastUpdatedBy"
+            | "validationRules"
+            | "created"
+            | "notifyUsersInHierarchyOnly"
+            | "name"
+            | "messageTemplate"
+        >;
+    };
+}
+
+export interface D2ValidationResultSchema {
+    name: "D2ValidationResult";
+    model: D2ValidationResult;
+    fields: {
+        attributeOptionCombo: D2CategoryOptionComboSchema;
+        created: string;
+        dayInPeriod: number;
+        id: string;
+        leftsideValue: number;
+        notificationSent: boolean;
+        organisationUnit: D2OrganisationUnitSchema;
+        period: any;
+        rightsideValue: number;
+        validationRule: D2ValidationRuleSchema;
+    };
+    fieldPresets: {
+        $all: Preset<D2ValidationResult, keyof D2ValidationResult>;
+        $identifiable: Preset<D2ValidationResult, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ValidationResult, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ValidationResult,
+            "created" | "rightsideValue" | "leftsideValue" | "notificationSent"
+        >;
+        $owner: Preset<
+            D2ValidationResult,
+            "created" | "rightsideValue" | "leftsideValue" | "notificationSent"
+        >;
+    };
+}
+
+export interface D2ValidationRuleSchema {
+    name: "D2ValidationRule";
+    model: D2ValidationRule;
+    fields: {
+        access: D2Access;
+        aggregateExportAttributeOptionCombo: string;
+        aggregateExportCategoryOptionCombo: string;
+        aggregationType:
+            | "SUM"
+            | "AVERAGE"
+            | "AVERAGE_SUM_ORG_UNIT"
+            | "LAST"
+            | "LAST_AVERAGE_ORG_UNIT"
+            | "FIRST"
+            | "FIRST_AVERAGE_ORG_UNIT"
+            | "COUNT"
+            | "STDDEV"
+            | "VARIANCE"
+            | "MIN"
+            | "MAX"
+            | "NONE"
+            | "CUSTOM"
+            | "DEFAULT";
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        description: string;
+        dimensionItem: string;
+        dimensionItemType:
+            | "DATA_ELEMENT"
+            | "DATA_ELEMENT_OPERAND"
+            | "INDICATOR"
+            | "REPORTING_RATE"
+            | "PROGRAM_DATA_ELEMENT"
+            | "PROGRAM_ATTRIBUTE"
+            | "PROGRAM_INDICATOR"
+            | "PERIOD"
+            | "ORGANISATION_UNIT"
+            | "CATEGORY_OPTION"
+            | "OPTION_GROUP"
+            | "DATA_ELEMENT_GROUP"
+            | "ORGANISATION_UNIT_GROUP"
+            | "CATEGORY_OPTION_GROUP";
+        displayDescription: string;
+        displayFormName: string;
+        displayName: string;
+        displayShortName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        formName: string;
+        href: string;
+        id: Id;
+        importance: "HIGH" | "MEDIUM" | "LOW";
+        instruction: string;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        leftSide: D2ExpressionSchema;
+        legendSet: D2LegendSetSchema;
+        legendSets: D2LegendSetSchema[];
+        name: string;
+        notificationTemplates: D2ValidationNotificationTemplateSchema[];
+        operator:
+            | "equal_to"
+            | "not_equal_to"
+            | "greater_than"
+            | "greater_than_or_equal_to"
+            | "less_than"
+            | "less_than_or_equal_to"
+            | "compulsory_pair"
+            | "exclusive_pair";
+        organisationUnitLevels: number[];
+        periodType: string;
+        publicAccess: string;
+        rightSide: D2ExpressionSchema;
+        shortName: string;
+        skipFormValidation: boolean;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        validationRuleGroups: D2ValidationRuleGroupSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ValidationRule, keyof D2ValidationRule>;
+        $identifiable: Preset<D2ValidationRule, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ValidationRule, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ValidationRule,
+            | "validationRuleGroups"
+            | "code"
+            | "importance"
+            | "publicAccess"
+            | "description"
+            | "operator"
+            | "organisationUnitLevels"
+            | "lastUpdated"
+            | "leftSide"
+            | "notificationTemplates"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "rightSide"
+            | "periodType"
+            | "instruction"
+            | "userAccesses"
+            | "name"
+            | "skipFormValidation"
+            | "user"
+        >;
+        $owner: Preset<
+            D2ValidationRule,
+            | "code"
+            | "importance"
+            | "publicAccess"
+            | "description"
+            | "operator"
+            | "organisationUnitLevels"
+            | "lastUpdated"
+            | "leftSide"
+            | "translations"
+            | "id"
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "created"
+            | "attributeValues"
+            | "rightSide"
+            | "periodType"
+            | "instruction"
+            | "userAccesses"
+            | "name"
+            | "skipFormValidation"
+            | "user"
+        >;
+    };
+}
+
+export interface D2ValidationRuleGroupSchema {
+    name: "D2ValidationRuleGroup";
+    model: D2ValidationRuleGroup;
+    fields: {
+        access: D2Access;
+        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
+        code: Id;
+        created: string;
+        description: string;
+        displayName: string;
+        externalAccess: boolean;
+        favorite: boolean;
+        favorites: string[];
+        href: string;
+        id: Id;
+        lastUpdated: string;
+        lastUpdatedBy: D2UserSchema;
+        name: string;
+        publicAccess: string;
+        translations: D2Translation[];
+        user: D2UserSchema;
+        userAccesses: D2UserAccessSchema[];
+        userGroupAccesses: D2UserGroupAccessSchema[];
+        validationRules: D2ValidationRuleSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2ValidationRuleGroup, keyof D2ValidationRuleGroup>;
+        $identifiable: Preset<D2ValidationRuleGroup, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2ValidationRuleGroup, FieldPresets["nameable"]>;
+        $persisted: Preset<
+            D2ValidationRuleGroup,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "validationRules"
+            | "created"
+            | "publicAccess"
+            | "attributeValues"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+        >;
+        $owner: Preset<
+            D2ValidationRuleGroup,
+            | "lastUpdatedBy"
+            | "userGroupAccesses"
+            | "code"
+            | "validationRules"
+            | "created"
+            | "publicAccess"
+            | "attributeValues"
+            | "description"
+            | "lastUpdated"
+            | "translations"
+            | "userAccesses"
+            | "name"
+            | "id"
+            | "user"
+        >;
     };
 }
 
@@ -11898,7 +14234,7 @@ export interface D2VisualizationSchema {
         name: string;
         noSpaceBetweenColumns: boolean;
         numberType: "VALUE" | "ROW_PERCENTAGE" | "COLUMN_PERCENTAGE";
-        optionalAxes: any[];
+        optionalAxes: D2Axis[];
         orgUnitField: string;
         organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimensionSchema[];
         organisationUnitLevels: number[];
@@ -11916,7 +14252,7 @@ export interface D2VisualizationSchema {
         regression: boolean;
         regressionType: "NONE" | "LINEAR" | "POLYNOMIAL" | "LOESS";
         relativePeriods: any;
-        reportingParams: any;
+        reportingParams: D2ReportingParams;
         rowDimensions: string[];
         rowSubTotals: boolean;
         rowTotals: boolean;
@@ -12139,2342 +14475,7 @@ export interface D2VisualizationSchema {
     };
 }
 
-export interface D2ValidationResultSchema {
-    name: "D2ValidationResult";
-    model: D2ValidationResult;
-    fields: {
-        attributeOptionCombo: D2CategoryOptionComboSchema;
-        created: string;
-        dayInPeriod: number;
-        id: string;
-        leftsideValue: number;
-        notificationSent: boolean;
-        organisationUnit: D2OrganisationUnitSchema;
-        period: any;
-        rightsideValue: number;
-        validationRule: D2ValidationRuleSchema;
-    };
-    fieldPresets: {
-        $all: Preset<D2ValidationResult, keyof D2ValidationResult>;
-        $identifiable: Preset<D2ValidationResult, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ValidationResult, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ValidationResult,
-            "created" | "rightsideValue" | "leftsideValue" | "notificationSent"
-        >;
-        $owner: Preset<
-            D2ValidationResult,
-            "created" | "rightsideValue" | "leftsideValue" | "notificationSent"
-        >;
-    };
-}
-
-export interface D2PredictorSchema {
-    name: "D2Predictor";
-    model: D2Predictor;
-    fields: {
-        access: D2Access;
-        annualSampleCount: number;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        generator: D2ExpressionSchema;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        organisationUnitLevels: D2OrganisationUnitLevelSchema[];
-        output: D2DataElementSchema;
-        outputCombo: D2CategoryOptionComboSchema;
-        periodType: string;
-        predictorGroups: D2PredictorGroupSchema[];
-        publicAccess: string;
-        sampleSkipTest: D2ExpressionSchema;
-        sequentialSampleCount: number;
-        sequentialSkipCount: number;
-        shortName: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Predictor, keyof D2Predictor>;
-        $identifiable: Preset<D2Predictor, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Predictor, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Predictor,
-            | "outputCombo"
-            | "code"
-            | "description"
-            | "generator"
-            | "organisationUnitLevels"
-            | "output"
-            | "lastUpdated"
-            | "sampleSkipTest"
-            | "id"
-            | "sequentialSampleCount"
-            | "annualSampleCount"
-            | "lastUpdatedBy"
-            | "created"
-            | "sequentialSkipCount"
-            | "predictorGroups"
-            | "periodType"
-            | "name"
-        >;
-        $owner: Preset<
-            D2Predictor,
-            | "outputCombo"
-            | "code"
-            | "description"
-            | "generator"
-            | "organisationUnitLevels"
-            | "output"
-            | "lastUpdated"
-            | "sampleSkipTest"
-            | "id"
-            | "sequentialSampleCount"
-            | "annualSampleCount"
-            | "lastUpdatedBy"
-            | "created"
-            | "sequentialSkipCount"
-            | "periodType"
-            | "name"
-        >;
-    };
-}
-
-export interface D2PredictorGroupSchema {
-    name: "D2PredictorGroup";
-    model: D2PredictorGroup;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        description: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        predictors: D2PredictorSchema[];
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2PredictorGroup, keyof D2PredictorGroup>;
-        $identifiable: Preset<D2PredictorGroup, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2PredictorGroup, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2PredictorGroup,
-            | "predictors"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "description"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2PredictorGroup,
-            | "predictors"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "description"
-            | "lastUpdated"
-            | "translations"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
-export interface D2DashboardItemSchema {
-    name: "D2DashboardItem";
-    model: D2DashboardItem;
-    fields: {
-        access: D2Access;
-        appKey: string;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        chart: D2ChartSchema;
-        code: Id;
-        contentCount: number;
-        created: string;
-        displayName: string;
-        eventChart: D2EventChartSchema;
-        eventReport: D2EventReportSchema;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        height: number;
-        href: string;
-        id: Id;
-        interpretationCount: number;
-        interpretationLikeCount: number;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        map: D2MapSchema;
-        messages: boolean;
-        name: string;
-        publicAccess: string;
-        reportTable: D2ReportTableSchema;
-        reports: D2ReportSchema[];
-        resources: D2DocumentSchema[];
-        shape: "NORMAL" | "DOUBLE_WIDTH" | "FULL_WIDTH";
-        text: string;
-        translations: D2Translation[];
-        type:
-            | "VISUALIZATION"
-            | "CHART"
-            | "EVENT_CHART"
-            | "MAP"
-            | "REPORT_TABLE"
-            | "EVENT_REPORT"
-            | "USERS"
-            | "REPORTS"
-            | "RESOURCES"
-            | "TEXT"
-            | "MESSAGES"
-            | "APP";
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        users: D2UserSchema[];
-        visualization: D2VisualizationSchema;
-        width: number;
-        x: number;
-        y: number;
-    };
-    fieldPresets: {
-        $all: Preset<D2DashboardItem, keyof D2DashboardItem>;
-        $identifiable: Preset<D2DashboardItem, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2DashboardItem, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2DashboardItem,
-            | "reports"
-            | "visualization"
-            | "code"
-            | "lastUpdated"
-            | "translations"
-            | "appKey"
-            | "id"
-            | "text"
-            | "map"
-            | "height"
-            | "lastUpdatedBy"
-            | "shape"
-            | "created"
-            | "resources"
-            | "users"
-            | "eventReport"
-            | "eventChart"
-            | "width"
-            | "x"
-            | "messages"
-            | "y"
-        >;
-        $owner: Preset<
-            D2DashboardItem,
-            | "reports"
-            | "visualization"
-            | "code"
-            | "lastUpdated"
-            | "translations"
-            | "appKey"
-            | "id"
-            | "text"
-            | "map"
-            | "height"
-            | "lastUpdatedBy"
-            | "shape"
-            | "created"
-            | "resources"
-            | "users"
-            | "eventReport"
-            | "eventChart"
-            | "width"
-            | "x"
-            | "messages"
-            | "y"
-        >;
-    };
-}
-
-export interface D2DashboardSchema {
-    name: "D2Dashboard";
-    model: D2Dashboard;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        dashboardItems: D2DashboardItemSchema[];
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        itemCount: number;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        shortName: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Dashboard, keyof D2Dashboard>;
-        $identifiable: Preset<D2Dashboard, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Dashboard, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Dashboard,
-            | "favorites"
-            | "code"
-            | "publicAccess"
-            | "description"
-            | "externalAccess"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "dashboardItems"
-            | "userAccesses"
-            | "name"
-            | "user"
-        >;
-        $owner: Preset<
-            D2Dashboard,
-            | "favorites"
-            | "code"
-            | "publicAccess"
-            | "description"
-            | "externalAccess"
-            | "lastUpdated"
-            | "translations"
-            | "id"
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "created"
-            | "dashboardItems"
-            | "userAccesses"
-            | "name"
-            | "user"
-        >;
-    };
-}
-
-export interface D2PushAnalysisSchema {
-    name: "D2PushAnalysis";
-    model: D2PushAnalysis;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        dashboard: D2DashboardSchema;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        message: string;
-        name: string;
-        publicAccess: string;
-        recipientUserGroups: D2UserGroupSchema[];
-        title: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2PushAnalysis, keyof D2PushAnalysis>;
-        $identifiable: Preset<D2PushAnalysis, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2PushAnalysis, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2PushAnalysis,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "recipientUserGroups"
-            | "message"
-            | "title"
-            | "lastUpdated"
-            | "name"
-            | "id"
-            | "dashboard"
-        >;
-        $owner: Preset<
-            D2PushAnalysis,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "recipientUserGroups"
-            | "message"
-            | "title"
-            | "lastUpdated"
-            | "name"
-            | "id"
-            | "dashboard"
-        >;
-    };
-}
-
-export interface D2KeyJsonValueSchema {
-    name: "D2KeyJsonValue";
-    model: D2KeyJsonValue;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        key: string;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        namespace: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        value: string;
-    };
-    fieldPresets: {
-        $all: Preset<D2KeyJsonValue, keyof D2KeyJsonValue>;
-        $identifiable: Preset<D2KeyJsonValue, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2KeyJsonValue, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2KeyJsonValue,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "lastUpdated"
-            | "userAccesses"
-            | "namespace"
-            | "id"
-            | "user"
-            | "key"
-        >;
-        $owner: Preset<
-            D2KeyJsonValue,
-            | "lastUpdatedBy"
-            | "userGroupAccesses"
-            | "code"
-            | "created"
-            | "publicAccess"
-            | "lastUpdated"
-            | "userAccesses"
-            | "namespace"
-            | "id"
-            | "user"
-            | "key"
-        >;
-    };
-}
-
-export interface D2UserAccessSchema {
-    name: "D2UserAccess";
-    model: D2UserAccess;
-    fields: { access: string; displayName: string; id: string; userUid: string };
-    fieldPresets: {
-        $all: Preset<D2UserAccess, keyof D2UserAccess>;
-        $identifiable: Preset<D2UserAccess, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2UserAccess, FieldPresets["nameable"]>;
-        $persisted: Preset<D2UserAccess, "access">;
-        $owner: Preset<D2UserAccess, "access">;
-    };
-}
-
-export interface D2AnalyticsPeriodBoundarySchema {
-    name: "D2AnalyticsPeriodBoundary";
-    model: D2AnalyticsPeriodBoundary;
-    fields: {
-        access: D2Access;
-        analyticsPeriodBoundaryType:
-            | "BEFORE_START_OF_REPORTING_PERIOD"
-            | "BEFORE_END_OF_REPORTING_PERIOD"
-            | "AFTER_START_OF_REPORTING_PERIOD"
-            | "AFTER_END_OF_REPORTING_PERIOD";
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        boundaryTarget: string;
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        offsetPeriodType: string;
-        offsetPeriods: number;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2AnalyticsPeriodBoundary, keyof D2AnalyticsPeriodBoundary>;
-        $identifiable: Preset<D2AnalyticsPeriodBoundary, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2AnalyticsPeriodBoundary, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2AnalyticsPeriodBoundary,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "lastUpdated"
-            | "offsetPeriodType"
-            | "id"
-            | "analyticsPeriodBoundaryType"
-            | "boundaryTarget"
-            | "offsetPeriods"
-        >;
-        $owner: Preset<
-            D2AnalyticsPeriodBoundary,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "lastUpdated"
-            | "offsetPeriodType"
-            | "id"
-            | "analyticsPeriodBoundaryType"
-            | "boundaryTarget"
-            | "offsetPeriods"
-        >;
-    };
-}
-
-export interface D2DataSetElementSchema {
-    name: "D2DataSetElement";
-    model: D2DataSetElement;
-    fields: {
-        categoryCombo: D2CategoryComboSchema;
-        dataElement: D2DataElementSchema;
-        dataSet: D2DataSetSchema;
-    };
-    fieldPresets: {
-        $all: Preset<D2DataSetElement, keyof D2DataSetElement>;
-        $identifiable: Preset<D2DataSetElement, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2DataSetElement, FieldPresets["nameable"]>;
-        $persisted: Preset<D2DataSetElement, "dataElement" | "categoryCombo" | "dataSet">;
-        $owner: Preset<D2DataSetElement, "dataElement" | "categoryCombo" | "dataSet">;
-    };
-}
-
-export interface D2TrackedEntityInstanceSchema {
-    name: "D2TrackedEntityInstance";
-    model: D2TrackedEntityInstance;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        createdAtClient: string;
-        deleted: boolean;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        geometry: D2Geometry;
-        href: string;
-        id: Id;
-        inactive: boolean;
-        lastUpdated: string;
-        lastUpdatedAtClient: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        organisationUnit: D2OrganisationUnitSchema;
-        programInstances: D2ProgramInstanceSchema[];
-        programOwners: any[];
-        publicAccess: string;
-        relationshipItems: any[];
-        trackedEntityAttributeValues: D2TrackedEntityAttributeValueSchema[];
-        trackedEntityType: D2TrackedEntityTypeSchema;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2TrackedEntityInstance, keyof D2TrackedEntityInstance>;
-        $identifiable: Preset<D2TrackedEntityInstance, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2TrackedEntityInstance, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2TrackedEntityInstance,
-            | "programOwners"
-            | "code"
-            | "programInstances"
-            | "organisationUnit"
-            | "createdAtClient"
-            | "lastUpdated"
-            | "inactive"
-            | "relationshipItems"
-            | "id"
-            | "lastUpdatedBy"
-            | "created"
-            | "deleted"
-            | "trackedEntityType"
-            | "geometry"
-            | "trackedEntityAttributeValues"
-            | "lastUpdatedAtClient"
-        >;
-        $owner: Preset<
-            D2TrackedEntityInstance,
-            | "code"
-            | "organisationUnit"
-            | "createdAtClient"
-            | "lastUpdated"
-            | "inactive"
-            | "id"
-            | "lastUpdatedBy"
-            | "created"
-            | "deleted"
-            | "trackedEntityType"
-            | "geometry"
-            | "lastUpdatedAtClient"
-        >;
-    };
-}
-
-export interface D2MinMaxDataElementSchema {
-    name: "D2MinMaxDataElement";
-    model: D2MinMaxDataElement;
-    fields: {
-        dataElement: D2DataElementSchema;
-        generated: boolean;
-        max: number;
-        min: number;
-        optionCombo: D2CategoryOptionComboSchema;
-        source: D2OrganisationUnitSchema;
-    };
-    fieldPresets: {
-        $all: Preset<D2MinMaxDataElement, keyof D2MinMaxDataElement>;
-        $identifiable: Preset<D2MinMaxDataElement, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2MinMaxDataElement, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2MinMaxDataElement,
-            "min" | "generated" | "max" | "dataElement" | "source" | "optionCombo"
-        >;
-        $owner: Preset<
-            D2MinMaxDataElement,
-            "min" | "generated" | "max" | "dataElement" | "source" | "optionCombo"
-        >;
-    };
-}
-
-export interface D2ProgramStageInstanceFilterSchema {
-    name: "D2ProgramStageInstanceFilter";
-    model: D2ProgramStageInstanceFilter;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        description: string;
-        displayName: string;
-        eventQueryCriteria: any;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        program: Id;
-        programStage: Id;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramStageInstanceFilter, keyof D2ProgramStageInstanceFilter>;
-        $identifiable: Preset<D2ProgramStageInstanceFilter, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramStageInstanceFilter, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramStageInstanceFilter,
-            | "lastUpdatedBy"
-            | "programStage"
-            | "eventQueryCriteria"
-            | "userGroupAccesses"
-            | "created"
-            | "publicAccess"
-            | "description"
-            | "program"
-            | "lastUpdated"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-        $owner: Preset<
-            D2ProgramStageInstanceFilter,
-            | "lastUpdatedBy"
-            | "programStage"
-            | "eventQueryCriteria"
-            | "userGroupAccesses"
-            | "created"
-            | "publicAccess"
-            | "description"
-            | "program"
-            | "lastUpdated"
-            | "userAccesses"
-            | "name"
-            | "id"
-            | "user"
-        >;
-    };
-}
-
-export interface D2DataElementGroupSetDimensionSchema {
-    name: "D2DataElementGroupSetDimension";
-    model: D2DataElementGroupSetDimension;
-    fields: {
-        dataElementGroupSet: D2DataElementGroupSetSchema;
-        dataElementGroups: D2DataElementGroupSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2DataElementGroupSetDimension, keyof D2DataElementGroupSetDimension>;
-        $identifiable: Preset<D2DataElementGroupSetDimension, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2DataElementGroupSetDimension, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2DataElementGroupSetDimension,
-            "dataElementGroups" | "dataElementGroupSet"
-        >;
-        $owner: Preset<D2DataElementGroupSetDimension, "dataElementGroups" | "dataElementGroupSet">;
-    };
-}
-
-export interface D2ProgramTrackedEntityAttributeSchema {
-    name: "D2ProgramTrackedEntityAttribute";
-    model: D2ProgramTrackedEntityAttribute;
-    fields: {
-        access: D2Access;
-        allowFutureDate: boolean;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        displayInList: boolean;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        mandatory: boolean;
-        name: string;
-        program: D2ProgramSchema;
-        programTrackedEntityAttributeGroups: D2ProgramTrackedEntityAttributeGroupSchema[];
-        publicAccess: string;
-        renderOptionsAsRadio: boolean;
-        renderType: any;
-        searchable: boolean;
-        sortOrder: number;
-        trackedEntityAttribute: D2TrackedEntityAttributeSchema;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        valueType:
-            | "TEXT"
-            | "LONG_TEXT"
-            | "LETTER"
-            | "PHONE_NUMBER"
-            | "EMAIL"
-            | "BOOLEAN"
-            | "TRUE_ONLY"
-            | "DATE"
-            | "DATETIME"
-            | "TIME"
-            | "NUMBER"
-            | "UNIT_INTERVAL"
-            | "PERCENTAGE"
-            | "INTEGER"
-            | "INTEGER_POSITIVE"
-            | "INTEGER_NEGATIVE"
-            | "INTEGER_ZERO_OR_POSITIVE"
-            | "TRACKER_ASSOCIATE"
-            | "USERNAME"
-            | "COORDINATE"
-            | "ORGANISATION_UNIT"
-            | "AGE"
-            | "URL"
-            | "FILE_RESOURCE"
-            | "IMAGE";
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramTrackedEntityAttribute, keyof D2ProgramTrackedEntityAttribute>;
-        $identifiable: Preset<D2ProgramTrackedEntityAttribute, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramTrackedEntityAttribute, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramTrackedEntityAttribute,
-            | "code"
-            | "programTrackedEntityAttributeGroups"
-            | "program"
-            | "mandatory"
-            | "trackedEntityAttribute"
-            | "lastUpdated"
-            | "renderOptionsAsRadio"
-            | "id"
-            | "allowFutureDate"
-            | "renderType"
-            | "lastUpdatedBy"
-            | "created"
-            | "searchable"
-            | "displayInList"
-            | "sortOrder"
-        >;
-        $owner: Preset<
-            D2ProgramTrackedEntityAttribute,
-            | "code"
-            | "programTrackedEntityAttributeGroups"
-            | "program"
-            | "mandatory"
-            | "trackedEntityAttribute"
-            | "lastUpdated"
-            | "renderOptionsAsRadio"
-            | "id"
-            | "allowFutureDate"
-            | "renderType"
-            | "lastUpdatedBy"
-            | "created"
-            | "searchable"
-            | "displayInList"
-            | "sortOrder"
-        >;
-    };
-}
-
-export interface D2MessageConversationSchema {
-    name: "D2MessageConversation";
-    model: D2MessageConversation;
-    fields: {
-        access: D2Access;
-        assignee: D2UserSchema;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        followUp: boolean;
-        href: string;
-        id: Id;
-        lastMessage: string;
-        lastSender: D2UserSchema;
-        lastSenderFirstname: string;
-        lastSenderSurname: string;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        messageCount: number;
-        messageType: "PRIVATE" | "SYSTEM" | "VALIDATION_RESULT" | "TICKET";
-        messages: any[];
-        name: string;
-        priority: "NONE" | "LOW" | "MEDIUM" | "HIGH";
-        publicAccess: string;
-        read: boolean;
-        status: "NONE" | "OPEN" | "PENDING" | "INVALID" | "SOLVED";
-        subject: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userFirstname: string;
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        userMessages: any[];
-        userSurname: string;
-    };
-    fieldPresets: {
-        $all: Preset<D2MessageConversation, keyof D2MessageConversation>;
-        $identifiable: Preset<D2MessageConversation, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2MessageConversation, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2MessageConversation,
-            | "messageCount"
-            | "subject"
-            | "lastUpdated"
-            | "messageType"
-            | "userMessages"
-            | "id"
-            | "lastSender"
-            | "created"
-            | "lastMessage"
-            | "priority"
-            | "messages"
-            | "assignee"
-            | "user"
-            | "status"
-        >;
-        $owner: Preset<
-            D2MessageConversation,
-            | "messageCount"
-            | "subject"
-            | "lastUpdated"
-            | "messageType"
-            | "userMessages"
-            | "id"
-            | "lastSender"
-            | "created"
-            | "lastMessage"
-            | "priority"
-            | "messages"
-            | "assignee"
-            | "user"
-            | "status"
-        >;
-    };
-}
-
-export interface D2OrganisationUnitGroupSetDimensionSchema {
-    name: "D2OrganisationUnitGroupSetDimension";
-    model: D2OrganisationUnitGroupSetDimension;
-    fields: {
-        organisationUnitGroupSet: D2OrganisationUnitGroupSetSchema;
-        organisationUnitGroups: D2OrganisationUnitGroupSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<
-            D2OrganisationUnitGroupSetDimension,
-            keyof D2OrganisationUnitGroupSetDimension
-        >;
-        $identifiable: Preset<D2OrganisationUnitGroupSetDimension, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2OrganisationUnitGroupSetDimension, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2OrganisationUnitGroupSetDimension,
-            "organisationUnitGroupSet" | "organisationUnitGroups"
-        >;
-        $owner: Preset<
-            D2OrganisationUnitGroupSetDimension,
-            "organisationUnitGroupSet" | "organisationUnitGroups"
-        >;
-    };
-}
-
-export interface D2CategoryOptionGroupSetDimensionSchema {
-    name: "D2CategoryOptionGroupSetDimension";
-    model: D2CategoryOptionGroupSetDimension;
-    fields: {
-        categoryOptionGroupSet: D2CategoryOptionGroupSetSchema;
-        categoryOptionGroups: D2CategoryOptionGroupSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2CategoryOptionGroupSetDimension, keyof D2CategoryOptionGroupSetDimension>;
-        $identifiable: Preset<D2CategoryOptionGroupSetDimension, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2CategoryOptionGroupSetDimension, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2CategoryOptionGroupSetDimension,
-            "categoryOptionGroups" | "categoryOptionGroupSet"
-        >;
-        $owner: Preset<
-            D2CategoryOptionGroupSetDimension,
-            "categoryOptionGroups" | "categoryOptionGroupSet"
-        >;
-    };
-}
-
-export interface D2UserGroupAccessSchema {
-    name: "D2UserGroupAccess";
-    model: D2UserGroupAccess;
-    fields: { access: string; displayName: string; id: string; userGroupUid: string };
-    fieldPresets: {
-        $all: Preset<D2UserGroupAccess, keyof D2UserGroupAccess>;
-        $identifiable: Preset<D2UserGroupAccess, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2UserGroupAccess, FieldPresets["nameable"]>;
-        $persisted: Preset<D2UserGroupAccess, "access">;
-        $owner: Preset<D2UserGroupAccess, "access">;
-    };
-}
-
-export interface D2TrackedEntityInstanceFilterSchema {
-    name: "D2TrackedEntityInstanceFilter";
-    model: D2TrackedEntityInstanceFilter;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        description: string;
-        displayName: string;
-        enrollmentCreatedPeriod: any;
-        enrollmentStatus: "ACTIVE" | "COMPLETED" | "CANCELLED";
-        eventFilters: any[];
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        followup: boolean;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        program: D2ProgramSchema;
-        publicAccess: string;
-        sortOrder: number;
-        style: D2Style;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2TrackedEntityInstanceFilter, keyof D2TrackedEntityInstanceFilter>;
-        $identifiable: Preset<D2TrackedEntityInstanceFilter, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2TrackedEntityInstanceFilter, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2TrackedEntityInstanceFilter,
-            | "code"
-            | "description"
-            | "program"
-            | "enrollmentCreatedPeriod"
-            | "lastUpdated"
-            | "id"
-            | "lastUpdatedBy"
-            | "created"
-            | "followup"
-            | "eventFilters"
-            | "enrollmentStatus"
-            | "sortOrder"
-            | "name"
-            | "style"
-        >;
-        $owner: Preset<
-            D2TrackedEntityInstanceFilter,
-            | "code"
-            | "description"
-            | "program"
-            | "enrollmentCreatedPeriod"
-            | "lastUpdated"
-            | "id"
-            | "lastUpdatedBy"
-            | "created"
-            | "followup"
-            | "eventFilters"
-            | "enrollmentStatus"
-            | "sortOrder"
-            | "name"
-            | "style"
-        >;
-    };
-}
-
-export interface D2ProgramDataElementDimensionItemSchema {
-    name: "D2ProgramDataElementDimensionItem";
-    model: D2ProgramDataElementDimensionItem;
-    fields: {
-        access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "FIRST"
-            | "FIRST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        dataElement: D2DataElementSchema;
-        description: string;
-        dimensionItem: string;
-        dimensionItemType:
-            | "DATA_ELEMENT"
-            | "DATA_ELEMENT_OPERAND"
-            | "INDICATOR"
-            | "REPORTING_RATE"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION"
-            | "OPTION_GROUP"
-            | "DATA_ELEMENT_GROUP"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY_OPTION_GROUP";
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        legendSet: D2LegendSetSchema;
-        legendSets: D2LegendSetSchema[];
-        name: string;
-        program: D2ProgramSchema;
-        publicAccess: string;
-        shortName: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        valueType:
-            | "TEXT"
-            | "LONG_TEXT"
-            | "LETTER"
-            | "PHONE_NUMBER"
-            | "EMAIL"
-            | "BOOLEAN"
-            | "TRUE_ONLY"
-            | "DATE"
-            | "DATETIME"
-            | "TIME"
-            | "NUMBER"
-            | "UNIT_INTERVAL"
-            | "PERCENTAGE"
-            | "INTEGER"
-            | "INTEGER_POSITIVE"
-            | "INTEGER_NEGATIVE"
-            | "INTEGER_ZERO_OR_POSITIVE"
-            | "TRACKER_ASSOCIATE"
-            | "USERNAME"
-            | "COORDINATE"
-            | "ORGANISATION_UNIT"
-            | "AGE"
-            | "URL"
-            | "FILE_RESOURCE"
-            | "IMAGE";
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramDataElementDimensionItem, keyof D2ProgramDataElementDimensionItem>;
-        $identifiable: Preset<D2ProgramDataElementDimensionItem, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramDataElementDimensionItem, FieldPresets["nameable"]>;
-        $persisted: Preset<D2ProgramDataElementDimensionItem, never>;
-        $owner: Preset<D2ProgramDataElementDimensionItem, never>;
-    };
-}
-
-export interface D2ReportingRateSchema {
-    name: "D2ReportingRate";
-    model: D2ReportingRate;
-    fields: {
-        access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "FIRST"
-            | "FIRST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        dataSet: D2DataSetSchema;
-        description: string;
-        dimensionItem: string;
-        dimensionItemType:
-            | "DATA_ELEMENT"
-            | "DATA_ELEMENT_OPERAND"
-            | "INDICATOR"
-            | "REPORTING_RATE"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION"
-            | "OPTION_GROUP"
-            | "DATA_ELEMENT_GROUP"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY_OPTION_GROUP";
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        legendSet: D2LegendSetSchema;
-        legendSets: D2LegendSetSchema[];
-        metric:
-            | "REPORTING_RATE"
-            | "REPORTING_RATE_ON_TIME"
-            | "ACTUAL_REPORTS"
-            | "ACTUAL_REPORTS_ON_TIME"
-            | "EXPECTED_REPORTS";
-        name: string;
-        publicAccess: string;
-        shortName: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ReportingRate, keyof D2ReportingRate>;
-        $identifiable: Preset<D2ReportingRate, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ReportingRate, FieldPresets["nameable"]>;
-        $persisted: Preset<D2ReportingRate, never>;
-        $owner: Preset<D2ReportingRate, never>;
-    };
-}
-
-export interface D2MetadataVersionSchema {
-    name: "D2MetadataVersion";
-    model: D2MetadataVersion;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        hashCode: string;
-        href: string;
-        id: Id;
-        importDate: string;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        type: "BEST_EFFORT" | "ATOMIC";
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2MetadataVersion, keyof D2MetadataVersion>;
-        $identifiable: Preset<D2MetadataVersion, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2MetadataVersion, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2MetadataVersion,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "type"
-            | "lastUpdated"
-            | "importDate"
-            | "hashCode"
-            | "name"
-            | "id"
-        >;
-        $owner: Preset<
-            D2MetadataVersion,
-            | "lastUpdatedBy"
-            | "code"
-            | "created"
-            | "type"
-            | "lastUpdated"
-            | "importDate"
-            | "hashCode"
-            | "name"
-            | "id"
-        >;
-    };
-}
-
-export interface D2DataInputPeriodSchema {
-    name: "D2DataInputPeriod";
-    model: D2DataInputPeriod;
-    fields: { closingDate: string; openingDate: string; period: any };
-    fieldPresets: {
-        $all: Preset<D2DataInputPeriod, keyof D2DataInputPeriod>;
-        $identifiable: Preset<D2DataInputPeriod, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2DataInputPeriod, FieldPresets["nameable"]>;
-        $persisted: Preset<D2DataInputPeriod, "period" | "closingDate" | "openingDate">;
-        $owner: Preset<D2DataInputPeriod, "period" | "closingDate" | "openingDate">;
-    };
-}
-
-export interface D2IconSchema {
-    name: "D2Icon";
-    model: D2Icon;
-    fields: {};
-    fieldPresets: {
-        $all: Preset<D2Icon, keyof D2Icon>;
-        $identifiable: Preset<D2Icon, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Icon, FieldPresets["nameable"]>;
-        $persisted: Preset<D2Icon, never>;
-        $owner: Preset<D2Icon, never>;
-    };
-}
-
-export interface D2TrackedEntityAttributeValueSchema {
-    name: "D2TrackedEntityAttributeValue";
-    model: D2TrackedEntityAttributeValue;
-    fields: {
-        created: string;
-        lastUpdated: string;
-        storedBy: string;
-        trackedEntityAttribute: D2TrackedEntityAttributeSchema;
-        trackedEntityInstance: D2TrackedEntityInstanceSchema;
-        value: string;
-    };
-    fieldPresets: {
-        $all: Preset<D2TrackedEntityAttributeValue, keyof D2TrackedEntityAttributeValue>;
-        $identifiable: Preset<D2TrackedEntityAttributeValue, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2TrackedEntityAttributeValue, FieldPresets["nameable"]>;
-        $persisted: Preset<D2TrackedEntityAttributeValue, "lastUpdated" | "storedBy" | "created">;
-        $owner: Preset<D2TrackedEntityAttributeValue, "lastUpdated" | "storedBy" | "created">;
-    };
-}
-
-export interface D2InterpretationSchema {
-    name: "D2Interpretation";
-    model: D2Interpretation;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        chart: D2ChartSchema;
-        code: Id;
-        comments: D2InterpretationCommentSchema[];
-        created: string;
-        dataSet: D2DataSetSchema;
-        displayName: string;
-        eventChart: D2EventChartSchema;
-        eventReport: D2EventReportSchema;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        likedBy: D2UserSchema[];
-        likes: number;
-        map: D2MapSchema;
-        mentions: any[];
-        name: string;
-        organisationUnit: D2OrganisationUnitSchema;
-        period: any;
-        publicAccess: string;
-        reportTable: D2ReportTableSchema;
-        text: string;
-        translations: D2Translation[];
-        type:
-            | "VISUALIZATION"
-            | "REPORT_TABLE"
-            | "CHART"
-            | "MAP"
-            | "EVENT_REPORT"
-            | "EVENT_CHART"
-            | "DATASET_REPORT";
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        visualization: D2VisualizationSchema;
-    };
-    fieldPresets: {
-        $all: Preset<D2Interpretation, keyof D2Interpretation>;
-        $identifiable: Preset<D2Interpretation, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Interpretation, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Interpretation,
-            | "visualization"
-            | "likedBy"
-            | "organisationUnit"
-            | "publicAccess"
-            | "lastUpdated"
-            | "id"
-            | "text"
-            | "map"
-            | "dataSet"
-            | "likes"
-            | "period"
-            | "userGroupAccesses"
-            | "comments"
-            | "created"
-            | "eventReport"
-            | "userAccesses"
-            | "mentions"
-            | "eventChart"
-            | "user"
-        >;
-        $owner: Preset<
-            D2Interpretation,
-            | "visualization"
-            | "likedBy"
-            | "organisationUnit"
-            | "publicAccess"
-            | "lastUpdated"
-            | "id"
-            | "text"
-            | "map"
-            | "dataSet"
-            | "likes"
-            | "period"
-            | "userGroupAccesses"
-            | "comments"
-            | "created"
-            | "eventReport"
-            | "userAccesses"
-            | "mentions"
-            | "eventChart"
-            | "user"
-        >;
-    };
-}
-
-export interface D2ProgramStageDataElementSchema {
-    name: "D2ProgramStageDataElement";
-    model: D2ProgramStageDataElement;
-    fields: {
-        access: D2Access;
-        allowFutureDate: boolean;
-        allowProvidedElsewhere: boolean;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        compulsory: boolean;
-        created: string;
-        dataElement: D2DataElementSchema;
-        displayInReports: boolean;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        programStage: D2ProgramStageSchema;
-        publicAccess: string;
-        renderOptionsAsRadio: boolean;
-        renderType: any;
-        skipSynchronization: boolean;
-        sortOrder: number;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramStageDataElement, keyof D2ProgramStageDataElement>;
-        $identifiable: Preset<D2ProgramStageDataElement, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramStageDataElement, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramStageDataElement,
-            | "displayInReports"
-            | "code"
-            | "skipSynchronization"
-            | "lastUpdated"
-            | "renderOptionsAsRadio"
-            | "id"
-            | "allowFutureDate"
-            | "renderType"
-            | "lastUpdatedBy"
-            | "programStage"
-            | "created"
-            | "dataElement"
-            | "compulsory"
-            | "allowProvidedElsewhere"
-            | "sortOrder"
-        >;
-        $owner: Preset<
-            D2ProgramStageDataElement,
-            | "displayInReports"
-            | "code"
-            | "skipSynchronization"
-            | "lastUpdated"
-            | "renderOptionsAsRadio"
-            | "id"
-            | "allowFutureDate"
-            | "renderType"
-            | "lastUpdatedBy"
-            | "programStage"
-            | "created"
-            | "dataElement"
-            | "compulsory"
-            | "allowProvidedElsewhere"
-            | "sortOrder"
-        >;
-    };
-}
-
-export interface D2InterpretationCommentSchema {
-    name: "D2InterpretationComment";
-    model: D2InterpretationComment;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        mentions: any[];
-        name: string;
-        publicAccess: string;
-        text: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2InterpretationComment, keyof D2InterpretationComment>;
-        $identifiable: Preset<D2InterpretationComment, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2InterpretationComment, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2InterpretationComment,
-            "created" | "lastUpdated" | "mentions" | "text" | "id" | "user"
-        >;
-        $owner: Preset<
-            D2InterpretationComment,
-            "created" | "lastUpdated" | "mentions" | "text" | "id" | "user"
-        >;
-    };
-}
-
-export interface D2TrackedEntityProgramIndicatorDimensionSchema {
-    name: "D2TrackedEntityProgramIndicatorDimension";
-    model: D2TrackedEntityProgramIndicatorDimension;
-    fields: {
-        filter: string;
-        legendSet: D2LegendSetSchema;
-        programIndicator: D2ProgramIndicatorSchema;
-    };
-    fieldPresets: {
-        $all: Preset<
-            D2TrackedEntityProgramIndicatorDimension,
-            keyof D2TrackedEntityProgramIndicatorDimension
-        >;
-        $identifiable: Preset<
-            D2TrackedEntityProgramIndicatorDimension,
-            FieldPresets["identifiable"]
-        >;
-        $nameable: Preset<D2TrackedEntityProgramIndicatorDimension, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2TrackedEntityProgramIndicatorDimension,
-            "filter" | "legendSet" | "programIndicator"
-        >;
-        $owner: Preset<
-            D2TrackedEntityProgramIndicatorDimension,
-            "filter" | "legendSet" | "programIndicator"
-        >;
-    };
-}
-
-export interface D2ProgramStageInstanceSchema {
-    name: "D2ProgramStageInstance";
-    model: D2ProgramStageInstance;
-    fields: {
-        access: D2Access;
-        assignedUser: D2UserSchema;
-        attributeOptionCombo: D2CategoryOptionComboSchema;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        comments: any[];
-        completed: boolean;
-        completedBy: string;
-        completedDate: string;
-        creatableInSearchScope: boolean;
-        created: string;
-        createdAtClient: string;
-        deleted: boolean;
-        displayName: string;
-        dueDate: string;
-        eventDataValues: any[];
-        eventDate: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        geometry: D2Geometry;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedAtClient: string;
-        lastUpdatedBy: D2UserSchema;
-        messageConversations: D2MessageConversationSchema[];
-        name: string;
-        organisationUnit: D2OrganisationUnitSchema;
-        programInstance: D2ProgramInstanceSchema;
-        programStage: D2ProgramStageSchema;
-        publicAccess: string;
-        relationshipItems: any[];
-        status: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";
-        storedBy: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramStageInstance, keyof D2ProgramStageInstance>;
-        $identifiable: Preset<D2ProgramStageInstance, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramStageInstance, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramStageInstance,
-            | "code"
-            | "storedBy"
-            | "organisationUnit"
-            | "dueDate"
-            | "createdAtClient"
-            | "messageConversations"
-            | "lastUpdated"
-            | "eventDataValues"
-            | "relationshipItems"
-            | "id"
-            | "assignedUser"
-            | "programStage"
-            | "comments"
-            | "created"
-            | "completedDate"
-            | "programInstance"
-            | "deleted"
-            | "attributeOptionCombo"
-            | "geometry"
-            | "completedBy"
-            | "status"
-            | "lastUpdatedAtClient"
-            | "eventDate"
-        >;
-        $owner: Preset<
-            D2ProgramStageInstance,
-            | "code"
-            | "storedBy"
-            | "organisationUnit"
-            | "dueDate"
-            | "createdAtClient"
-            | "messageConversations"
-            | "lastUpdated"
-            | "eventDataValues"
-            | "id"
-            | "assignedUser"
-            | "programStage"
-            | "comments"
-            | "created"
-            | "completedDate"
-            | "programInstance"
-            | "deleted"
-            | "attributeOptionCombo"
-            | "geometry"
-            | "completedBy"
-            | "status"
-            | "lastUpdatedAtClient"
-            | "eventDate"
-        >;
-    };
-}
-
-export interface D2CategoryDimensionSchema {
-    name: "D2CategoryDimension";
-    model: D2CategoryDimension;
-    fields: { category: D2CategorySchema; categoryOptions: D2CategoryOptionSchema[] };
-    fieldPresets: {
-        $all: Preset<D2CategoryDimension, keyof D2CategoryDimension>;
-        $identifiable: Preset<D2CategoryDimension, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2CategoryDimension, FieldPresets["nameable"]>;
-        $persisted: Preset<D2CategoryDimension, "categoryOptions" | "category">;
-        $owner: Preset<D2CategoryDimension, "categoryOptions" | "category">;
-    };
-}
-
-export interface D2UserCredentialsSchema {
-    name: "D2UserCredentials";
-    model: D2UserCredentials;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        catDimensionConstraints: D2CategorySchema[];
-        code: Id;
-        cogsDimensionConstraints: D2CategoryOptionGroupSetSchema[];
-        created: string;
-        disabled: boolean;
-        displayName: string;
-        externalAccess: boolean;
-        externalAuth: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        invitation: boolean;
-        lastLogin: string;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        ldapId: string;
-        name: string;
-        openId: string;
-        password: string;
-        passwordLastUpdated: string;
-        publicAccess: string;
-        selfRegistered: boolean;
-        translations: D2Translation[];
-        twoFA: boolean;
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-        userInfo: D2UserSchema;
-        userRoles: D2UserAuthorityGroupSchema[];
-        username: string;
-    };
-    fieldPresets: {
-        $all: Preset<D2UserCredentials, keyof D2UserCredentials>;
-        $identifiable: Preset<D2UserCredentials, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2UserCredentials, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2UserCredentials,
-            | "lastLogin"
-            | "userInfo"
-            | "code"
-            | "openId"
-            | "externalAuth"
-            | "cogsDimensionConstraints"
-            | "catDimensionConstraints"
-            | "lastUpdated"
-            | "password"
-            | "ldapId"
-            | "disabled"
-            | "id"
-            | "twoFA"
-            | "passwordLastUpdated"
-            | "lastUpdatedBy"
-            | "invitation"
-            | "created"
-            | "selfRegistered"
-            | "userRoles"
-            | "user"
-            | "username"
-        >;
-        $owner: Preset<
-            D2UserCredentials,
-            | "lastLogin"
-            | "userInfo"
-            | "code"
-            | "openId"
-            | "externalAuth"
-            | "cogsDimensionConstraints"
-            | "catDimensionConstraints"
-            | "lastUpdated"
-            | "password"
-            | "ldapId"
-            | "disabled"
-            | "id"
-            | "twoFA"
-            | "passwordLastUpdated"
-            | "lastUpdatedBy"
-            | "invitation"
-            | "created"
-            | "selfRegistered"
-            | "userRoles"
-            | "user"
-            | "username"
-        >;
-    };
-}
-
-export interface D2ColorSchema {
-    name: "D2Color";
-    model: D2Color;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        color: string;
-        created: string;
-        displayName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Color, keyof D2Color>;
-        $identifiable: Preset<D2Color, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Color, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Color,
-            | "lastUpdatedBy"
-            | "code"
-            | "color"
-            | "created"
-            | "lastUpdated"
-            | "translations"
-            | "name"
-            | "id"
-        >;
-        $owner: Preset<
-            D2Color,
-            | "lastUpdatedBy"
-            | "code"
-            | "color"
-            | "created"
-            | "lastUpdated"
-            | "translations"
-            | "name"
-            | "id"
-        >;
-    };
-}
-
-export interface D2ProgramInstanceSchema {
-    name: "D2ProgramInstance";
-    model: D2ProgramInstance;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        completedBy: string;
-        created: string;
-        createdAtClient: string;
-        deleted: boolean;
-        displayName: string;
-        endDate: string;
-        enrollmentDate: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        followup: boolean;
-        geometry: D2Geometry;
-        href: string;
-        id: Id;
-        incidentDate: string;
-        lastUpdated: string;
-        lastUpdatedAtClient: string;
-        lastUpdatedBy: D2UserSchema;
-        messageConversations: D2MessageConversationSchema[];
-        name: string;
-        organisationUnit: D2OrganisationUnitSchema;
-        program: D2ProgramSchema;
-        programStageInstances: D2ProgramStageInstanceSchema[];
-        publicAccess: string;
-        relationshipItems: any[];
-        status: "ACTIVE" | "COMPLETED" | "CANCELLED";
-        storedBy: string;
-        trackedEntityComments: any[];
-        trackedEntityInstance: D2TrackedEntityInstanceSchema;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2ProgramInstance, keyof D2ProgramInstance>;
-        $identifiable: Preset<D2ProgramInstance, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2ProgramInstance, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2ProgramInstance,
-            | "storedBy"
-            | "endDate"
-            | "organisationUnit"
-            | "enrollmentDate"
-            | "createdAtClient"
-            | "program"
-            | "messageConversations"
-            | "trackedEntityComments"
-            | "lastUpdated"
-            | "relationshipItems"
-            | "id"
-            | "created"
-            | "programStageInstances"
-            | "trackedEntityInstance"
-            | "followup"
-            | "deleted"
-            | "geometry"
-            | "incidentDate"
-            | "completedBy"
-            | "status"
-            | "lastUpdatedAtClient"
-        >;
-        $owner: Preset<
-            D2ProgramInstance,
-            | "storedBy"
-            | "endDate"
-            | "organisationUnit"
-            | "enrollmentDate"
-            | "createdAtClient"
-            | "program"
-            | "messageConversations"
-            | "trackedEntityComments"
-            | "lastUpdated"
-            | "id"
-            | "created"
-            | "trackedEntityInstance"
-            | "followup"
-            | "deleted"
-            | "geometry"
-            | "incidentDate"
-            | "completedBy"
-            | "status"
-            | "lastUpdatedAtClient"
-        >;
-    };
-}
-
-export interface D2FileResourceSchema {
-    name: "D2FileResource";
-    model: D2FileResource;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        contentLength: string;
-        contentMd5: string;
-        contentType: string;
-        created: string;
-        displayName: string;
-        domain: "DATA_VALUE" | "PUSH_ANALYSIS" | "DOCUMENT" | "MESSAGE_ATTACHMENT" | "USER_AVATAR";
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        hasMultipleStorageFiles: boolean;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        storageStatus: "NONE" | "PENDING" | "FAILED" | "STORED";
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2FileResource, keyof D2FileResource>;
-        $identifiable: Preset<D2FileResource, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2FileResource, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2FileResource,
-            | "contentMd5"
-            | "code"
-            | "lastUpdated"
-            | "id"
-            | "contentType"
-            | "lastUpdatedBy"
-            | "created"
-            | "domain"
-            | "hasMultipleStorageFiles"
-            | "name"
-            | "contentLength"
-            | "user"
-        >;
-        $owner: Preset<
-            D2FileResource,
-            | "contentMd5"
-            | "code"
-            | "lastUpdated"
-            | "id"
-            | "contentType"
-            | "lastUpdatedBy"
-            | "created"
-            | "domain"
-            | "hasMultipleStorageFiles"
-            | "name"
-            | "contentLength"
-            | "user"
-        >;
-    };
-}
-
-export interface D2LegendSchema {
-    name: "D2Legend";
-    model: D2Legend;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        color: string;
-        created: string;
-        displayName: string;
-        endValue: number;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        href: string;
-        id: Id;
-        image: string;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        startValue: number;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Legend, keyof D2Legend>;
-        $identifiable: Preset<D2Legend, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Legend, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Legend,
-            | "lastUpdatedBy"
-            | "image"
-            | "code"
-            | "endValue"
-            | "color"
-            | "created"
-            | "lastUpdated"
-            | "translations"
-            | "name"
-            | "startValue"
-            | "id"
-        >;
-        $owner: Preset<
-            D2Legend,
-            | "lastUpdatedBy"
-            | "image"
-            | "code"
-            | "endValue"
-            | "color"
-            | "created"
-            | "lastUpdated"
-            | "translations"
-            | "name"
-            | "startValue"
-            | "id"
-        >;
-    };
-}
-
-export interface D2ProgramTrackedEntityAttributeDimensionItemSchema {
-    name: "D2ProgramTrackedEntityAttributeDimensionItem";
-    model: D2ProgramTrackedEntityAttributeDimensionItem;
-    fields: {
-        access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "FIRST"
-            | "FIRST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
-        attribute: D2TrackedEntityAttributeSchema;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        description: string;
-        dimensionItem: string;
-        dimensionItemType:
-            | "DATA_ELEMENT"
-            | "DATA_ELEMENT_OPERAND"
-            | "INDICATOR"
-            | "REPORTING_RATE"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION"
-            | "OPTION_GROUP"
-            | "DATA_ELEMENT_GROUP"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY_OPTION_GROUP";
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        legendSet: D2LegendSetSchema;
-        legendSets: D2LegendSetSchema[];
-        name: string;
-        program: D2ProgramSchema;
-        publicAccess: string;
-        shortName: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<
-            D2ProgramTrackedEntityAttributeDimensionItem,
-            keyof D2ProgramTrackedEntityAttributeDimensionItem
-        >;
-        $identifiable: Preset<
-            D2ProgramTrackedEntityAttributeDimensionItem,
-            FieldPresets["identifiable"]
-        >;
-        $nameable: Preset<D2ProgramTrackedEntityAttributeDimensionItem, FieldPresets["nameable"]>;
-        $persisted: Preset<D2ProgramTrackedEntityAttributeDimensionItem, never>;
-        $owner: Preset<D2ProgramTrackedEntityAttributeDimensionItem, never>;
-    };
-}
-
-export interface D2TrackedEntityDataElementDimensionSchema {
-    name: "D2TrackedEntityDataElementDimension";
-    model: D2TrackedEntityDataElementDimension;
-    fields: {
-        dataElement: D2DataElementSchema;
-        filter: string;
-        legendSet: D2LegendSetSchema;
-        programStage: D2ProgramStageSchema;
-    };
-    fieldPresets: {
-        $all: Preset<
-            D2TrackedEntityDataElementDimension,
-            keyof D2TrackedEntityDataElementDimension
-        >;
-        $identifiable: Preset<D2TrackedEntityDataElementDimension, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2TrackedEntityDataElementDimension, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2TrackedEntityDataElementDimension,
-            "filter" | "legendSet" | "programStage" | "dataElement"
-        >;
-        $owner: Preset<
-            D2TrackedEntityDataElementDimension,
-            "filter" | "legendSet" | "programStage" | "dataElement"
-        >;
-    };
-}
-
-export interface D2RelationshipSchema {
-    name: "D2Relationship";
-    model: D2Relationship;
-    fields: {
-        access: D2Access;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        code: Id;
-        created: string;
-        description: string;
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        from: any;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        name: string;
-        publicAccess: string;
-        relationshipType: D2RelationshipTypeSchema;
-        shortName: string;
-        style: D2Style;
-        to: any;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2Relationship, keyof D2Relationship>;
-        $identifiable: Preset<D2Relationship, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2Relationship, FieldPresets["nameable"]>;
-        $persisted: Preset<
-            D2Relationship,
-            | "code"
-            | "description"
-            | "lastUpdated"
-            | "formName"
-            | "from"
-            | "id"
-            | "lastUpdatedBy"
-            | "relationshipType"
-            | "created"
-            | "style"
-            | "to"
-        >;
-        $owner: Preset<
-            D2Relationship,
-            | "code"
-            | "description"
-            | "lastUpdated"
-            | "formName"
-            | "from"
-            | "id"
-            | "lastUpdatedBy"
-            | "relationshipType"
-            | "created"
-            | "style"
-            | "to"
-        >;
-    };
-}
-
-export interface D2DataElementOperandSchema {
-    name: "D2DataElementOperand";
-    model: D2DataElementOperand;
-    fields: {
-        access: D2Access;
-        aggregationType:
-            | "SUM"
-            | "AVERAGE"
-            | "AVERAGE_SUM_ORG_UNIT"
-            | "LAST"
-            | "LAST_AVERAGE_ORG_UNIT"
-            | "FIRST"
-            | "FIRST_AVERAGE_ORG_UNIT"
-            | "COUNT"
-            | "STDDEV"
-            | "VARIANCE"
-            | "MIN"
-            | "MAX"
-            | "NONE"
-            | "CUSTOM"
-            | "DEFAULT";
-        attributeOptionCombo: D2CategoryOptionComboSchema;
-        attributeValues: D2AttributeValueGeneric<D2Attribute>[];
-        categoryOptionCombo: D2CategoryOptionComboSchema;
-        code: Id;
-        created: string;
-        dataElement: D2DataElementSchema;
-        description: string;
-        dimensionItem: string;
-        dimensionItemType:
-            | "DATA_ELEMENT"
-            | "DATA_ELEMENT_OPERAND"
-            | "INDICATOR"
-            | "REPORTING_RATE"
-            | "PROGRAM_DATA_ELEMENT"
-            | "PROGRAM_ATTRIBUTE"
-            | "PROGRAM_INDICATOR"
-            | "PERIOD"
-            | "ORGANISATION_UNIT"
-            | "CATEGORY_OPTION"
-            | "OPTION_GROUP"
-            | "DATA_ELEMENT_GROUP"
-            | "ORGANISATION_UNIT_GROUP"
-            | "CATEGORY_OPTION_GROUP";
-        displayDescription: string;
-        displayFormName: string;
-        displayName: string;
-        displayShortName: string;
-        externalAccess: boolean;
-        favorite: boolean;
-        favorites: string[];
-        formName: string;
-        href: string;
-        id: Id;
-        lastUpdated: string;
-        lastUpdatedBy: D2UserSchema;
-        legendSet: D2LegendSetSchema;
-        legendSets: D2LegendSetSchema[];
-        name: string;
-        publicAccess: string;
-        shortName: string;
-        translations: D2Translation[];
-        user: D2UserSchema;
-        userAccesses: D2UserAccessSchema[];
-        userGroupAccesses: D2UserGroupAccessSchema[];
-    };
-    fieldPresets: {
-        $all: Preset<D2DataElementOperand, keyof D2DataElementOperand>;
-        $identifiable: Preset<D2DataElementOperand, FieldPresets["identifiable"]>;
-        $nameable: Preset<D2DataElementOperand, FieldPresets["nameable"]>;
-        $persisted: Preset<D2DataElementOperand, "categoryOptionCombo" | "dataElement">;
-        $owner: Preset<D2DataElementOperand, "categoryOptionCombo" | "dataElement">;
-    };
-}
-
 export type D2Model =
-    | D2Predictor
     | D2AnalyticsPeriodBoundary
     | D2AnalyticsTableHook
     | D2Attribute
@@ -14495,7 +14496,6 @@ export type D2Model =
     | D2DataApprovalLevel
     | D2DataApprovalWorkflow
     | D2DataElement
-    | D2TrackedEntityDataElementDimension
     | D2DataElementGroup
     | D2DataElementGroupSet
     | D2DataElementGroupSetDimension
@@ -14509,12 +14509,10 @@ export type D2Model =
     | D2EventChart
     | D2EventReport
     | D2Expression
-    | D2ExternalMapLayer
-    | D2Icon
     | D2ExternalFileResource
-    | D2ValidationNotificationTemplate
-    | D2KeyJsonValue
+    | D2ExternalMapLayer
     | D2FileResource
+    | D2Icon
     | D2Indicator
     | D2IndicatorGroup
     | D2IndicatorGroupSet
@@ -14522,6 +14520,7 @@ export type D2Model =
     | D2Interpretation
     | D2InterpretationComment
     | D2JobConfiguration
+    | D2KeyJsonValue
     | D2Legend
     | D2LegendSet
     | D2Map
@@ -14539,12 +14538,11 @@ export type D2Model =
     | D2OrganisationUnitGroupSet
     | D2OrganisationUnitGroupSetDimension
     | D2OrganisationUnitLevel
+    | D2Predictor
     | D2PredictorGroup
     | D2Program
-    | D2ProgramTrackedEntityAttributeDimensionItem
     | D2ProgramDataElementDimensionItem
     | D2ProgramIndicator
-    | D2TrackedEntityProgramIndicatorDimension
     | D2ProgramIndicatorGroup
     | D2ProgramInstance
     | D2ProgramNotificationTemplate
@@ -14554,9 +14552,11 @@ export type D2Model =
     | D2ProgramSection
     | D2ProgramStage
     | D2ProgramStageDataElement
+    | D2ProgramStageInstance
     | D2ProgramStageInstanceFilter
     | D2ProgramStageSection
     | D2ProgramTrackedEntityAttribute
+    | D2ProgramTrackedEntityAttributeDimensionItem
     | D2ProgramTrackedEntityAttributeGroup
     | D2PushAnalysis
     | D2Relationship
@@ -14564,244 +14564,30 @@ export type D2Model =
     | D2Report
     | D2ReportTable
     | D2ReportingRate
-    | D2Section
     | D2SMSCommand
-    | D2ProgramStageInstance
+    | D2Section
     | D2SqlView
     | D2TrackedEntityAttribute
     | D2TrackedEntityAttributeValue
+    | D2TrackedEntityDataElementDimension
     | D2TrackedEntityInstance
     | D2TrackedEntityInstanceFilter
+    | D2TrackedEntityProgramIndicatorDimension
     | D2TrackedEntityType
     | D2TrackedEntityTypeAttribute
     | D2User
     | D2UserAccess
+    | D2UserAuthorityGroup
     | D2UserCredentials
     | D2UserGroup
     | D2UserGroupAccess
-    | D2UserAuthorityGroup
+    | D2ValidationNotificationTemplate
     | D2ValidationResult
     | D2ValidationRule
     | D2ValidationRuleGroup
     | D2Visualization;
 
 export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
-    predictors: {
-        klass: "org.hisp.dhis.predictor.Predictor",
-        shareable: false,
-        metadata: true,
-        relativeApiEndpoint: "/predictors",
-        plural: "predictors",
-        displayName: "Predictor",
-        collectionName: "predictors",
-        nameableObject: true,
-        translatable: false,
-        identifiableObject: true,
-        dataShareable: false,
-        name: "Predictor",
-        persisted: true,
-        embeddedObject: false,
-        properties: [
-            {
-                name: "favorite",
-                fieldName: "favorites",
-                propertyType: "COLLECTION",
-                itemPropertyType: "TEXT",
-                klass: "java.util.Set",
-                itemKlass: "java.lang.String",
-            },
-            {
-                name: "outputCombo",
-                fieldName: "outputCombo",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.category.CategoryOptionCombo",
-            },
-            {
-                name: "code",
-                fieldName: "code",
-                propertyType: "IDENTIFIER",
-                klass: "java.lang.String",
-            },
-            {
-                name: "access",
-                fieldName: "access",
-                propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.security.acl.Access",
-            },
-            {
-                name: "displayName",
-                fieldName: "displayName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "publicAccess",
-                fieldName: "publicAccess",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "description",
-                fieldName: "description",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "generator",
-                fieldName: "generator",
-                propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.expression.Expression",
-            },
-            {
-                name: "displayShortName",
-                fieldName: "displayShortName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "organisationUnitLevel",
-                fieldName: "organisationUnitLevels",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.organisationunit.OrganisationUnitLevel",
-            },
-            {
-                name: "externalAccess",
-                fieldName: "externalAccess",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "output",
-                fieldName: "output",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.dataelement.DataElement",
-            },
-            {
-                name: "lastUpdated",
-                fieldName: "lastUpdated",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "sampleSkipTest",
-                fieldName: "sampleSkipTest",
-                propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.expression.Expression",
-            },
-            {
-                name: "translation",
-                fieldName: "translations",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.translation.Translation",
-            },
-            {
-                name: "formName",
-                fieldName: "formName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
-            {
-                name: "sequentialSampleCount",
-                fieldName: "sequentialSampleCount",
-                propertyType: "INTEGER",
-                klass: "java.lang.Integer",
-            },
-            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
-            {
-                name: "displayDescription",
-                fieldName: "displayDescription",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "annualSampleCount",
-                fieldName: "annualSampleCount",
-                propertyType: "INTEGER",
-                klass: "java.lang.Integer",
-            },
-            {
-                name: "lastUpdatedBy",
-                fieldName: "lastUpdatedBy",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            {
-                name: "userGroupAccess",
-                fieldName: "userGroupAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
-            },
-            {
-                name: "created",
-                fieldName: "created",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "attributeValue",
-                fieldName: "attributeValues",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
-            },
-            {
-                name: "sequentialSkipCount",
-                fieldName: "sequentialSkipCount",
-                propertyType: "INTEGER",
-                klass: "java.lang.Integer",
-            },
-            {
-                name: "predictorGroup",
-                fieldName: "groups",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.predictor.PredictorGroup",
-            },
-            {
-                name: "displayFormName",
-                fieldName: "displayFormName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "periodType",
-                fieldName: "periodType",
-                propertyType: "TEXT",
-                klass: "org.hisp.dhis.period.PeriodType",
-            },
-            {
-                name: "userAccess",
-                fieldName: "userAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserAccess",
-            },
-            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
-            {
-                name: "shortName",
-                fieldName: "shortName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "user",
-                fieldName: "user",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
-        ],
-    },
     analyticsPeriodBoundaries: {
         klass: "org.hisp.dhis.program.AnalyticsPeriodBoundary",
         shareable: false,
@@ -18602,47 +18388,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             },
         ],
     },
-    trackedEntityDataElementDimensions: {
-        klass: "org.hisp.dhis.trackedentity.TrackedEntityDataElementDimension",
-        shareable: false,
-        metadata: false,
-        plural: "trackedEntityDataElementDimensions",
-        displayName: "Tracked Entity Data Element Dimension",
-        collectionName: "trackedEntityDataElementDimensions",
-        nameableObject: false,
-        translatable: false,
-        identifiableObject: false,
-        dataShareable: false,
-        name: "dataElementDimension",
-        persisted: true,
-        embeddedObject: false,
-        properties: [
-            {
-                name: "filter",
-                fieldName: "filter",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "legendSet",
-                fieldName: "legendSet",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.legend.LegendSet",
-            },
-            {
-                name: "programStage",
-                fieldName: "programStage",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.program.ProgramStage",
-            },
-            {
-                name: "dataElement",
-                fieldName: "dataElement",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.dataelement.DataElement",
-            },
-        ],
-    },
     dataElementGroups: {
         klass: "org.hisp.dhis.dataelement.DataElementGroup",
         shareable: true,
@@ -21379,6 +21124,122 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             },
         ],
     },
+    externalFileResources: {
+        klass: "org.hisp.dhis.fileresource.ExternalFileResource",
+        shareable: false,
+        metadata: true,
+        relativeApiEndpoint: "/externalFileResources",
+        plural: "externalFileResources",
+        displayName: "External File Resource",
+        collectionName: "externalFileResources",
+        nameableObject: false,
+        translatable: false,
+        identifiableObject: true,
+        dataShareable: false,
+        name: "identifiableObject",
+        persisted: true,
+        embeddedObject: false,
+        properties: [
+            {
+                name: "favorite",
+                fieldName: "favorites",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.Set",
+                itemKlass: "java.lang.String",
+            },
+            {
+                name: "lastUpdatedBy",
+                fieldName: "lastUpdatedBy",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "access",
+                fieldName: "access",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.security.acl.Access",
+            },
+            {
+                name: "userGroupAccess",
+                fieldName: "userGroupAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
+            },
+            {
+                name: "code",
+                fieldName: "code",
+                propertyType: "IDENTIFIER",
+                klass: "java.lang.String",
+            },
+            {
+                name: "created",
+                fieldName: "created",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "displayName",
+                fieldName: "displayName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "publicAccess",
+                fieldName: "publicAccess",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "attributeValue",
+                fieldName: "attributeValues",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
+            },
+            {
+                name: "externalAccess",
+                fieldName: "externalAccess",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "lastUpdated",
+                fieldName: "lastUpdated",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "translation",
+                fieldName: "translations",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.translation.Translation",
+            },
+            {
+                name: "userAccess",
+                fieldName: "userAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserAccess",
+            },
+            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
+            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
+            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
+            {
+                name: "user",
+                fieldName: "user",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+        ],
+    },
     externalMapLayers: {
         klass: "org.hisp.dhis.mapping.ExternalMapLayer",
         shareable: true,
@@ -21538,425 +21399,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
         ],
     },
-    icons: {
-        klass: "org.hisp.dhis.icon.Icon",
-        shareable: false,
-        metadata: false,
-        relativeApiEndpoint: "/icons",
-        plural: "icons",
-        displayName: "Icon",
-        collectionName: "icons",
-        nameableObject: false,
-        translatable: false,
-        identifiableObject: false,
-        dataShareable: false,
-        name: "icon",
-        persisted: false,
-        embeddedObject: false,
-        properties: [],
-    },
-    externalFileResources: {
-        klass: "org.hisp.dhis.fileresource.ExternalFileResource",
-        shareable: false,
-        metadata: true,
-        relativeApiEndpoint: "/externalFileResources",
-        plural: "externalFileResources",
-        displayName: "External File Resource",
-        collectionName: "externalFileResources",
-        nameableObject: false,
-        translatable: false,
-        identifiableObject: true,
-        dataShareable: false,
-        name: "identifiableObject",
-        persisted: true,
-        embeddedObject: false,
-        properties: [
-            {
-                name: "favorite",
-                fieldName: "favorites",
-                propertyType: "COLLECTION",
-                itemPropertyType: "TEXT",
-                klass: "java.util.Set",
-                itemKlass: "java.lang.String",
-            },
-            {
-                name: "lastUpdatedBy",
-                fieldName: "lastUpdatedBy",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            {
-                name: "access",
-                fieldName: "access",
-                propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.security.acl.Access",
-            },
-            {
-                name: "userGroupAccess",
-                fieldName: "userGroupAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
-            },
-            {
-                name: "code",
-                fieldName: "code",
-                propertyType: "IDENTIFIER",
-                klass: "java.lang.String",
-            },
-            {
-                name: "created",
-                fieldName: "created",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "displayName",
-                fieldName: "displayName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "publicAccess",
-                fieldName: "publicAccess",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "attributeValue",
-                fieldName: "attributeValues",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
-            },
-            {
-                name: "externalAccess",
-                fieldName: "externalAccess",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "lastUpdated",
-                fieldName: "lastUpdated",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "translation",
-                fieldName: "translations",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.translation.Translation",
-            },
-            {
-                name: "userAccess",
-                fieldName: "userAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserAccess",
-            },
-            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
-            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
-            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
-            {
-                name: "user",
-                fieldName: "user",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
-        ],
-    },
-    validationNotificationTemplates: {
-        klass: "org.hisp.dhis.validation.notification.ValidationNotificationTemplate",
-        shareable: false,
-        metadata: true,
-        relativeApiEndpoint: "/validationNotificationTemplates",
-        plural: "validationNotificationTemplates",
-        displayName: "Validation Notification Template",
-        collectionName: "validationNotificationTemplates",
-        nameableObject: false,
-        translatable: false,
-        identifiableObject: true,
-        dataShareable: false,
-        name: "identifiableObject",
-        persisted: true,
-        embeddedObject: false,
-        properties: [
-            {
-                name: "favorite",
-                fieldName: "favorites",
-                propertyType: "COLLECTION",
-                itemPropertyType: "TEXT",
-                klass: "java.util.Set",
-                itemKlass: "java.lang.String",
-            },
-            {
-                name: "access",
-                fieldName: "access",
-                propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.security.acl.Access",
-            },
-            {
-                name: "code",
-                fieldName: "code",
-                propertyType: "IDENTIFIER",
-                klass: "java.lang.String",
-            },
-            {
-                name: "displayName",
-                fieldName: "displayName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "publicAccess",
-                fieldName: "publicAccess",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "recipientUserGroups",
-                fieldName: "recipientUserGroups",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserGroup",
-            },
-            {
-                name: "externalAccess",
-                fieldName: "externalAccess",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "lastUpdated",
-                fieldName: "lastUpdated",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "translation",
-                fieldName: "translations",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.translation.Translation",
-            },
-            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
-            {
-                name: "subjectTemplate",
-                fieldName: "subjectTemplate",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
-            {
-                name: "sendStrategy",
-                fieldName: "sendStrategy",
-                propertyType: "CONSTANT",
-                klass: "org.hisp.dhis.notification.SendStrategy",
-            },
-            {
-                name: "lastUpdatedBy",
-                fieldName: "lastUpdatedBy",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            {
-                name: "userGroupAccess",
-                fieldName: "userGroupAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
-            },
-            {
-                name: "validationRules",
-                fieldName: "validationRules",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.validation.ValidationRule",
-            },
-            {
-                name: "created",
-                fieldName: "created",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "notifyUsersInHierarchyOnly",
-                fieldName: "notifyUsersInHierarchyOnly",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "attributeValue",
-                fieldName: "attributeValues",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
-            },
-            {
-                name: "notifyParentOrganisationUnitOnly",
-                fieldName: "notifyParentOrganisationUnitOnly",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "userAccess",
-                fieldName: "userAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserAccess",
-            },
-            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
-            {
-                name: "user",
-                fieldName: "user",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
-            {
-                name: "messageTemplate",
-                fieldName: "messageTemplate",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-        ],
-    },
-    dataStores: {
-        klass: "org.hisp.dhis.keyjsonvalue.KeyJsonValue",
-        shareable: true,
-        metadata: false,
-        relativeApiEndpoint: "/dataStore",
-        plural: "dataStores",
-        displayName: "Key Json Value",
-        collectionName: "dataStores",
-        nameableObject: false,
-        translatable: false,
-        identifiableObject: true,
-        dataShareable: false,
-        name: "identifiableObject",
-        persisted: true,
-        embeddedObject: false,
-        properties: [
-            {
-                name: "favorite",
-                fieldName: "favorites",
-                propertyType: "COLLECTION",
-                itemPropertyType: "TEXT",
-                klass: "java.util.Set",
-                itemKlass: "java.lang.String",
-            },
-            {
-                name: "lastUpdatedBy",
-                fieldName: "lastUpdatedBy",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            {
-                name: "access",
-                fieldName: "access",
-                propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.security.acl.Access",
-            },
-            {
-                name: "userGroupAccess",
-                fieldName: "userGroupAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
-            },
-            {
-                name: "code",
-                fieldName: "code",
-                propertyType: "IDENTIFIER",
-                klass: "java.lang.String",
-            },
-            {
-                name: "created",
-                fieldName: "created",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "displayName",
-                fieldName: "displayName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "publicAccess",
-                fieldName: "publicAccess",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "attributeValue",
-                fieldName: "attributeValues",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
-            },
-            {
-                name: "externalAccess",
-                fieldName: "externalAccess",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "lastUpdated",
-                fieldName: "lastUpdated",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "translation",
-                fieldName: "translations",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.translation.Translation",
-            },
-            {
-                name: "userAccess",
-                fieldName: "userAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserAccess",
-            },
-            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
-            {
-                name: "namespace",
-                fieldName: "namespace",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
-            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
-            {
-                name: "user",
-                fieldName: "user",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            { name: "value", fieldName: "value", propertyType: "TEXT", klass: "java.lang.String" },
-            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
-            { name: "key", fieldName: "key", propertyType: "TEXT", klass: "java.lang.String" },
-        ],
-    },
     fileResources: {
         klass: "org.hisp.dhis.fileresource.FileResource",
         shareable: false,
@@ -22108,6 +21550,23 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             },
             { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
         ],
+    },
+    icons: {
+        klass: "org.hisp.dhis.icon.Icon",
+        shareable: false,
+        metadata: false,
+        relativeApiEndpoint: "/icons",
+        plural: "icons",
+        displayName: "Icon",
+        collectionName: "icons",
+        nameableObject: false,
+        translatable: false,
+        identifiableObject: false,
+        dataShareable: false,
+        name: "icon",
+        persisted: false,
+        embeddedObject: false,
+        properties: [],
     },
     indicators: {
         klass: "org.hisp.dhis.indicator.Indicator",
@@ -23292,6 +22751,130 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 propertyType: "TEXT",
                 klass: "java.lang.String",
             },
+        ],
+    },
+    dataStores: {
+        klass: "org.hisp.dhis.keyjsonvalue.KeyJsonValue",
+        shareable: true,
+        metadata: false,
+        relativeApiEndpoint: "/dataStore",
+        plural: "dataStores",
+        displayName: "Key Json Value",
+        collectionName: "dataStores",
+        nameableObject: false,
+        translatable: false,
+        identifiableObject: true,
+        dataShareable: false,
+        name: "identifiableObject",
+        persisted: true,
+        embeddedObject: false,
+        properties: [
+            {
+                name: "favorite",
+                fieldName: "favorites",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.Set",
+                itemKlass: "java.lang.String",
+            },
+            {
+                name: "lastUpdatedBy",
+                fieldName: "lastUpdatedBy",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "access",
+                fieldName: "access",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.security.acl.Access",
+            },
+            {
+                name: "userGroupAccess",
+                fieldName: "userGroupAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
+            },
+            {
+                name: "code",
+                fieldName: "code",
+                propertyType: "IDENTIFIER",
+                klass: "java.lang.String",
+            },
+            {
+                name: "created",
+                fieldName: "created",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "displayName",
+                fieldName: "displayName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "publicAccess",
+                fieldName: "publicAccess",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "attributeValue",
+                fieldName: "attributeValues",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
+            },
+            {
+                name: "externalAccess",
+                fieldName: "externalAccess",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "lastUpdated",
+                fieldName: "lastUpdated",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "translation",
+                fieldName: "translations",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.translation.Translation",
+            },
+            {
+                name: "userAccess",
+                fieldName: "userAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserAccess",
+            },
+            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
+            {
+                name: "namespace",
+                fieldName: "namespace",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
+            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
+            {
+                name: "user",
+                fieldName: "user",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            { name: "value", fieldName: "value", propertyType: "TEXT", klass: "java.lang.String" },
+            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+            { name: "key", fieldName: "key", propertyType: "TEXT", klass: "java.lang.String" },
         ],
     },
     legends: {
@@ -26513,6 +26096,222 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
         ],
     },
+    predictors: {
+        klass: "org.hisp.dhis.predictor.Predictor",
+        shareable: false,
+        metadata: true,
+        relativeApiEndpoint: "/predictors",
+        plural: "predictors",
+        displayName: "Predictor",
+        collectionName: "predictors",
+        nameableObject: true,
+        translatable: false,
+        identifiableObject: true,
+        dataShareable: false,
+        name: "Predictor",
+        persisted: true,
+        embeddedObject: false,
+        properties: [
+            {
+                name: "favorite",
+                fieldName: "favorites",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.Set",
+                itemKlass: "java.lang.String",
+            },
+            {
+                name: "outputCombo",
+                fieldName: "outputCombo",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.category.CategoryOptionCombo",
+            },
+            {
+                name: "code",
+                fieldName: "code",
+                propertyType: "IDENTIFIER",
+                klass: "java.lang.String",
+            },
+            {
+                name: "access",
+                fieldName: "access",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.security.acl.Access",
+            },
+            {
+                name: "displayName",
+                fieldName: "displayName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "publicAccess",
+                fieldName: "publicAccess",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "description",
+                fieldName: "description",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "generator",
+                fieldName: "generator",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.expression.Expression",
+            },
+            {
+                name: "displayShortName",
+                fieldName: "displayShortName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "organisationUnitLevel",
+                fieldName: "organisationUnitLevels",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.organisationunit.OrganisationUnitLevel",
+            },
+            {
+                name: "externalAccess",
+                fieldName: "externalAccess",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "output",
+                fieldName: "output",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.dataelement.DataElement",
+            },
+            {
+                name: "lastUpdated",
+                fieldName: "lastUpdated",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "sampleSkipTest",
+                fieldName: "sampleSkipTest",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.expression.Expression",
+            },
+            {
+                name: "translation",
+                fieldName: "translations",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.translation.Translation",
+            },
+            {
+                name: "formName",
+                fieldName: "formName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
+            {
+                name: "sequentialSampleCount",
+                fieldName: "sequentialSampleCount",
+                propertyType: "INTEGER",
+                klass: "java.lang.Integer",
+            },
+            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
+            {
+                name: "displayDescription",
+                fieldName: "displayDescription",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "annualSampleCount",
+                fieldName: "annualSampleCount",
+                propertyType: "INTEGER",
+                klass: "java.lang.Integer",
+            },
+            {
+                name: "lastUpdatedBy",
+                fieldName: "lastUpdatedBy",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "userGroupAccess",
+                fieldName: "userGroupAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
+            },
+            {
+                name: "created",
+                fieldName: "created",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "attributeValue",
+                fieldName: "attributeValues",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
+            },
+            {
+                name: "sequentialSkipCount",
+                fieldName: "sequentialSkipCount",
+                propertyType: "INTEGER",
+                klass: "java.lang.Integer",
+            },
+            {
+                name: "predictorGroup",
+                fieldName: "groups",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.predictor.PredictorGroup",
+            },
+            {
+                name: "displayFormName",
+                fieldName: "displayFormName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "periodType",
+                fieldName: "periodType",
+                propertyType: "TEXT",
+                klass: "org.hisp.dhis.period.PeriodType",
+            },
+            {
+                name: "userAccess",
+                fieldName: "userAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserAccess",
+            },
+            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
+            {
+                name: "shortName",
+                fieldName: "shortName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "user",
+                fieldName: "user",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+        ],
+    },
     predictorGroups: {
         klass: "org.hisp.dhis.predictor.PredictorGroup",
         shareable: true,
@@ -27005,195 +26804,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             },
         ],
     },
-    ProgramTrackedEntityAttributeDimensionItems: {
-        klass: "org.hisp.dhis.program.ProgramTrackedEntityAttributeDimensionItem",
-        shareable: false,
-        metadata: false,
-        plural: "ProgramTrackedEntityAttributeDimensionItems",
-        displayName: "Program Tracked Entity Attribute Dimension Item",
-        collectionName: "ProgramTrackedEntityAttributeDimensionItems",
-        nameableObject: true,
-        translatable: false,
-        identifiableObject: true,
-        dataShareable: false,
-        name: "programAttributeDimension",
-        persisted: false,
-        embeddedObject: true,
-        properties: [
-            {
-                name: "favorite",
-                fieldName: "favorites",
-                propertyType: "COLLECTION",
-                itemPropertyType: "TEXT",
-                klass: "java.util.Set",
-                itemKlass: "java.lang.String",
-            },
-            {
-                name: "aggregationType",
-                fieldName: "aggregationType",
-                propertyType: "CONSTANT",
-                klass: "org.hisp.dhis.analytics.AggregationType",
-            },
-            {
-                name: "code",
-                fieldName: "code",
-                propertyType: "IDENTIFIER",
-                klass: "java.lang.String",
-            },
-            {
-                name: "access",
-                fieldName: "access",
-                propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.security.acl.Access",
-            },
-            {
-                name: "displayName",
-                fieldName: "displayName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "publicAccess",
-                fieldName: "publicAccess",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "description",
-                fieldName: "description",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "program",
-                fieldName: "program",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.program.Program",
-            },
-            {
-                name: "displayShortName",
-                fieldName: "displayShortName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "externalAccess",
-                fieldName: "externalAccess",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "lastUpdated",
-                fieldName: "lastUpdated",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "translation",
-                fieldName: "translations",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.translation.Translation",
-            },
-            {
-                name: "formName",
-                fieldName: "formName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
-            {
-                name: "attribute",
-                fieldName: "attribute",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.trackedentity.TrackedEntityAttribute",
-            },
-            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
-            {
-                name: "displayDescription",
-                fieldName: "displayDescription",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "lastUpdatedBy",
-                fieldName: "lastUpdatedBy",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            {
-                name: "userGroupAccess",
-                fieldName: "userGroupAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
-            },
-            { name: "dimensionItem", propertyType: "TEXT", klass: "java.lang.String" },
-            {
-                name: "created",
-                fieldName: "created",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "attributeValue",
-                fieldName: "attributeValues",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
-            },
-            {
-                name: "displayFormName",
-                fieldName: "displayFormName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "userAccess",
-                fieldName: "userAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserAccess",
-            },
-            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
-            {
-                name: "legendSet",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.legend.LegendSet",
-            },
-            {
-                name: "legendSets",
-                fieldName: "legendSets",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.List",
-                itemKlass: "org.hisp.dhis.legend.LegendSet",
-            },
-            {
-                name: "shortName",
-                fieldName: "shortName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "user",
-                fieldName: "user",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
-            {
-                name: "dimensionItemType",
-                fieldName: "dimensionItemType",
-                propertyType: "CONSTANT",
-                klass: "org.hisp.dhis.common.DimensionItemType",
-            },
-        ],
-    },
     programDataElements: {
         klass: "org.hisp.dhis.program.ProgramDataElementDimensionItem",
         shareable: false,
@@ -27634,41 +27244,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 fieldName: "dimensionItemType",
                 propertyType: "CONSTANT",
                 klass: "org.hisp.dhis.common.DimensionItemType",
-            },
-        ],
-    },
-    dataElementDimensions: {
-        klass: "org.hisp.dhis.trackedentity.TrackedEntityProgramIndicatorDimension",
-        shareable: false,
-        metadata: false,
-        plural: "dataElementDimensions",
-        displayName: "Tracked Entity Program Indicator Dimension",
-        collectionName: "dataElementDimensions",
-        nameableObject: false,
-        translatable: false,
-        identifiableObject: false,
-        dataShareable: false,
-        name: "programIndicatorDimension",
-        persisted: true,
-        embeddedObject: false,
-        properties: [
-            {
-                name: "filter",
-                fieldName: "filter",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "legendSet",
-                fieldName: "legendSet",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.legend.LegendSet",
-            },
-            {
-                name: "programIndicator",
-                fieldName: "programIndicator",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.program.ProgramIndicator",
             },
         ],
     },
@@ -29407,6 +28982,246 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
         ],
     },
+    programStageInstances: {
+        klass: "org.hisp.dhis.program.ProgramStageInstance",
+        shareable: false,
+        metadata: false,
+        relativeApiEndpoint: "/programStageInstances",
+        plural: "programStageInstances",
+        displayName: "Program Stage Instance",
+        collectionName: "programStageInstances",
+        nameableObject: false,
+        translatable: false,
+        identifiableObject: true,
+        dataShareable: false,
+        name: "softDeletableObject",
+        persisted: true,
+        embeddedObject: false,
+        properties: [
+            {
+                name: "favorite",
+                fieldName: "favorites",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.Set",
+                itemKlass: "java.lang.String",
+            },
+            {
+                name: "code",
+                fieldName: "code",
+                propertyType: "IDENTIFIER",
+                klass: "java.lang.String",
+            },
+            {
+                name: "storedBy",
+                fieldName: "storedBy",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "access",
+                fieldName: "access",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.security.acl.Access",
+            },
+            {
+                name: "organisationUnit",
+                fieldName: "organisationUnit",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.organisationunit.OrganisationUnit",
+            },
+            {
+                name: "displayName",
+                fieldName: "displayName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "publicAccess",
+                fieldName: "publicAccess",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "dueDate",
+                fieldName: "dueDate",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "createdAtClient",
+                fieldName: "createdAtClient",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "messageConversations",
+                fieldName: "messageConversations",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.message.MessageConversation",
+            },
+            {
+                name: "externalAccess",
+                fieldName: "externalAccess",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "lastUpdated",
+                fieldName: "lastUpdated",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "eventDataValues",
+                fieldName: "eventDataValues",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.eventdatavalue.EventDataValue",
+            },
+            {
+                name: "translation",
+                fieldName: "translations",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.translation.Translation",
+            },
+            {
+                name: "relationshipItem",
+                fieldName: "relationshipItems",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.relationship.RelationshipItem",
+            },
+            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
+            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
+            {
+                name: "assignedUser",
+                fieldName: "assignedUser",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "lastUpdatedBy",
+                fieldName: "lastUpdatedBy",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "programStage",
+                fieldName: "programStage",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.program.ProgramStage",
+            },
+            {
+                name: "userGroupAccess",
+                fieldName: "userGroupAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
+            },
+            {
+                name: "comments",
+                fieldName: "comments",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.trackedentitycomment.TrackedEntityComment",
+            },
+            {
+                name: "created",
+                fieldName: "created",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            { name: "creatableInSearchScope", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+            {
+                name: "attributeValue",
+                fieldName: "attributeValues",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
+            },
+            { name: "completed", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+            {
+                name: "completedDate",
+                fieldName: "completedDate",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "programInstance",
+                fieldName: "programInstance",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.program.ProgramInstance",
+            },
+            {
+                name: "deleted",
+                fieldName: "deleted",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "userAccess",
+                fieldName: "userAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserAccess",
+            },
+            {
+                name: "attributeOptionCombo",
+                fieldName: "attributeOptionCombo",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.category.CategoryOptionCombo",
+            },
+            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
+            {
+                name: "geometry",
+                fieldName: "geometry",
+                propertyType: "COMPLEX",
+                klass: "com.vividsolutions.jts.geom.Geometry",
+            },
+            {
+                name: "user",
+                fieldName: "user",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+            {
+                name: "completedBy",
+                fieldName: "completedBy",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "status",
+                fieldName: "status",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.event.EventStatus",
+            },
+            {
+                name: "lastUpdatedAtClient",
+                fieldName: "lastUpdatedAtClient",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "eventDate",
+                fieldName: "executionDate",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+        ],
+    },
     eventFilters: {
         klass: "org.hisp.dhis.programstagefilter.ProgramStageInstanceFilter",
         shareable: true,
@@ -29920,6 +29735,195 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "org.hisp.dhis.user.User",
             },
             { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+        ],
+    },
+    ProgramTrackedEntityAttributeDimensionItems: {
+        klass: "org.hisp.dhis.program.ProgramTrackedEntityAttributeDimensionItem",
+        shareable: false,
+        metadata: false,
+        plural: "ProgramTrackedEntityAttributeDimensionItems",
+        displayName: "Program Tracked Entity Attribute Dimension Item",
+        collectionName: "ProgramTrackedEntityAttributeDimensionItems",
+        nameableObject: true,
+        translatable: false,
+        identifiableObject: true,
+        dataShareable: false,
+        name: "programAttributeDimension",
+        persisted: false,
+        embeddedObject: true,
+        properties: [
+            {
+                name: "favorite",
+                fieldName: "favorites",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.Set",
+                itemKlass: "java.lang.String",
+            },
+            {
+                name: "aggregationType",
+                fieldName: "aggregationType",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.analytics.AggregationType",
+            },
+            {
+                name: "code",
+                fieldName: "code",
+                propertyType: "IDENTIFIER",
+                klass: "java.lang.String",
+            },
+            {
+                name: "access",
+                fieldName: "access",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.security.acl.Access",
+            },
+            {
+                name: "displayName",
+                fieldName: "displayName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "publicAccess",
+                fieldName: "publicAccess",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "description",
+                fieldName: "description",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "program",
+                fieldName: "program",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.program.Program",
+            },
+            {
+                name: "displayShortName",
+                fieldName: "displayShortName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "externalAccess",
+                fieldName: "externalAccess",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "lastUpdated",
+                fieldName: "lastUpdated",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "translation",
+                fieldName: "translations",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.translation.Translation",
+            },
+            {
+                name: "formName",
+                fieldName: "formName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
+            {
+                name: "attribute",
+                fieldName: "attribute",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.trackedentity.TrackedEntityAttribute",
+            },
+            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
+            {
+                name: "displayDescription",
+                fieldName: "displayDescription",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "lastUpdatedBy",
+                fieldName: "lastUpdatedBy",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "userGroupAccess",
+                fieldName: "userGroupAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
+            },
+            { name: "dimensionItem", propertyType: "TEXT", klass: "java.lang.String" },
+            {
+                name: "created",
+                fieldName: "created",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "attributeValue",
+                fieldName: "attributeValues",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
+            },
+            {
+                name: "displayFormName",
+                fieldName: "displayFormName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "userAccess",
+                fieldName: "userAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserAccess",
+            },
+            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
+            {
+                name: "legendSet",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.legend.LegendSet",
+            },
+            {
+                name: "legendSets",
+                fieldName: "legendSets",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.legend.LegendSet",
+            },
+            {
+                name: "shortName",
+                fieldName: "shortName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "user",
+                fieldName: "user",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+            {
+                name: "dimensionItemType",
+                fieldName: "dimensionItemType",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.common.DimensionItemType",
+            },
         ],
     },
     programTrackedEntityAttributeGroups: {
@@ -31441,183 +31445,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             },
         ],
     },
-    sections: {
-        klass: "org.hisp.dhis.dataset.Section",
-        shareable: false,
-        metadata: true,
-        relativeApiEndpoint: "/sections",
-        plural: "sections",
-        displayName: "Section",
-        collectionName: "sections",
-        nameableObject: false,
-        translatable: true,
-        identifiableObject: true,
-        dataShareable: false,
-        name: "section",
-        persisted: true,
-        embeddedObject: false,
-        properties: [
-            {
-                name: "favorite",
-                fieldName: "favorites",
-                propertyType: "COLLECTION",
-                itemPropertyType: "TEXT",
-                klass: "java.util.Set",
-                itemKlass: "java.lang.String",
-            },
-            {
-                name: "code",
-                fieldName: "code",
-                propertyType: "IDENTIFIER",
-                klass: "java.lang.String",
-            },
-            {
-                name: "access",
-                fieldName: "access",
-                propertyType: "COMPLEX",
-                klass: "org.hisp.dhis.security.acl.Access",
-            },
-            {
-                name: "greyedField",
-                fieldName: "greyedFields",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.dataelement.DataElementOperand",
-            },
-            {
-                name: "displayName",
-                fieldName: "displayName",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "publicAccess",
-                fieldName: "publicAccess",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "description",
-                fieldName: "description",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "externalAccess",
-                fieldName: "externalAccess",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "lastUpdated",
-                fieldName: "lastUpdated",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "translation",
-                fieldName: "translations",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.translation.Translation",
-            },
-            {
-                name: "categoryCombos",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.category.CategoryCombo",
-            },
-            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
-            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
-            {
-                name: "dataSet",
-                fieldName: "dataSet",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.dataset.DataSet",
-            },
-            {
-                name: "dataElement",
-                fieldName: "dataElements",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.List",
-                itemKlass: "org.hisp.dhis.dataelement.DataElement",
-            },
-            {
-                name: "showColumnTotals",
-                fieldName: "showColumnTotals",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            {
-                name: "lastUpdatedBy",
-                fieldName: "lastUpdatedBy",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            {
-                name: "userGroupAccess",
-                fieldName: "userGroupAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
-            },
-            {
-                name: "created",
-                fieldName: "created",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "attributeValue",
-                fieldName: "attributeValues",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
-            },
-            {
-                name: "indicator",
-                fieldName: "indicators",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.List",
-                itemKlass: "org.hisp.dhis.indicator.Indicator",
-            },
-            {
-                name: "sortOrder",
-                fieldName: "sortOrder",
-                propertyType: "INTEGER",
-                klass: "java.lang.Integer",
-            },
-            {
-                name: "userAccess",
-                fieldName: "userAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserAccess",
-            },
-            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
-            {
-                name: "user",
-                fieldName: "user",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            {
-                name: "showRowTotals",
-                fieldName: "showRowTotals",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
-            },
-            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
-        ],
-    },
     smsCommands: {
         klass: "org.hisp.dhis.sms.command.SMSCommand",
         shareable: false,
@@ -31840,19 +31667,19 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
         ],
     },
-    programStageInstances: {
-        klass: "org.hisp.dhis.program.ProgramStageInstance",
+    sections: {
+        klass: "org.hisp.dhis.dataset.Section",
         shareable: false,
-        metadata: false,
-        relativeApiEndpoint: "/programStageInstances",
-        plural: "programStageInstances",
-        displayName: "Program Stage Instance",
-        collectionName: "programStageInstances",
+        metadata: true,
+        relativeApiEndpoint: "/sections",
+        plural: "sections",
+        displayName: "Section",
+        collectionName: "sections",
         nameableObject: false,
-        translatable: false,
+        translatable: true,
         identifiableObject: true,
         dataShareable: false,
-        name: "softDeletableObject",
+        name: "section",
         persisted: true,
         embeddedObject: false,
         properties: [
@@ -31871,22 +31698,18 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "java.lang.String",
             },
             {
-                name: "storedBy",
-                fieldName: "storedBy",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
                 name: "access",
                 fieldName: "access",
                 propertyType: "COMPLEX",
                 klass: "org.hisp.dhis.security.acl.Access",
             },
             {
-                name: "organisationUnit",
-                fieldName: "organisationUnit",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.organisationunit.OrganisationUnit",
+                name: "greyedField",
+                fieldName: "greyedFields",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.dataelement.DataElementOperand",
             },
             {
                 name: "displayName",
@@ -31901,24 +31724,10 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "java.lang.String",
             },
             {
-                name: "dueDate",
-                fieldName: "dueDate",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "createdAtClient",
-                fieldName: "createdAtClient",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "messageConversations",
-                fieldName: "messageConversations",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.List",
-                itemKlass: "org.hisp.dhis.message.MessageConversation",
+                name: "description",
+                fieldName: "description",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
             },
             {
                 name: "externalAccess",
@@ -31933,14 +31742,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "java.util.Date",
             },
             {
-                name: "eventDataValues",
-                fieldName: "eventDataValues",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.eventdatavalue.EventDataValue",
-            },
-            {
                 name: "translation",
                 fieldName: "translations",
                 propertyType: "COLLECTION",
@@ -31949,32 +31750,39 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 itemKlass: "org.hisp.dhis.translation.Translation",
             },
             {
-                name: "relationshipItem",
-                fieldName: "relationshipItems",
+                name: "categoryCombos",
                 propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
+                itemPropertyType: "REFERENCE",
                 klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.relationship.RelationshipItem",
+                itemKlass: "org.hisp.dhis.category.CategoryCombo",
             },
             { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
             { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
             {
-                name: "assignedUser",
-                fieldName: "assignedUser",
+                name: "dataSet",
+                fieldName: "dataSet",
                 propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
+                klass: "org.hisp.dhis.dataset.DataSet",
+            },
+            {
+                name: "dataElement",
+                fieldName: "dataElements",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.dataelement.DataElement",
+            },
+            {
+                name: "showColumnTotals",
+                fieldName: "showColumnTotals",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
             },
             {
                 name: "lastUpdatedBy",
                 fieldName: "lastUpdatedBy",
                 propertyType: "REFERENCE",
                 klass: "org.hisp.dhis.user.User",
-            },
-            {
-                name: "programStage",
-                fieldName: "programStage",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.program.ProgramStage",
             },
             {
                 name: "userGroupAccess",
@@ -31985,20 +31793,11 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 itemKlass: "org.hisp.dhis.user.UserGroupAccess",
             },
             {
-                name: "comments",
-                fieldName: "comments",
-                propertyType: "COLLECTION",
-                itemPropertyType: "REFERENCE",
-                klass: "java.util.List",
-                itemKlass: "org.hisp.dhis.trackedentitycomment.TrackedEntityComment",
-            },
-            {
                 name: "created",
                 fieldName: "created",
                 propertyType: "DATE",
                 klass: "java.util.Date",
             },
-            { name: "creatableInSearchScope", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
             {
                 name: "attributeValue",
                 fieldName: "attributeValues",
@@ -32007,24 +31806,19 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "java.util.Set",
                 itemKlass: "org.hisp.dhis.attribute.AttributeValue",
             },
-            { name: "completed", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
             {
-                name: "completedDate",
-                fieldName: "completedDate",
-                propertyType: "DATE",
-                klass: "java.util.Date",
+                name: "indicator",
+                fieldName: "indicators",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.indicator.Indicator",
             },
             {
-                name: "programInstance",
-                fieldName: "programInstance",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.program.ProgramInstance",
-            },
-            {
-                name: "deleted",
-                fieldName: "deleted",
-                propertyType: "BOOLEAN",
-                klass: "java.lang.Boolean",
+                name: "sortOrder",
+                fieldName: "sortOrder",
+                propertyType: "INTEGER",
+                klass: "java.lang.Integer",
             },
             {
                 name: "userAccess",
@@ -32034,50 +31828,20 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "java.util.Set",
                 itemKlass: "org.hisp.dhis.user.UserAccess",
             },
-            {
-                name: "attributeOptionCombo",
-                fieldName: "attributeOptionCombo",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.category.CategoryOptionCombo",
-            },
             { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
-            {
-                name: "geometry",
-                fieldName: "geometry",
-                propertyType: "COMPLEX",
-                klass: "com.vividsolutions.jts.geom.Geometry",
-            },
             {
                 name: "user",
                 fieldName: "user",
                 propertyType: "REFERENCE",
                 klass: "org.hisp.dhis.user.User",
             },
+            {
+                name: "showRowTotals",
+                fieldName: "showRowTotals",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
             { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
-            {
-                name: "completedBy",
-                fieldName: "completedBy",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "status",
-                fieldName: "status",
-                propertyType: "CONSTANT",
-                klass: "org.hisp.dhis.event.EventStatus",
-            },
-            {
-                name: "lastUpdatedAtClient",
-                fieldName: "lastUpdatedAtClient",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
-            {
-                name: "eventDate",
-                fieldName: "executionDate",
-                propertyType: "DATE",
-                klass: "java.util.Date",
-            },
         ],
     },
     sqlViews: {
@@ -32544,6 +32308,47 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             },
         ],
     },
+    trackedEntityDataElementDimensions: {
+        klass: "org.hisp.dhis.trackedentity.TrackedEntityDataElementDimension",
+        shareable: false,
+        metadata: false,
+        plural: "trackedEntityDataElementDimensions",
+        displayName: "Tracked Entity Data Element Dimension",
+        collectionName: "trackedEntityDataElementDimensions",
+        nameableObject: false,
+        translatable: false,
+        identifiableObject: false,
+        dataShareable: false,
+        name: "dataElementDimension",
+        persisted: true,
+        embeddedObject: false,
+        properties: [
+            {
+                name: "filter",
+                fieldName: "filter",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "legendSet",
+                fieldName: "legendSet",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.legend.LegendSet",
+            },
+            {
+                name: "programStage",
+                fieldName: "programStage",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.program.ProgramStage",
+            },
+            {
+                name: "dataElement",
+                fieldName: "dataElement",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.dataelement.DataElement",
+            },
+        ],
+    },
     trackedEntityInstances: {
         klass: "org.hisp.dhis.trackedentity.TrackedEntityInstance",
         shareable: false,
@@ -32897,6 +32702,41 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "org.hisp.dhis.user.User",
             },
             { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+        ],
+    },
+    dataElementDimensions: {
+        klass: "org.hisp.dhis.trackedentity.TrackedEntityProgramIndicatorDimension",
+        shareable: false,
+        metadata: false,
+        plural: "dataElementDimensions",
+        displayName: "Tracked Entity Program Indicator Dimension",
+        collectionName: "dataElementDimensions",
+        nameableObject: false,
+        translatable: false,
+        identifiableObject: false,
+        dataShareable: false,
+        name: "programIndicatorDimension",
+        persisted: true,
+        embeddedObject: false,
+        properties: [
+            {
+                name: "filter",
+                fieldName: "filter",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "legendSet",
+                fieldName: "legendSet",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.legend.LegendSet",
+            },
+            {
+                name: "programIndicator",
+                fieldName: "programIndicator",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.program.ProgramIndicator",
+            },
         ],
     },
     trackedEntityTypes: {
@@ -33536,6 +33376,143 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             { name: "userUid", propertyType: "TEXT", klass: "java.lang.String" },
         ],
     },
+    userRoles: {
+        klass: "org.hisp.dhis.user.UserAuthorityGroup",
+        shareable: true,
+        metadata: true,
+        relativeApiEndpoint: "/userRoles",
+        plural: "userRoles",
+        displayName: "User Authority Group",
+        collectionName: "userRoles",
+        nameableObject: false,
+        translatable: true,
+        identifiableObject: true,
+        dataShareable: false,
+        name: "userRole",
+        persisted: true,
+        embeddedObject: false,
+        properties: [
+            {
+                name: "favorite",
+                fieldName: "favorites",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.Set",
+                itemKlass: "java.lang.String",
+            },
+            {
+                name: "lastUpdatedBy",
+                fieldName: "lastUpdatedBy",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "access",
+                fieldName: "access",
+                propertyType: "COMPLEX",
+                klass: "org.hisp.dhis.security.acl.Access",
+            },
+            {
+                name: "userGroupAccess",
+                fieldName: "userGroupAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
+            },
+            {
+                name: "code",
+                fieldName: "code",
+                propertyType: "IDENTIFIER",
+                klass: "java.lang.String",
+            },
+            {
+                name: "created",
+                fieldName: "created",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "displayName",
+                fieldName: "displayName",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "publicAccess",
+                fieldName: "publicAccess",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "attributeValue",
+                fieldName: "attributeValues",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
+            },
+            {
+                name: "description",
+                fieldName: "description",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            {
+                name: "authority",
+                fieldName: "authorities",
+                propertyType: "COLLECTION",
+                itemPropertyType: "TEXT",
+                klass: "java.util.Set",
+                itemKlass: "java.lang.String",
+            },
+            {
+                name: "userObject",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.List",
+                itemKlass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "externalAccess",
+                fieldName: "externalAccess",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "lastUpdated",
+                fieldName: "lastUpdated",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "translation",
+                fieldName: "translations",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.translation.Translation",
+            },
+            {
+                name: "userAccess",
+                fieldName: "userAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserAccess",
+            },
+            { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
+            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
+            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
+            {
+                name: "user",
+                fieldName: "user",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+        ],
+    },
     userCredentials: {
         klass: "org.hisp.dhis.user.UserCredentials",
         shareable: false,
@@ -33913,19 +33890,19 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             { name: "displayName", propertyType: "TEXT", klass: "java.lang.String" },
         ],
     },
-    userRoles: {
-        klass: "org.hisp.dhis.user.UserAuthorityGroup",
-        shareable: true,
+    validationNotificationTemplates: {
+        klass: "org.hisp.dhis.validation.notification.ValidationNotificationTemplate",
+        shareable: false,
         metadata: true,
-        relativeApiEndpoint: "/userRoles",
-        plural: "userRoles",
-        displayName: "User Authority Group",
-        collectionName: "userRoles",
+        relativeApiEndpoint: "/validationNotificationTemplates",
+        plural: "validationNotificationTemplates",
+        displayName: "Validation Notification Template",
+        collectionName: "validationNotificationTemplates",
         nameableObject: false,
-        translatable: true,
+        translatable: false,
         identifiableObject: true,
         dataShareable: false,
-        name: "userRole",
+        name: "identifiableObject",
         persisted: true,
         embeddedObject: false,
         properties: [
@@ -33938,36 +33915,16 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 itemKlass: "java.lang.String",
             },
             {
-                name: "lastUpdatedBy",
-                fieldName: "lastUpdatedBy",
-                propertyType: "REFERENCE",
-                klass: "org.hisp.dhis.user.User",
-            },
-            {
                 name: "access",
                 fieldName: "access",
                 propertyType: "COMPLEX",
                 klass: "org.hisp.dhis.security.acl.Access",
             },
             {
-                name: "userGroupAccess",
-                fieldName: "userGroupAccesses",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
-            },
-            {
                 name: "code",
                 fieldName: "code",
                 propertyType: "IDENTIFIER",
                 klass: "java.lang.String",
-            },
-            {
-                name: "created",
-                fieldName: "created",
-                propertyType: "DATE",
-                klass: "java.util.Date",
             },
             {
                 name: "displayName",
@@ -33982,33 +33939,12 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "java.lang.String",
             },
             {
-                name: "attributeValue",
-                fieldName: "attributeValues",
-                propertyType: "COLLECTION",
-                itemPropertyType: "COMPLEX",
-                klass: "java.util.Set",
-                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
-            },
-            {
-                name: "description",
-                fieldName: "description",
-                propertyType: "TEXT",
-                klass: "java.lang.String",
-            },
-            {
-                name: "authority",
-                fieldName: "authorities",
-                propertyType: "COLLECTION",
-                itemPropertyType: "TEXT",
-                klass: "java.util.Set",
-                itemKlass: "java.lang.String",
-            },
-            {
-                name: "userObject",
+                name: "recipientUserGroups",
+                fieldName: "recipientUserGroups",
                 propertyType: "COLLECTION",
                 itemPropertyType: "REFERENCE",
-                klass: "java.util.List",
-                itemKlass: "org.hisp.dhis.user.User",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserGroup",
             },
             {
                 name: "externalAccess",
@@ -34030,6 +33966,68 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "java.util.Set",
                 itemKlass: "org.hisp.dhis.translation.Translation",
             },
+            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
+            {
+                name: "subjectTemplate",
+                fieldName: "subjectTemplate",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
+            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
+            {
+                name: "sendStrategy",
+                fieldName: "sendStrategy",
+                propertyType: "CONSTANT",
+                klass: "org.hisp.dhis.notification.SendStrategy",
+            },
+            {
+                name: "lastUpdatedBy",
+                fieldName: "lastUpdatedBy",
+                propertyType: "REFERENCE",
+                klass: "org.hisp.dhis.user.User",
+            },
+            {
+                name: "userGroupAccess",
+                fieldName: "userGroupAccesses",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.user.UserGroupAccess",
+            },
+            {
+                name: "validationRules",
+                fieldName: "validationRules",
+                propertyType: "COLLECTION",
+                itemPropertyType: "REFERENCE",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.validation.ValidationRule",
+            },
+            {
+                name: "created",
+                fieldName: "created",
+                propertyType: "DATE",
+                klass: "java.util.Date",
+            },
+            {
+                name: "notifyUsersInHierarchyOnly",
+                fieldName: "notifyUsersInHierarchyOnly",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "attributeValue",
+                fieldName: "attributeValues",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.attribute.AttributeValue",
+            },
+            {
+                name: "notifyParentOrganisationUnitOnly",
+                fieldName: "notifyParentOrganisationUnitOnly",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
             {
                 name: "userAccess",
                 fieldName: "userAccesses",
@@ -34039,8 +34037,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 itemKlass: "org.hisp.dhis.user.UserAccess",
             },
             { name: "name", fieldName: "name", propertyType: "TEXT", klass: "java.lang.String" },
-            { name: "href", fieldName: "href", propertyType: "URL", klass: "java.lang.String" },
-            { name: "id", fieldName: "uid", propertyType: "IDENTIFIER", klass: "java.lang.String" },
             {
                 name: "user",
                 fieldName: "user",
@@ -34048,6 +34044,12 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "org.hisp.dhis.user.User",
             },
             { name: "favorite", propertyType: "BOOLEAN", klass: "java.lang.Boolean" },
+            {
+                name: "messageTemplate",
+                fieldName: "messageTemplate",
+                propertyType: "TEXT",
+                klass: "java.lang.String",
+            },
         ],
     },
     validationResults: {
@@ -35178,7 +35180,6 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
 };
 
 export type D2ModelSchemas = {
-    predictors: D2PredictorSchema;
     analyticsPeriodBoundaries: D2AnalyticsPeriodBoundarySchema;
     analyticsTableHooks: D2AnalyticsTableHookSchema;
     attributes: D2AttributeSchema;
@@ -35199,7 +35200,6 @@ export type D2ModelSchemas = {
     dataApprovalLevels: D2DataApprovalLevelSchema;
     dataApprovalWorkflows: D2DataApprovalWorkflowSchema;
     dataElements: D2DataElementSchema;
-    trackedEntityDataElementDimensions: D2TrackedEntityDataElementDimensionSchema;
     dataElementGroups: D2DataElementGroupSchema;
     dataElementGroupSets: D2DataElementGroupSetSchema;
     dataElementGroupSetDimensions: D2DataElementGroupSetDimensionSchema;
@@ -35213,12 +35213,10 @@ export type D2ModelSchemas = {
     eventCharts: D2EventChartSchema;
     eventReports: D2EventReportSchema;
     expressions: D2ExpressionSchema;
-    externalMapLayers: D2ExternalMapLayerSchema;
-    icons: D2IconSchema;
     externalFileResources: D2ExternalFileResourceSchema;
-    validationNotificationTemplates: D2ValidationNotificationTemplateSchema;
-    dataStores: D2KeyJsonValueSchema;
+    externalMapLayers: D2ExternalMapLayerSchema;
     fileResources: D2FileResourceSchema;
+    icons: D2IconSchema;
     indicators: D2IndicatorSchema;
     indicatorGroups: D2IndicatorGroupSchema;
     indicatorGroupSets: D2IndicatorGroupSetSchema;
@@ -35226,6 +35224,7 @@ export type D2ModelSchemas = {
     interpretations: D2InterpretationSchema;
     interpretationComments: D2InterpretationCommentSchema;
     jobConfigurations: D2JobConfigurationSchema;
+    dataStores: D2KeyJsonValueSchema;
     legends: D2LegendSchema;
     legendSets: D2LegendSetSchema;
     maps: D2MapSchema;
@@ -35243,12 +35242,11 @@ export type D2ModelSchemas = {
     organisationUnitGroupSets: D2OrganisationUnitGroupSetSchema;
     organisationUnitGroupSetDimensions: D2OrganisationUnitGroupSetDimensionSchema;
     organisationUnitLevels: D2OrganisationUnitLevelSchema;
+    predictors: D2PredictorSchema;
     predictorGroups: D2PredictorGroupSchema;
     programs: D2ProgramSchema;
-    ProgramTrackedEntityAttributeDimensionItems: D2ProgramTrackedEntityAttributeDimensionItemSchema;
     programDataElements: D2ProgramDataElementDimensionItemSchema;
     programIndicators: D2ProgramIndicatorSchema;
-    dataElementDimensions: D2TrackedEntityProgramIndicatorDimensionSchema;
     programIndicatorGroups: D2ProgramIndicatorGroupSchema;
     programInstances: D2ProgramInstanceSchema;
     programNotificationTemplates: D2ProgramNotificationTemplateSchema;
@@ -35258,9 +35256,11 @@ export type D2ModelSchemas = {
     programSections: D2ProgramSectionSchema;
     programStages: D2ProgramStageSchema;
     programStageDataElements: D2ProgramStageDataElementSchema;
+    programStageInstances: D2ProgramStageInstanceSchema;
     eventFilters: D2ProgramStageInstanceFilterSchema;
     programStageSections: D2ProgramStageSectionSchema;
     programTrackedEntityAttributes: D2ProgramTrackedEntityAttributeSchema;
+    ProgramTrackedEntityAttributeDimensionItems: D2ProgramTrackedEntityAttributeDimensionItemSchema;
     programTrackedEntityAttributeGroups: D2ProgramTrackedEntityAttributeGroupSchema;
     pushAnalysis: D2PushAnalysisSchema;
     relationships: D2RelationshipSchema;
@@ -35268,22 +35268,24 @@ export type D2ModelSchemas = {
     reports: D2ReportSchema;
     reportTables: D2ReportTableSchema;
     reportingRates: D2ReportingRateSchema;
-    sections: D2SectionSchema;
     smsCommands: D2SMSCommandSchema;
-    programStageInstances: D2ProgramStageInstanceSchema;
+    sections: D2SectionSchema;
     sqlViews: D2SqlViewSchema;
     trackedEntityAttributes: D2TrackedEntityAttributeSchema;
     trackedEntityAttributeValues: D2TrackedEntityAttributeValueSchema;
+    trackedEntityDataElementDimensions: D2TrackedEntityDataElementDimensionSchema;
     trackedEntityInstances: D2TrackedEntityInstanceSchema;
     trackedEntityInstanceFilters: D2TrackedEntityInstanceFilterSchema;
+    dataElementDimensions: D2TrackedEntityProgramIndicatorDimensionSchema;
     trackedEntityTypes: D2TrackedEntityTypeSchema;
     trackedEntityTypeAttributes: D2TrackedEntityTypeAttributeSchema;
     users: D2UserSchema;
     userAccesses: D2UserAccessSchema;
+    userRoles: D2UserAuthorityGroupSchema;
     userCredentials: D2UserCredentialsSchema;
     userGroups: D2UserGroupSchema;
     userGroupAccesses: D2UserGroupAccessSchema;
-    userRoles: D2UserAuthorityGroupSchema;
+    validationNotificationTemplates: D2ValidationNotificationTemplateSchema;
     validationResults: D2ValidationResultSchema;
     validationRules: D2ValidationRuleSchema;
     validationRuleGroups: D2ValidationRuleGroupSchema;

--- a/src/schemas/base.ts
+++ b/src/schemas/base.ts
@@ -192,3 +192,15 @@ export interface D2SchemaProperties {
     embeddedObject: boolean;
     properties: D2SchemaFieldProperties[];
 }
+
+export interface D2ReportingParams {
+    reportingPeriod: boolean;
+    grandParentOrganisationUnit: boolean;
+    parentOrganisationUnit: boolean;
+    organisationUnit: boolean;
+}
+
+export interface D2Axis {
+    dimensionalItem: string;
+    axis: number;
+}

--- a/src/scripts/generate-schemas.ts
+++ b/src/scripts/generate-schemas.ts
@@ -198,6 +198,7 @@ const instances: Instance[] = [
     { version: "2.31", url: "http://admin:district@localhost:8031", isDeprecated: true },
     { version: "2.32", url: "https://admin:district@play.dhis2.org/2.32" },
     { version: "2.33", url: "https://admin:district@play.dhis2.org/2.33" },
+    { version: "2.34", url: "https://admin:district@play.dhis2.org/2.34" },
 ];
 
 async function generateSchema(instance: Instance) {

--- a/src/scripts/generate-schemas.ts
+++ b/src/scripts/generate-schemas.ts
@@ -86,7 +86,8 @@ const interfaceFromClass: _.Dictionary<string> = {
     "org.hisp.dhis.trackedentity.TrackedEntityAttributeDimension": "any",
     "org.hisp.dhis.trackedentity.TrackedEntityProgramOwner": "any",
     "org.hisp.dhis.common.DimensionalItemObject": "any",
-
+    "org.hisp.dhis.visualization.ReportingParams": "D2ReportingParams",
+    "org.hisp.dhis.visualization.Axis": "D2Axis",
     "java.lang.Object": "object",
     "java.util.Map": "object",
 };
@@ -206,14 +207,12 @@ async function generateSchema(instance: Instance) {
     const schemaUrl = joinPath(url, "/api/schemas.json?fields=:all,metadata");
     console.debug(`GET ${schemaUrl}`);
 
-    const { schemas } = (await axios.get(schemaUrl, {
+    const { schemas: allSchemas } = (await axios.get(schemaUrl, {
         validateStatus: (status: number) => status >= 200 && status < 300,
     })).data as { schemas: Schema[] };
 
-    const models = _(schemas)
-        .filter(schema => !!schema.href)
-        .sortBy(schema => schema.name)
-        .value();
+    const schemas = _.sortBy(allSchemas, schema => _.last(schema.klass.split(".")));
+    const models = schemas.filter(schema => !!schema.href);
     const schemasByClassName = _.keyBy(schemas, schema => _.last(schema.klass.split(".")) || "");
 
     const modelsDeclaration = `
@@ -223,7 +222,7 @@ async function generateSchema(instance: Instance) {
             Id, Preset, FieldPresets, D2SchemaProperties,
             D2Access, D2Translation, D2Geometry,  D2Style,
             D2AttributeValueGeneric, D2DimensionalKeywords, D2Expression,
-            D2RelationshipConstraint
+            D2RelationshipConstraint, D2ReportingParams, D2Axis
         } from "../schemas/base";
 
         ${schemas


### PR DESCRIPTION
Currently, not required by any project. I had the idea to use it in metadata-sync transformations, but currently we use no typing there, it only makes sense when fully typed.

Also: it orders schemas by name, on each generation the order was random and source diffs were useless.