### PR TITLE
Implement timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ import { D2Api } from "d2-api/2.32"
 const api = new D2Api({
     baseUrl: "https://play.dhis2.org/2.30",
     auth: { username: "admin", password: "district" },
+    timeout: 60 * 1000,
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "d2-api",
     "description": "Typed wrapper over DHIS2 API",
-    "version": "1.2.0",
+    "version": "1.2.1-beta.1",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "repository": {

--- a/src/api/d2Api.ts
+++ b/src/api/d2Api.ts
@@ -23,14 +23,14 @@ export class D2ApiGeneric {
     apiConnection: HttpClientRepository;
 
     public constructor(options?: D2ApiOptions) {
-        const { baseUrl = "http://localhost:8080", apiVersion, auth, backend = "xhr" } =
+        const { baseUrl = "http://localhost:8080", apiVersion, auth, backend = "xhr", timeout } =
             options || {};
         this.baseUrl = baseUrl;
         this.apiPath = joinPath(baseUrl, "api", apiVersion ? String(apiVersion) : null);
         const HttpClientRepositoryImpl =
             backend === "fetch" ? FetchHttpClientRepository : AxiosHttpClientRepository;
-        this.baseConnection = new HttpClientRepositoryImpl({ baseUrl, auth });
-        this.apiConnection = new HttpClientRepositoryImpl({ baseUrl: this.apiPath, auth });
+        this.baseConnection = new HttpClientRepositoryImpl({ baseUrl, auth, timeout });
+        this.apiConnection = new HttpClientRepositoryImpl({ baseUrl: this.apiPath, auth, timeout });
     }
 
     @cache()

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -7,6 +7,7 @@ export interface D2ApiOptions {
     apiVersion?: number;
     auth?: { username: string; password: string };
     backend?: "xhr" | "fetch";
+    timeout?: number;
 }
 
 export type IndexedModels<D2ApiDefinition extends D2ApiDefinitionBase> = {

--- a/src/data/AxiosHttpClientRepository.ts
+++ b/src/data/AxiosHttpClientRepository.ts
@@ -1,13 +1,13 @@
 import MockAdapter from "axios-mock-adapter";
 import axios, { AxiosInstance } from "axios";
+import qs from "qs";
+
 import {
     HttpClientRepository,
-    Credentials,
     HttpRequest,
     HttpResponse,
     ConstructorOptions,
 } from "../repositories/HttpClientRepository";
-import qs from "qs";
 import { CancelableResponse } from "../repositories/CancelableResponse";
 
 export class AxiosHttpClientRepository implements HttpClientRepository {
@@ -40,6 +40,7 @@ export class AxiosHttpClientRepository implements HttpClientRepository {
             withCredentials: !options.auth,
             paramsSerializer: params => qs.stringify(params, { arrayFormat: "repeat" }),
             validateStatus: status => status >= 200 && status < 300,
+            timeout: options.timeout,
         });
     }
 }

--- a/src/repositories/HttpClientRepository.ts
+++ b/src/repositories/HttpClientRepository.ts
@@ -1,4 +1,3 @@
-import { HttpRequest } from "./HttpClientRepository";
 import MockAdapter from "axios-mock-adapter";
 import { CancelableResponse } from "./CancelableResponse";
 
@@ -17,6 +16,7 @@ export interface HttpRequest {
     params?: Record<string, ParamValue | ParamValue[]>;
     data?: unknown;
     validateStatus?(status: number): boolean;
+    timeout?: number;
 }
 
 export interface HttpResponse<Data> {
@@ -33,6 +33,7 @@ export interface Credentials {
 export interface ConstructorOptions {
     baseUrl?: string;
     auth?: Credentials;
+    timeout?: number;
 }
 
 interface HttpErrorOptions {


### PR DESCRIPTION
Required by https://github.com/EyeSeeTea/project-monitoring-app/pull/338

Implementation:

- The option `timeout` can be passed both on the `D2Api` instantiation (it will be used by default) or overriden in a particular API request 
- XHR: Axios already has a `timeout` option, so just forward it.
- Fetch: The Fetch API does not implement an inbuilt timeout mechanism, so we use `setTimeout` + `controller.abort`.