### PR TITLE
[data store] validate response of update operations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@eyeseetea/d2-api",
     "description": "Typed wrapper over DHIS2 API",
-    "version": "1.8.0",
+    "version": "1.8.0-beta.3",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@eyeseetea/d2-api",
     "description": "Typed wrapper over DHIS2 API",
-    "version": "1.8.0-beta.3",
+    "version": "1.8.0-beta.4",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "repository": {

--- a/src/api/dataStore.ts
+++ b/src/api/dataStore.ts
@@ -1,5 +1,8 @@
-import { D2ApiResponse } from "./common";
+import { D2ApiResponse, HttpResponse } from "./common";
+import { HttpResponse as HttpClientResponse } from "../repositories/HttpClientRepository";
 import { D2ApiGeneric } from "./d2Api";
+
+type UpdateResponse = HttpResponse<undefined>;
 
 export class DataStore {
     private endpoint: string;
@@ -49,16 +52,20 @@ export class DataStore {
         const config = { url: `/${this.endpoint}/${namespace}/${key}`, data: value };
 
         return d2Api
-            .request<void>({
+            .request<UpdateResponse>({
                 method: "put",
                 ...config,
                 validateStatus: validate404,
             })
+            .map(validateResponse)
             .flatMap(response => {
                 if (response.status === 404) {
-                    return d2Api.request({ method: "post", ...config });
+                    return d2Api
+                        .request<UpdateResponse>({ method: "post", ...config })
+                        .map(validateResponse);
                 } else {
-                    return D2ApiResponse.build({ response: Promise.resolve(response) });
+                    const voidResponse = { ...response, data: undefined };
+                    return D2ApiResponse.build({ response: Promise.resolve(voidResponse) });
                 }
             });
     }
@@ -67,17 +74,26 @@ export class DataStore {
         const { d2Api, namespace } = this;
 
         return d2Api
-            .request({
+            .request<UpdateResponse>({
                 method: "delete",
                 url: `/${this.endpoint}/${namespace}/${key}`,
                 validateStatus: validate404,
             })
-            .map(response => (response.status === 404 ? false : true));
+            .map(response => (response.status === 404 ? false : response.data.status === "OK"));
     }
 }
 
 function validate404(status: number): boolean {
     return (status >= 200 && status < 300) || status === 404;
+}
+
+function validateResponse(response: HttpClientResponse<HttpResponse<unknown>>): undefined {
+    const { data } = response;
+    if (data.status === "OK") {
+        return;
+    } else {
+        throw new Error(data.message || "Invalid response from server");
+    }
 }
 
 export type DataStoreType = "global" | "user";

--- a/src/api/dataStore.ts
+++ b/src/api/dataStore.ts
@@ -57,14 +57,13 @@ export class DataStore {
                 ...config,
                 validateStatus: validate404,
             })
-            .map(validateResponse)
             .flatMap(response => {
                 if (response.status === 404) {
                     return d2Api
                         .request<UpdateResponse>({ method: "post", ...config })
                         .map(validateResponse);
                 } else {
-                    const voidResponse = { ...response, data: undefined };
+                    const voidResponse = { ...response, data: validateResponse(response) };
                     return D2ApiResponse.build({ response: Promise.resolve(voidResponse) });
                 }
             });
@@ -89,7 +88,7 @@ function validate404(status: number): boolean {
 
 function validateResponse(response: HttpClientResponse<HttpResponse<unknown>>): undefined {
     const { data } = response;
-    if (data.status === "OK") {
+    if (response.status === 200 && data.status === "OK") {
         return;
     } else {
         throw new Error(data.message || "Invalid response from server");


### PR DESCRIPTION
Required by https://app.clickup.com/t/gz1b56

Problem: When the session is lost, DHIS2 does a 302-redirect + 200-html containing the login page (!). This is wrong and dangerous if our particular operation did not check the response, only the status code.

This PR addresses partially the problem:

- For dataStore, check POST/PUT/DELETE return value. We'll need to discuss how to tackle the rest of the problem, there are many ways to do it (and some may break existing code).