### PR TITLE
[Feature] Change default backend to fetch

### DIFF
--- a/src/api/d2Api.ts
+++ b/src/api/d2Api.ts
@@ -33,7 +33,7 @@ export class D2ApiGeneric {
     apiConnection: HttpClientRepository;
 
     public constructor(options?: D2ApiOptions) {
-        const { baseUrl = "http://localhost:8080", apiVersion, auth, backend = "xhr", timeout } =
+        const { baseUrl = "http://localhost:8080", apiVersion, auth, backend = "fetch", timeout } =
             options || {};
         this.baseUrl = baseUrl;
         this.apiPath = joinPath(baseUrl, "api", apiVersion ? String(apiVersion) : null);


### PR DESCRIPTION
In all current apps I believe we have already switched to ``fetch`` backend. Make it default and probably deprecated in next major?

Related: https://github.com/nodejs/node/pull/41749. Node will soon have a ``fetch`` compliant implementation on top of ``undici`` exposed as a Global.