### PR TITLE
Return lazy promises

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@eyeseetea/d2-api",
     "description": "Typed wrapper over DHIS2 API",
-    "version": "1.10.0",
+    "version": "1.10.1-beta.1",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "repository": {

--- a/src/api/dataStore.ts
+++ b/src/api/dataStore.ts
@@ -64,7 +64,7 @@ export class DataStore {
                         .map(validateResponse);
                 } else {
                     const voidResponse = { ...response, data: validateResponse(response) };
-                    return D2ApiResponse.build({ response: Promise.resolve(voidResponse) });
+                    return D2ApiResponse.build({ response: () => Promise.resolve(voidResponse) });
                 }
             });
     }

--- a/src/api/system.ts
+++ b/src/api/system.ts
@@ -70,12 +70,12 @@ export class System {
                 `/system/taskSummaries/${jobType}/${id}`
             );
 
-            return response;
+            return response();
         };
 
         return D2ApiResponse.build({
             cancel: _.noop,
-            response: prepareResponse(),
+            response: () => prepareResponse(),
         });
     }
 

--- a/src/data/AxiosHttpClientRepository.ts
+++ b/src/data/AxiosHttpClientRepository.ts
@@ -18,13 +18,15 @@ export class AxiosHttpClientRepository implements HttpClientRepository {
 
     request<Data>(options: HttpRequest): CancelableResponse<Data> {
         const { token: cancelToken, cancel } = axios.CancelToken.source();
-        const axiosResponse = this.instance({ ...options, cancelToken });
 
-        const response: Promise<HttpResponse<Data>> = axiosResponse.then(res => ({
-            status: res.status,
-            data: res.data as Data,
-            headers: res.headers,
-        }));
+        const response: () => Promise<HttpResponse<Data>> = () => {
+            const axiosResponse = this.instance({ ...options, cancelToken });
+            return axiosResponse.then(res => ({
+                status: res.status,
+                data: res.data as Data,
+                headers: res.headers,
+            }));
+        };
 
         return CancelableResponse.build({ cancel, response: response });
     }

--- a/src/repositories/CancelableResponse.ts
+++ b/src/repositories/CancelableResponse.ts
@@ -2,30 +2,31 @@ import Axios from "axios";
 import { HttpResponse } from "./HttpClientRepository";
 
 export class CancelableResponse<Data> {
-    constructor(public cancel: Canceler, public response: Promise<HttpResponse<Data>>) {}
+    constructor(public cancel: Canceler, public response: () => Promise<HttpResponse<Data>>) {}
 
     static build<BuildData>(options: {
         cancel?: Canceler;
-        response: Promise<HttpResponse<BuildData>>;
+        response: () => Promise<HttpResponse<BuildData>>;
     }): CancelableResponse<BuildData> {
         const { cancel, response } = options;
         return new CancelableResponse(cancel || noop, response);
     }
 
     getData() {
-        return this.response.then(({ data }) => data);
+        return this.response().then(({ data }) => data);
     }
 
     map<MappedData>(
         mapper: (response: HttpResponse<Data>) => MappedData
     ): CancelableResponse<MappedData> {
         const { cancel, response } = this;
-        const mappedResponse = response.then(
-            (response_: HttpResponse<Data>): HttpResponse<MappedData> => ({
-                ...response_,
-                data: mapper(response_),
-            })
-        );
+        const mappedResponse = () =>
+            response().then(
+                (response_: HttpResponse<Data>): HttpResponse<MappedData> => ({
+                    ...response_,
+                    data: mapper(response_),
+                })
+            );
 
         return new CancelableResponse<MappedData>(cancel, mappedResponse);
     }
@@ -36,11 +37,12 @@ export class CancelableResponse<Data> {
         const { cancel, response } = this;
         let cancel2: Canceler | undefined;
 
-        const mappedResponse = response.then(response_ => {
-            const res2 = mapper(response_);
-            cancel2 = res2.cancel;
-            return res2.response;
-        });
+        const mappedResponse: () => Promise<HttpResponse<MappedData>> = () =>
+            response().then(response_ => {
+                const res2 = mapper(response_);
+                cancel2 = res2.cancel;
+                return res2.response();
+            });
 
         function cancelAll() {
             cancel();


### PR DESCRIPTION
Closes https://app.clickup.com/t/1u62crd

Use deferrable responses so promises run only on `res.getData()`

Implementation:

- Fix any scenario where the promise should not effectively execute until required (i.e. when using future wrappers).
- Instead of working with `promiseResponse`, work with `() => promiseResponse`. 

NOTES:

- Beta release: https://www.npmjs.com/package/@eyeseetea/d2-api/v/1.10.1-beta.1
- It should not be a breaking change, but make sure that your app is working properly when updating. 
- Being used in `data-management` and `central-planning-reporting.`
