### PR TITLE
[data-values] post single value + add deleted <property>

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@eyeseetea/d2-api",
     "description": "Typed wrapper over DHIS2 API",
-    "version": "1.8.5",
+    "version": "1.8.6-beta.5",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "repository": {

--- a/src/api/dataValues.ts
+++ b/src/api/dataValues.ts
@@ -1,5 +1,6 @@
+import _ from "lodash";
 import { Id } from "../schemas";
-import { AsyncPostResponse, D2ApiResponse } from "./common";
+import { AsyncPostResponse, D2ApiResponse, HttpResponse } from "./common";
 import { D2ApiGeneric } from "./d2Api";
 
 export interface DataValueSetsPostRequest {
@@ -130,8 +131,35 @@ export interface DataValueSetsDataValue {
     deleted: boolean;
 }
 
+// https://docs.dhis2.org/en/full/develop/dhis-core-version-master/developer-manual.html#webapi_sending_individual_data_values
+export interface DataValuePostRequest {
+    ou: string;
+    pe: string;
+    de: string;
+    co?: string;
+    cc?: string;
+    cp?: string;
+    ds?: string;
+    value?: string;
+    comment?: string;
+    followUp?: string;
+}
+
+export type DataValuePostResponse = HttpResponse<void>;
+
 export class DataValues {
     constructor(public d2Api: D2ApiGeneric) {}
+
+    post(request: DataValuePostRequest): D2ApiResponse<void> {
+        return this.d2Api
+            .request<DataValuePostResponse>({
+                method: "post",
+                url: "/dataValues",
+                data: new URLSearchParams(_.omitBy(request, _.isUndefined)),
+                dataType: "raw",
+            })
+            .map(_res => undefined);
+    }
 
     getSet(params: DataValueSetsGetRequest): D2ApiResponse<DataValueSetsGetResponse> {
         return this.d2Api

--- a/src/api/dataValues.ts
+++ b/src/api/dataValues.ts
@@ -127,6 +127,7 @@ export interface DataValueSetsDataValue {
     created: string;
     lastUpdated: string;
     followup: boolean;
+    deleted: boolean;
 }
 
 export class DataValues {


### PR DESCRIPTION
Tasks:

1) Implement POST /api/dataValues for a single data value. Using `data: new URLSearchParams(...)`  + `dataType: "raw"` to build the form data.

2) AFICS, it's not documented, but data values have a boolean `deleted` property, as the source code reveals:

https://github.com/dhis2/dhis2-core/blob/master/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataValue.java#L100

This property must be used in conjunction with `updateStrategy=DELETE` to be able to delete values using `/dataValueSets`.