### PR TITLE
[Fix] Handle different encodings with fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "d2-api",
     "description": "Typed wrapper over DHIS2 API",
-    "version": "1.3.1-beta.1",
+    "version": "1.3.1-beta.2",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "d2-api",
     "description": "Typed wrapper over DHIS2 API",
-    "version": "1.3.0",
+    "version": "1.3.1-beta.1",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "repository": {

--- a/src/data/FetchHttpClientRepository.ts
+++ b/src/data/FetchHttpClientRepository.ts
@@ -110,5 +110,5 @@ function getCharset(headers: _.Dictionary<string>): string {
     if (!contentType) return "utf-8";
 
     const contentTypes = _.fromPairs(contentType.split(";").map(type => type.split("=")));
-    return contentTypes["charset"] || "uft-8";
+    return contentTypes["charset"] || "utf-8";
 }


### PR DESCRIPTION
This solves the issue with special characters such as "Côte d'Ivoire". However we still have problems storing in the dataStore the inverted apostrophe, to fix them we should be able to either set as an option the charset (which I dislike) or magically detect it from contents before doing POST/PUT operations.

Alternatively I believe we should be good if we ask "WIDP IT Team" to clean-up from the database in NHWA modules the incorrect apostrophes appears 3 times. The character (special aprostrophe "’") and use normal apostrophes instead.

![image](https://user-images.githubusercontent.com/2181866/98807493-00bc7600-241b-11eb-8c44-167731adf0be.png)
