### PR TITLE
Fix datastore check status

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@eyeseetea/d2-api",
     "description": "Typed wrapper over DHIS2 API",
-    "version": "1.8.2",
+    "version": "1.8.3-beta.1",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "repository": {

--- a/src/api/dataStore.ts
+++ b/src/api/dataStore.ts
@@ -82,13 +82,17 @@ export class DataStore {
     }
 }
 
+function validate2xx(status: number): boolean {
+    return (status >= 200 && status < 300);
+}
+
 function validate404(status: number): boolean {
-    return (status >= 200 && status < 300) || status === 404;
+    return validate2xx(status) || status === 404;
 }
 
 function validateResponse(response: HttpClientResponse<HttpResponse<unknown>>): undefined {
     const { data } = response;
-    if (response.status === 200 && data.status === "OK") {
+    if (validate2xx(response.status) && data.status === "OK") {
         return;
     } else {
         throw new Error(data.message || "Invalid response from server");


### PR DESCRIPTION
When checking the status code of data store responses, we only see 200 as successful, should be 2xx (the server may return a 201, for example)