### PR TITLE
[Fix] Change TextDecoder to iconv-lite

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "d2-api",
     "description": "Typed wrapper over DHIS2 API",
-    "version": "1.4.0-beta.1",
+    "version": "1.4.0-beta.2",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "repository": {
@@ -36,6 +36,7 @@
         "d2": "^31.8.1",
         "dotenv": "^8.0.0",
         "express": "^4.17.1",
+        "iconv-lite": "0.6.2",
         "isomorphic-fetch": "3.0.0",
         "lodash": "^4.17.15",
         "log4js": "^4.5.1",

--- a/src/data/FetchHttpClientRepository.ts
+++ b/src/data/FetchHttpClientRepository.ts
@@ -1,14 +1,13 @@
 import AbortController from "abort-controller";
 import MockAdapter from "axios-mock-adapter";
 import btoa from "btoa";
+import iconv from "iconv-lite";
 import "isomorphic-fetch";
 import _ from "lodash";
 import qs from "qs";
-
 import { CancelableResponse } from "../repositories/CancelableResponse";
 import {
     ConstructorOptions,
-    Credentials,
     HttpClientRepository,
     HttpError,
     HttpRequest,
@@ -54,9 +53,8 @@ export class FetchHttpClientRepository implements HttpClientRepository {
                 const encoding = getCharset(headers);
                 const dataIsJson = (headers["content-type"] || "").includes("json");
 
-                const decoder = new TextDecoder(encoding);
                 const arrayBuffer = await res.arrayBuffer();
-                const content = decoder.decode(arrayBuffer);
+                const content = iconv.decode(Buffer.from(arrayBuffer), encoding);
 
                 const data = (dataIsJson ? JSON.parse(content) : content) as Data;
                 if (!validateStatus(res.status)) raiseHttpError(options, res, data);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2534,6 +2534,13 @@ iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+iconv-lite@0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.2.tgz#ce13d1875b0c3a674bd6a04b7f76b01b1b6ded01"
+  integrity sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
 ignore-walk@^3.0.1:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
@@ -3955,7 +3962,7 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-"safer-buffer@>= 2.1.2 < 3":
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==


### PR DESCRIPTION
- Browser and NodeJS have different implementations of ``TextDecoder``
- DHIS2 uses ``latin1`` in some endpoints (such as dataStore)
- NodeJS implementation does not have ``latin1`` support
- Switch from ``TextDecoder`` to ``iconv-lite``