### PR TITLE
Extend tracked entity instances types (geometry + specific post type)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@eyeseetea/d2-api",
     "description": "Typed wrapper over DHIS2 API",
-    "version": "1.10.1",
+    "version": "1.10.2-beta.2",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "repository": {

--- a/src/schemas/base.ts
+++ b/src/schemas/base.ts
@@ -60,9 +60,11 @@ export interface D2DimensionalKeywords {
     code: string;
 }
 
+export type D2Coordinates = [number, number];
+
 export type D2Geometry =
-    | { type: "Point"; coordinates: [number, number] }
-    | { type: "Polygon"; coordinates: Array<Array<[number, number]>> };
+    | { type: "Point"; coordinates: D2Coordinates }
+    | { type: "Polygon"; coordinates: Array<D2Coordinates[]> };
 
 export interface D2Expression {
     expression: string;
@@ -248,3 +250,11 @@ export interface D2Axis {
     dimensionalItem: string;
     axis: number;
 }
+
+export interface D2ProgramOwner {
+    ownerOrgUnit: Id;
+    program: Id;
+    trackedEntityInstance: Id;
+}
+
+export type D2ProgramOwnerSchema = GetDefaultSchema<D2ProgramOwner>;

--- a/src/scripts/generate-schemas.ts
+++ b/src/scripts/generate-schemas.ts
@@ -88,7 +88,10 @@ const interfaceFromClass: _.Dictionary<string | { type: string; schema: string }
     "org.hisp.dhis.trackedentityfilter.EventFilter": "unknown",
     "org.hisp.dhis.trackedentityfilter.FilterPeriod": "unknown",
     "org.hisp.dhis.trackedentity.TrackedEntityAttributeDimension": "unknown",
-    "org.hisp.dhis.trackedentity.TrackedEntityProgramOwner": "unknown",
+    "org.hisp.dhis.trackedentity.TrackedEntityProgramOwner": {
+        type: "D2ProgramOwner",
+        schema: "D2ProgramOwnerSchema",
+    },
     "org.hisp.dhis.user.sharing.Sharing": "Sharing",
     "org.hisp.dhis.common.DimensionalItemObject": "unknown",
     "org.hisp.dhis.visualization.ReportingParams": "D2ReportingParams",
@@ -233,7 +236,7 @@ const instances: Instance[] = [
     { version: "2.31", url: "http://admin:district@localhost:8031", isDeprecated: true },
     { version: "2.32", url: "https://admin:district@play.dhis2.org/2.32", isDeprecated: true },
     { version: "2.33", url: "https://admin:district@play.dhis2.org/2.33", isDeprecated: true },
-    { version: "2.34", url: "https://admin:district@play.dhis2.org/2.34" },
+    { version: "2.34", url: "https://admin:district@play.dhis2.org/2.34", isDeprecated: true },
     { version: "2.35", url: "https://admin:district@play.dhis2.org/2.35" },
     { version: "2.36", url: "https://admin:district@play.dhis2.org/2.36" },
     { version: "2.37", url: "https://admin:district@play.dhis2.org/2.37" },
@@ -260,6 +263,7 @@ async function generateSchema(instance: Instance) {
             D2Access, D2Translation, D2Geometry,  D2Style,
             D2DimensionalKeywords, D2Expression,
             D2RelationshipConstraint, D2ReportingParams, D2Axis, Sharing,
+            D2ProgramOwner, D2ProgramOwnerSchema,
             D2AttributeValueGeneric, D2AttributeValueGenericSchema
         } from "../schemas/base";
 


### PR DESCRIPTION
Required by https://app.clickup.com/t/1vqyygd

- Added some missing fields to TEI type.
- Add geometry fields to TEI type.
- Create specific type `TrackedEntityInstanceToPost`
- Fix `D2Geometry` polygon type
- Support `D2ProgramOwner` custom type.
- Set v2.34 as deprecated.

(schemas not updated, some play.dhis2 servers are down)