### PR TITLE
[data value] audits

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@eyeseetea/d2-api",
     "description": "Typed wrapper over DHIS2 API",
-    "version": "1.8.6-beta.5",
+    "version": "1.8.6-beta.6",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "repository": {

--- a/src/api/audit.ts
+++ b/src/api/audit.ts
@@ -1,0 +1,50 @@
+import { D2ApiGeneric, Id, Ref } from "..";
+import { D2ApiResponse } from "./common";
+import { PaginatedObjects, Pager } from ".";
+
+// https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/audit.html
+
+export class Audit {
+    constructor(public d2Api: D2ApiGeneric) {}
+
+    /* Return paginated audits for data values */
+    getDataValues(
+        options: DataValuesAuditOptions
+    ): D2ApiResponse<PaginatedObjects<DataValueAudit>> {
+        return this.d2Api
+            .get<GetDataValueAuditResponse>("/audits/dataValue", { ...options, paging: true })
+            .map(({ data }) => ({ pager: data.pager, objects: data.dataValueAudits }));
+    }
+}
+
+export type AuditType = "UPDATE" | "DELETE";
+
+// Apparently, the official docs are wrong (they reference a skipPaging property).
+// Standard properties paging/page/pageSize work.
+export type DataValuesAuditOptions = {
+    ds?: Id[];
+    de?: Id[];
+    pe?: string[];
+    ou?: Id[];
+    auditType?: AuditType;
+    // paging: boolean;
+    page?: number;
+    pageSize?: number;
+};
+
+export interface GetDataValueAuditResponse {
+    pager: Pager;
+    dataValueAudits: DataValueAudit[];
+}
+
+export interface DataValueAudit {
+    created: string;
+    modifiedBy: string;
+    auditType: AuditType;
+    value: string;
+    period: { id: string };
+    organisationUnit: Ref;
+    attributeOptionCombo: Ref;
+    categoryOptionCombo: Ref;
+    dataElement: Ref;
+}

--- a/src/api/audit.ts
+++ b/src/api/audit.ts
@@ -27,7 +27,6 @@ export type DataValuesAuditOptions = {
     pe?: string[];
     ou?: Id[];
     auditType?: AuditType;
-    // paging: boolean;
     page?: number;
     pageSize?: number;
 };

--- a/src/api/d2Api.ts
+++ b/src/api/d2Api.ts
@@ -20,6 +20,7 @@ import { Sharing } from "./sharing";
 import { System } from "./system";
 import { D2ApiOptions, D2ApiRequest, IndexedModels } from "./types";
 import { Maintenance } from "./maintenance";
+import { Audit } from "./audit";
 
 export class D2ApiGeneric {
     public baseUrl: string;
@@ -171,6 +172,11 @@ export abstract class D2ApiVersioned<
     @cache()
     get maintenance() {
         return new Maintenance(this);
+    }
+
+    @cache()
+    get audit() {
+        return new Audit(this);
     }
 }
 


### PR DESCRIPTION
Adds paginated endpoint `audit/dataValues`. We dismissed having conditional types to avoid complexity for paging yes/no, so we have to decide if we duplicate the endpoints or not. 