### PR TITLE
[events] typed status + strategy import param

### DIFF
--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -3,12 +3,14 @@ import { AsyncPostResponse, D2ApiResponse, HttpResponse } from "./common";
 import { D2ApiGeneric } from "./d2Api";
 import { Pager } from "./model";
 
+export type EventStatus = "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULED" | "OVERDUE" | "SKIPPED";
+
 export interface EventsPostRequest {
     events: Array<{
         event?: string;
         orgUnit: string;
         program: string;
-        status: string;
+        status: EventStatus;
         eventDate: string;
         coordinate?: {
             latitude: string;
@@ -139,7 +141,7 @@ export interface Event {
     event: string;
     programStage: string;
     orgUnit: string;
-    status: string;
+    status: EventStatus;
     orgUnitName: string;
     eventDate: string;
     attributeCategoryOptions: string;

--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -36,6 +36,7 @@ export type EventsPostParams = Partial<{
     payloadFormat: "json" | "xml" | "csv";
     async: boolean;
     dryRun: boolean;
+    strategy: "CREATE" | "UPDATE" | "CREATE_AND_UPDATE" | "DELETE";
 }>;
 
 export type IdScheme = string;


### PR DESCRIPTION
Required by https://app.clickup.com/t/1hkf28g

Still some missing, but not sure the docs are exact though (for example `eventIdScheme` does not appear in the docs, but it does exist):

https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-235/web-api.html#webapi_import_parameters