### PR TITLE
Add endpoint maintenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@eyeseetea/d2-api",
     "description": "Typed wrapper over DHIS2 API",
-    "version": "1.8.4",
+    "version": "1.8.5-beta.1",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "repository": {

--- a/src/api/d2Api.ts
+++ b/src/api/d2Api.ts
@@ -19,6 +19,7 @@ import { Model } from "./model";
 import { Sharing } from "./sharing";
 import { System } from "./system";
 import { D2ApiOptions, D2ApiRequest, IndexedModels } from "./types";
+import { Maintenance } from "./maintenance";
 
 export class D2ApiGeneric {
     public baseUrl: string;
@@ -165,6 +166,11 @@ export abstract class D2ApiVersioned<
     @cache()
     get appHub() {
         return new AppHub(this);
+    }
+
+    @cache()
+    get maintenance() {
+        return new Maintenance(this);
     }
 }
 

--- a/src/api/dataStore.ts
+++ b/src/api/dataStore.ts
@@ -83,7 +83,7 @@ export class DataStore {
 }
 
 function validate2xx(status: number): boolean {
-    return (status >= 200 && status < 300);
+    return status >= 200 && status < 300;
 }
 
 function validate404(status: number): boolean {

--- a/src/api/maintenance.ts
+++ b/src/api/maintenance.ts
@@ -1,0 +1,82 @@
+import { D2ApiGeneric } from "./d2Api";
+import { D2ApiResponse } from "./common";
+
+/* https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/maintenance.html */
+
+export class Maintenance {
+    constructor(public d2Api: D2ApiGeneric) {}
+
+    analyticsTablesClear(): D2ApiResponse<void> {
+        return this.d2Api.post<void>("/maintenance/analyticsTablesClear");
+    }
+
+    analyticsTablesAnalyze(): D2ApiResponse<void> {
+        return this.d2Api.post<void>("/maintenance/analyticsTablesAnalyze");
+    }
+
+    expiredInvitationsClear(): D2ApiResponse<void> {
+        return this.d2Api.post<void>("/maintenance/expiredInvitationsClear");
+    }
+
+    periodPruning(): D2ApiResponse<void> {
+        return this.d2Api.post<void>("/maintenance/periodPruning");
+    }
+
+    zeroDataValueRemoval(): D2ApiResponse<void> {
+        return this.d2Api.post<void>("/maintenance/zeroDataValueRemoval");
+    }
+
+    softDeletedDataValueRemoval(): D2ApiResponse<void> {
+        return this.d2Api.post<void>("/maintenance/softDeletedDataValueRemoval");
+    }
+
+    softDeletedProgramStageInstanceRemoval(): D2ApiResponse<void> {
+        return this.d2Api.post<void>("/maintenance/softDeletedProgramStageInstanceRemoval");
+    }
+
+    softDeletedProgramInstanceRemoval(): D2ApiResponse<void> {
+        return this.d2Api.post<void>("/maintenance/softDeletedProgramInstanceRemoval");
+    }
+
+    softDeletedTrackedEntityInstanceRemoval(): D2ApiResponse<void> {
+        return this.d2Api.post<void>("/maintenance/softDeletedTrackedEntityInstanceRemoval");
+    }
+
+    sqlViewsDrop(): D2ApiResponse<void> {
+        return this.d2Api.post<void>("/maintenance/sqlViewsDrop");
+    }
+
+    sqlViewsCreate(): D2ApiResponse<void> {
+        return this.d2Api.post<void>("/maintenance/sqlViewsCreate");
+    }
+
+    categoryOptionComboUpdate(options: { categoryComboId?: string } = {}): D2ApiResponse<void> {
+        const { categoryComboId } = options;
+        const extraPath = categoryComboId ? `/categoryCombo/${categoryComboId}` : "";
+        return this.d2Api.post<void>("/maintenance/categoryOptionComboUpdate" + extraPath);
+    }
+
+    cacheClear(): D2ApiResponse<void> {
+        return this.d2Api.post<void>("/maintenance/cacheClear");
+    }
+
+    ouPathsUpdate(): D2ApiResponse<void> {
+        return this.d2Api.post<void>("/maintenance/ouPathsUpdate");
+    }
+
+    dataPruningOrganisationUnit(id: string): D2ApiResponse<void> {
+        return this.d2Api.post<void>(`/maintenance/dataPruning/organisationUnits/${id}`);
+    }
+
+    dataPruningDataElement(id: string): D2ApiResponse<void> {
+        return this.d2Api.post<void>(`/maintenance/dataPruning/dataElements/${id}`);
+    }
+
+    metadataValidation(): D2ApiResponse<void> {
+        return this.d2Api.post<void>("/maintenance/metadataValidation");
+    }
+
+    appReload(): D2ApiResponse<void> {
+        return this.d2Api.post<void>("/maintenance/appReload");
+    }
+}

--- a/src/api/system.ts
+++ b/src/api/system.ts
@@ -52,10 +52,11 @@ export class System {
                 .get<{ message: string; completed?: boolean }[]>(`/system/tasks/${jobType}/${id}`)
                 .getData();
 
-            return _.some(result, ({ completed }) => completed)
+            return _.some(result, ({ completed }) => completed);
         };
 
         const prepareResponse = async () => {
+            // eslint-disable-next-line no-constant-condition
             while (true) {
                 const isDone = await checkTask();
                 const hasReachedMaxRetries = maxRetries !== undefined && retries > maxRetries;
@@ -73,7 +74,7 @@ export class System {
         };
 
         return D2ApiResponse.build({
-            cancel: () => {},
+            cancel: _.noop,
             response: prepareResponse(),
         });
     }

--- a/src/api/system.ts
+++ b/src/api/system.ts
@@ -44,7 +44,6 @@ export class System {
     ): D2ApiResponse<WaitForResponse[Type] | null> {
         const { interval = 1000, maxRetries } = options;
 
-        let isCancel = false;
         let retries = 0;
 
         const checkTask = async () => {
@@ -60,7 +59,7 @@ export class System {
             while (true) {
                 const isDone = await checkTask();
                 const hasReachedMaxRetries = maxRetries !== undefined && retries > maxRetries;
-                if (isDone || isCancel || hasReachedMaxRetries) break;
+                if (isDone || hasReachedMaxRetries) break;
 
                 await timeout(interval);
                 retries = retries + 1;

--- a/src/data/AxiosHttpClientRepository.ts
+++ b/src/data/AxiosHttpClientRepository.ts
@@ -4,7 +4,6 @@ import qs from "qs";
 import { CancelableResponse } from "../repositories/CancelableResponse";
 import {
     ConstructorOptions,
-    getBody,
     HttpClientRepository,
     HttpRequest,
     HttpResponse,


### PR DESCRIPTION
Required by https://github.com/EyeSeeTea/project-monitoring-app/pull/389

The task only needed categoryOptionComboUpdate, but I added all of them anyway for future usage.

See https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/maintenance.html