### PR TITLE
Implement field transformer ~size

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "d2-api",
     "description": "Typed wrapper over DHIS2 API",
-    "version": "1.4.0-beta.2",
+    "version": "1.4.0-beta.3",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "repository": {

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -54,11 +54,18 @@ export interface FilterBase {
 
 function applyFieldTransformers(key: string, value: any) {
     if (value.hasOwnProperty("$fn")) {
+        const valueWithFn = _.omit(value, ["$fn"]);
+
         switch (value["$fn"]["name"]) {
             case "rename":
                 return {
                     key: `${key}~rename(${value["$fn"]["to"]})`,
-                    value: _.omit(value, ["$fn"]),
+                    value: valueWithFn,
+                };
+            case "size":
+                return {
+                    key: `${key}~size`,
+                    value: valueWithFn,
                 };
             default:
                 return { key, value };


### PR DESCRIPTION
Required by https://github.com/EyeSeeTea/project-monitoring-app/issues/333

https://docs.dhis2.org/2.30/en/developer/html/dhis2_developer_manual_full.html#webapi_field_transformers

Note: transformers may be chainable (`organisationUnits~size~rename(ou)`), so we don't really capture the full specs. For some other issue.