### PR TITLE
[events] Fix/refactor endpoint for 2.36

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,4 +18,5 @@ module.exports = {
         "@typescript-eslint/prefer-interface": "off",
         "no-dupe-class-members": "off",
     },
+    env: { node: true, browser: true, es6: true },
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@eyeseetea/d2-api",
     "description": "Typed wrapper over DHIS2 API",
-    "version": "1.11.0",
+    "version": "1.12.0-beta.1",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "repository": {

--- a/src/2.35/schemas.ts
+++ b/src/2.35/schemas.ts
@@ -16,6 +16,8 @@ import {
     D2ReportingParams,
     D2Axis,
     Sharing,
+    D2ProgramOwner,
+    D2ProgramOwnerSchema,
     D2AttributeValueGeneric,
     D2AttributeValueGenericSchema,
 } from "../schemas/base";
@@ -2869,9 +2871,11 @@ export type D2Program = {
     dataEntryForm: D2DataEntryForm;
     description: string;
     displayDescription: string;
+    displayEnrollmentDateLabel: string;
     displayFormName: string;
     displayFrontPageList: boolean;
     displayIncidentDate: boolean;
+    displayIncidentDateLabel: string;
     displayName: string;
     displayShortName: string;
     enrollmentDateLabel: string;
@@ -3351,6 +3355,8 @@ export type D2ProgramStage = {
     dataEntryForm: D2DataEntryForm;
     description: string;
     displayDescription: string;
+    displayDueDateLabel: string;
+    displayExecutionDateLabel: string;
     displayFormName: string;
     displayGenerateEventBox: boolean;
     displayName: string;
@@ -4234,7 +4240,7 @@ export type D2TrackedEntityInstance = {
     name: string;
     organisationUnit: D2OrganisationUnit;
     programInstances: D2ProgramInstance[];
-    programOwners: unknown[];
+    programOwners: D2ProgramOwner[];
     publicAccess: string;
     relationshipItems: unknown[];
     storedBy: string;
@@ -4600,6 +4606,7 @@ export type D2ValidationRule = {
         | "CATEGORY_OPTION_GROUP";
     displayDescription: string;
     displayFormName: string;
+    displayInstruction: string;
     displayName: string;
     displayShortName: string;
     externalAccess: boolean;
@@ -10401,6 +10408,7 @@ export interface D2PredictorSchema {
             | "output"
             | "lastUpdated"
             | "sampleSkipTest"
+            | "translations"
             | "id"
             | "sequentialSampleCount"
             | "annualSampleCount"
@@ -10421,6 +10429,7 @@ export interface D2PredictorSchema {
             | "output"
             | "lastUpdated"
             | "sampleSkipTest"
+            | "translations"
             | "id"
             | "sequentialSampleCount"
             | "annualSampleCount"
@@ -10511,9 +10520,11 @@ export interface D2ProgramSchema {
         dataEntryForm: D2DataEntryFormSchema;
         description: string;
         displayDescription: string;
+        displayEnrollmentDateLabel: string;
         displayFormName: string;
         displayFrontPageList: boolean;
         displayIncidentDate: boolean;
+        displayIncidentDateLabel: string;
         displayName: string;
         displayShortName: string;
         enrollmentDateLabel: string;
@@ -11507,6 +11518,8 @@ export interface D2ProgramStageSchema {
         dataEntryForm: D2DataEntryFormSchema;
         description: string;
         displayDescription: string;
+        displayDueDateLabel: string;
+        displayExecutionDateLabel: string;
         displayFormName: string;
         displayGenerateEventBox: boolean;
         displayName: string;
@@ -13244,7 +13257,7 @@ export interface D2TrackedEntityInstanceSchema {
         name: string;
         organisationUnit: D2OrganisationUnitSchema;
         programInstances: D2ProgramInstanceSchema[];
-        programOwners: unknown[];
+        programOwners: D2ProgramOwnerSchema[];
         publicAccess: string;
         relationshipItems: unknown[];
         storedBy: string;
@@ -14101,6 +14114,7 @@ export interface D2ValidationRuleSchema {
             | "CATEGORY_OPTION_GROUP";
         displayDescription: string;
         displayFormName: string;
+        displayInstruction: string;
         displayName: string;
         displayShortName: string;
         externalAccess: boolean;
@@ -26081,7 +26095,7 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
         displayName: "Predictor",
         collectionName: "predictors",
         nameableObject: true,
-        translatable: false,
+        translatable: true,
         identifiableObject: true,
         dataShareable: false,
         name: "Predictor",
@@ -26466,6 +26480,7 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 klass: "java.util.Set",
                 itemKlass: "org.hisp.dhis.program.ProgramIndicator",
             },
+            { name: "displayIncidentDateLabel", propertyType: "TEXT", klass: "java.lang.String" },
             {
                 name: "lastUpdated",
                 fieldName: "lastUpdated",
@@ -26546,6 +26561,7 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 propertyType: "INTEGER",
                 klass: "java.lang.Integer",
             },
+            { name: "displayEnrollmentDateLabel", propertyType: "TEXT", klass: "java.lang.String" },
             {
                 name: "maxTeiCountToReturn",
                 fieldName: "maxTeiCountToReturn",
@@ -28701,6 +28717,7 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 propertyType: "TEXT",
                 klass: "java.lang.String",
             },
+            { name: "displayExecutionDateLabel", propertyType: "TEXT", klass: "java.lang.String" },
             {
                 name: "externalAccess",
                 fieldName: "externalAccess",
@@ -28775,6 +28792,7 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 propertyType: "TEXT",
                 klass: "org.hisp.dhis.period.PeriodType",
             },
+            { name: "displayDueDateLabel", propertyType: "TEXT", klass: "java.lang.String" },
             {
                 name: "blockEntryForm",
                 fieldName: "blockEntryForm",
@@ -34284,6 +34302,7 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 propertyType: "DATE",
                 klass: "java.util.Date",
             },
+            { name: "displayInstruction", propertyType: "TEXT", klass: "java.lang.String" },
             {
                 name: "leftSide",
                 fieldName: "leftSide",

--- a/src/2.36/schemas.ts
+++ b/src/2.36/schemas.ts
@@ -16,6 +16,8 @@ import {
     D2ReportingParams,
     D2Axis,
     Sharing,
+    D2ProgramOwner,
+    D2ProgramOwnerSchema,
     D2AttributeValueGeneric,
     D2AttributeValueGenericSchema,
 } from "../schemas/base";
@@ -299,7 +301,7 @@ export type D2CategoryCombo = {
 
 export type D2CategoryDimension = {
     category: D2Category;
-    categoryOptions: unknown;
+    categoryOptions: object;
 };
 
 export type D2CategoryOption = {
@@ -592,7 +594,7 @@ export type D2CategoryOptionGroupSet = {
 
 export type D2CategoryOptionGroupSetDimension = {
     categoryOptionGroupSet: D2CategoryOptionGroupSet;
-    categoryOptionGroups: unknown;
+    categoryOptionGroups: object;
 };
 
 export type D2Chart = {
@@ -1149,7 +1151,7 @@ export type D2DataElementGroupSet = {
 
 export type D2DataElementGroupSetDimension = {
     dataElementGroupSet: D2DataElementGroupSet;
-    dataElementGroups: unknown;
+    dataElementGroups: object;
 };
 
 export type D2DataElementOperand = {
@@ -1665,9 +1667,11 @@ export type D2EventReport = {
 
 export type D2Expression = {
     description: string;
+    displayDescription: string;
     expression: string;
     missingValueStrategy: "SKIP_IF_ANY_VALUE_MISSING" | "SKIP_IF_ALL_VALUES_MISSING" | "NEVER_SKIP";
     slidingWindow: boolean;
+    translations: D2Translation[];
 };
 
 export type D2ExternalFileResource = {
@@ -2706,7 +2710,7 @@ export type D2OrganisationUnit = {
     favorite: boolean;
     favorites: string[];
     formName: string;
-    geometry: unknown;
+    geometry: D2Geometry;
     href: string;
     id: Id;
     lastUpdated: string;
@@ -2787,7 +2791,7 @@ export type D2OrganisationUnitGroup = {
     favorites: string[];
     featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
     formName: string;
-    geometry: unknown;
+    geometry: D2Geometry;
     groupSets: D2OrganisationUnitGroupSet[];
     href: string;
     id: Id;
@@ -2888,7 +2892,7 @@ export type D2OrganisationUnitGroupSet = {
 
 export type D2OrganisationUnitGroupSetDimension = {
     organisationUnitGroupSet: D2OrganisationUnitGroupSet;
-    organisationUnitGroups: unknown;
+    organisationUnitGroups: object;
 };
 
 export type D2OrganisationUnitLevel = {
@@ -3257,7 +3261,7 @@ export type D2ProgramInstance = {
     favorite: boolean;
     favorites: string[];
     followup: boolean;
-    geometry: unknown;
+    geometry: D2Geometry;
     href: string;
     id: Id;
     incidentDate: string;
@@ -3568,6 +3572,7 @@ export type D2ProgramStageDataElement = {
     renderOptionsAsRadio: boolean;
     renderType: unknown;
     sharing: Sharing;
+    skipAnalytics: boolean;
     skipSynchronization: boolean;
     sortOrder: number;
     translations: D2Translation[];
@@ -3599,7 +3604,7 @@ export type D2ProgramStageInstance = {
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
-    geometry: unknown;
+    geometry: D2Geometry;
     href: string;
     id: Id;
     lastUpdated: string;
@@ -4211,6 +4216,7 @@ export type D2Section = {
     dataElements: D2DataElement[];
     dataSet: D2DataSet;
     description: string;
+    disableDataElementAutoGroup: boolean;
     displayName: string;
     externalAccess: boolean;
     favorite: boolean;
@@ -4406,7 +4412,7 @@ export type D2TrackedEntityInstance = {
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
-    geometry: unknown;
+    geometry: D2Geometry;
     href: string;
     id: Id;
     inactive: boolean;
@@ -4416,7 +4422,7 @@ export type D2TrackedEntityInstance = {
     name: string;
     organisationUnit: D2OrganisationUnit;
     programInstances: D2ProgramInstance[];
-    programOwners: unknown[];
+    programOwners: D2ProgramOwner[];
     publicAccess: string;
     relationshipItems: unknown[];
     sharing: Sharing;
@@ -5568,7 +5574,7 @@ export interface D2CategoryComboSchema {
 export interface D2CategoryDimensionSchema {
     name: "D2CategoryDimension";
     model: D2CategoryDimension;
-    fields: { category: D2CategorySchema; categoryOptions: unknown };
+    fields: { category: D2CategorySchema; categoryOptions: object };
     fieldPresets: {
         $all: Preset<D2CategoryDimension, keyof D2CategoryDimension>;
         $identifiable: Preset<D2CategoryDimension, FieldPresets["identifiable"]>;
@@ -6043,7 +6049,7 @@ export interface D2CategoryOptionGroupSetDimensionSchema {
     model: D2CategoryOptionGroupSetDimension;
     fields: {
         categoryOptionGroupSet: D2CategoryOptionGroupSetSchema;
-        categoryOptionGroups: unknown;
+        categoryOptionGroups: object;
     };
     fieldPresets: {
         $all: Preset<D2CategoryOptionGroupSetDimension, keyof D2CategoryOptionGroupSetDimension>;
@@ -7007,7 +7013,7 @@ export interface D2DataElementGroupSetSchema {
 export interface D2DataElementGroupSetDimensionSchema {
     name: "D2DataElementGroupSetDimension";
     model: D2DataElementGroupSetDimension;
-    fields: { dataElementGroupSet: D2DataElementGroupSetSchema; dataElementGroups: unknown };
+    fields: { dataElementGroupSet: D2DataElementGroupSetSchema; dataElementGroups: object };
     fieldPresets: {
         $all: Preset<D2DataElementGroupSetDimension, keyof D2DataElementGroupSetDimension>;
         $identifiable: Preset<D2DataElementGroupSetDimension, FieldPresets["identifiable"]>;
@@ -8088,12 +8094,14 @@ export interface D2ExpressionSchema {
     model: D2Expression;
     fields: {
         description: string;
+        displayDescription: string;
         expression: string;
         missingValueStrategy:
             | "SKIP_IF_ANY_VALUE_MISSING"
             | "SKIP_IF_ALL_VALUES_MISSING"
             | "NEVER_SKIP";
         slidingWindow: boolean;
+        translations: D2Translation[];
     };
     fieldPresets: {
         $all: Preset<D2Expression, keyof D2Expression>;
@@ -8101,11 +8109,11 @@ export interface D2ExpressionSchema {
         $nameable: Preset<D2Expression, FieldPresets["nameable"]>;
         $persisted: Preset<
             D2Expression,
-            "description" | "expression" | "missingValueStrategy" | "slidingWindow"
+            "expression" | "translations" | "description" | "missingValueStrategy" | "slidingWindow"
         >;
         $owner: Preset<
             D2Expression,
-            "description" | "expression" | "missingValueStrategy" | "slidingWindow"
+            "expression" | "translations" | "description" | "missingValueStrategy" | "slidingWindow"
         >;
     };
 }
@@ -10160,7 +10168,7 @@ export interface D2OrganisationUnitSchema {
         favorite: boolean;
         favorites: string[];
         formName: string;
-        geometry: unknown;
+        geometry: D2Geometry;
         href: string;
         id: Id;
         lastUpdated: string;
@@ -10307,7 +10315,7 @@ export interface D2OrganisationUnitGroupSchema {
         favorites: string[];
         featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
         formName: string;
-        geometry: unknown;
+        geometry: D2Geometry;
         groupSets: D2OrganisationUnitGroupSetSchema[];
         href: string;
         id: Id;
@@ -10501,7 +10509,7 @@ export interface D2OrganisationUnitGroupSetDimensionSchema {
     model: D2OrganisationUnitGroupSetDimension;
     fields: {
         organisationUnitGroupSet: D2OrganisationUnitGroupSetSchema;
-        organisationUnitGroups: unknown;
+        organisationUnitGroups: object;
     };
     fieldPresets: {
         $all: Preset<
@@ -10634,6 +10642,7 @@ export interface D2PredictorSchema {
             | "output"
             | "lastUpdated"
             | "sampleSkipTest"
+            | "translations"
             | "id"
             | "sequentialSampleCount"
             | "annualSampleCount"
@@ -10654,6 +10663,7 @@ export interface D2PredictorSchema {
             | "output"
             | "lastUpdated"
             | "sampleSkipTest"
+            | "translations"
             | "id"
             | "sequentialSampleCount"
             | "annualSampleCount"
@@ -11224,7 +11234,7 @@ export interface D2ProgramInstanceSchema {
         favorite: boolean;
         favorites: string[];
         followup: boolean;
-        geometry: unknown;
+        geometry: D2Geometry;
         href: string;
         id: Id;
         incidentDate: string;
@@ -11916,6 +11926,7 @@ export interface D2ProgramStageDataElementSchema {
         renderOptionsAsRadio: boolean;
         renderType: unknown;
         sharing: Sharing;
+        skipAnalytics: boolean;
         skipSynchronization: boolean;
         sortOrder: number;
         translations: D2Translation[];
@@ -11934,6 +11945,7 @@ export interface D2ProgramStageDataElementSchema {
             | "skipSynchronization"
             | "lastUpdated"
             | "renderOptionsAsRadio"
+            | "skipAnalytics"
             | "id"
             | "allowFutureDate"
             | "renderType"
@@ -11952,6 +11964,7 @@ export interface D2ProgramStageDataElementSchema {
             | "skipSynchronization"
             | "lastUpdated"
             | "renderOptionsAsRadio"
+            | "skipAnalytics"
             | "id"
             | "allowFutureDate"
             | "renderType"
@@ -11992,7 +12005,7 @@ export interface D2ProgramStageInstanceSchema {
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
-        geometry: unknown;
+        geometry: D2Geometry;
         href: string;
         id: Id;
         lastUpdated: string;
@@ -13094,6 +13107,7 @@ export interface D2SectionSchema {
         dataElements: D2DataElementSchema[];
         dataSet: D2DataSetSchema;
         description: string;
+        disableDataElementAutoGroup: boolean;
         displayName: string;
         externalAccess: boolean;
         favorite: boolean;
@@ -13124,6 +13138,7 @@ export interface D2SectionSchema {
             | "code"
             | "greyedFields"
             | "description"
+            | "disableDataElementAutoGroup"
             | "lastUpdated"
             | "translations"
             | "id"
@@ -13143,6 +13158,7 @@ export interface D2SectionSchema {
             | "code"
             | "greyedFields"
             | "description"
+            | "disableDataElementAutoGroup"
             | "lastUpdated"
             | "translations"
             | "id"
@@ -13485,7 +13501,7 @@ export interface D2TrackedEntityInstanceSchema {
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
-        geometry: unknown;
+        geometry: D2Geometry;
         href: string;
         id: Id;
         inactive: boolean;
@@ -13495,7 +13511,7 @@ export interface D2TrackedEntityInstanceSchema {
         name: string;
         organisationUnit: D2OrganisationUnitSchema;
         programInstances: D2ProgramInstanceSchema[];
-        programOwners: unknown[];
+        programOwners: D2ProgramOwnerSchema[];
         publicAccess: string;
         relationshipItems: unknown[];
         sharing: Sharing;
@@ -21142,15 +21158,24 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
         persisted: true,
         embeddedObject: true,
         properties: [
+            { name: "displayDescription", propertyType: "TEXT", klass: "java.lang.String" },
             {
-                name: "description",
-                fieldName: "description",
+                name: "expression",
+                fieldName: "expression",
                 propertyType: "TEXT",
                 klass: "java.lang.String",
             },
             {
-                name: "expression",
-                fieldName: "expression",
+                name: "translation",
+                fieldName: "translations",
+                propertyType: "COLLECTION",
+                itemPropertyType: "COMPLEX",
+                klass: "java.util.Set",
+                itemKlass: "org.hisp.dhis.translation.Translation",
+            },
+            {
+                name: "description",
+                fieldName: "description",
                 propertyType: "TEXT",
                 klass: "java.lang.String",
             },
@@ -26132,7 +26157,7 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
         displayName: "Predictor",
         collectionName: "predictors",
         nameableObject: true,
-        translatable: false,
+        translatable: true,
         identifiableObject: true,
         dataShareable: false,
         name: "Predictor",
@@ -28862,6 +28887,12 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
             {
                 name: "renderOptionsAsRadio",
                 fieldName: "renderOptionsAsRadio",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
+            },
+            {
+                name: "skipAnalytics",
+                fieldName: "skipAnalytics",
                 propertyType: "BOOLEAN",
                 klass: "java.lang.Boolean",
             },
@@ -31663,6 +31694,12 @@ export const models: Record<keyof D2ModelSchemas, D2SchemaProperties> = {
                 fieldName: "description",
                 propertyType: "TEXT",
                 klass: "java.lang.String",
+            },
+            {
+                name: "disableDataElementAutoGroup",
+                fieldName: "disableDataElementAutoGroup",
+                propertyType: "BOOLEAN",
+                klass: "java.lang.Boolean",
             },
             {
                 name: "externalAccess",

--- a/src/2.37/schemas.ts
+++ b/src/2.37/schemas.ts
@@ -16,6 +16,8 @@ import {
     D2ReportingParams,
     D2Axis,
     Sharing,
+    D2ProgramOwner,
+    D2ProgramOwnerSchema,
     D2AttributeValueGeneric,
     D2AttributeValueGenericSchema,
 } from "../schemas/base";
@@ -327,7 +329,7 @@ export type D2CategoryCombo = {
 
 export type D2CategoryDimension = {
     category: D2Category;
-    categoryOptions: unknown;
+    categoryOptions: object;
 };
 
 export type D2CategoryOption = {
@@ -620,7 +622,7 @@ export type D2CategoryOptionGroupSet = {
 
 export type D2CategoryOptionGroupSetDimension = {
     categoryOptionGroupSet: D2CategoryOptionGroupSet;
-    categoryOptionGroups: unknown;
+    categoryOptionGroups: object;
 };
 
 export type D2Constant = {
@@ -1046,7 +1048,7 @@ export type D2DataElementGroupSet = {
 
 export type D2DataElementGroupSetDimension = {
     dataElementGroupSet: D2DataElementGroupSet;
-    dataElementGroups: unknown;
+    dataElementGroups: object;
 };
 
 export type D2DataElementOperand = {
@@ -2612,7 +2614,7 @@ export type D2OrganisationUnit = {
     favorite: boolean;
     favorites: string[];
     formName: string;
-    geometry: unknown;
+    geometry: D2Geometry;
     href: string;
     id: Id;
     image: D2FileResource;
@@ -2694,7 +2696,7 @@ export type D2OrganisationUnitGroup = {
     favorites: string[];
     featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
     formName: string;
-    geometry: unknown;
+    geometry: D2Geometry;
     groupSets: D2OrganisationUnitGroupSet[];
     href: string;
     id: Id;
@@ -2795,7 +2797,7 @@ export type D2OrganisationUnitGroupSet = {
 
 export type D2OrganisationUnitGroupSetDimension = {
     organisationUnitGroupSet: D2OrganisationUnitGroupSet;
-    organisationUnitGroups: unknown;
+    organisationUnitGroups: object;
 };
 
 export type D2OrganisationUnitLevel = {
@@ -3165,7 +3167,7 @@ export type D2ProgramInstance = {
     favorite: boolean;
     favorites: string[];
     followup: boolean;
-    geometry: unknown;
+    geometry: D2Geometry;
     href: string;
     id: Id;
     incidentDate: string;
@@ -3511,7 +3513,7 @@ export type D2ProgramStageInstance = {
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
-    geometry: unknown;
+    geometry: D2Geometry;
     href: string;
     id: Id;
     lastUpdated: string;
@@ -4213,7 +4215,7 @@ export type D2TrackedEntityInstance = {
     externalAccess: boolean;
     favorite: boolean;
     favorites: string[];
-    geometry: unknown;
+    geometry: D2Geometry;
     href: string;
     id: Id;
     inactive: boolean;
@@ -4225,7 +4227,7 @@ export type D2TrackedEntityInstance = {
     organisationUnit: D2OrganisationUnit;
     potentialDuplicate: boolean;
     programInstances: D2ProgramInstance[];
-    programOwners: unknown[];
+    programOwners: D2ProgramOwner[];
     publicAccess: string;
     relationshipItems: unknown[];
     sharing: Sharing;
@@ -5441,7 +5443,7 @@ export interface D2CategoryComboSchema {
 export interface D2CategoryDimensionSchema {
     name: "D2CategoryDimension";
     model: D2CategoryDimension;
-    fields: { category: D2CategorySchema; categoryOptions: unknown };
+    fields: { category: D2CategorySchema; categoryOptions: object };
     fieldPresets: {
         $all: Preset<D2CategoryDimension, keyof D2CategoryDimension>;
         $identifiable: Preset<D2CategoryDimension, FieldPresets["identifiable"]>;
@@ -5916,7 +5918,7 @@ export interface D2CategoryOptionGroupSetDimensionSchema {
     model: D2CategoryOptionGroupSetDimension;
     fields: {
         categoryOptionGroupSet: D2CategoryOptionGroupSetSchema;
-        categoryOptionGroups: unknown;
+        categoryOptionGroups: object;
     };
     fieldPresets: {
         $all: Preset<D2CategoryOptionGroupSetDimension, keyof D2CategoryOptionGroupSetDimension>;
@@ -6737,7 +6739,7 @@ export interface D2DataElementGroupSetSchema {
 export interface D2DataElementGroupSetDimensionSchema {
     name: "D2DataElementGroupSetDimension";
     model: D2DataElementGroupSetDimension;
-    fields: { dataElementGroupSet: D2DataElementGroupSetSchema; dataElementGroups: unknown };
+    fields: { dataElementGroupSet: D2DataElementGroupSetSchema; dataElementGroups: object };
     fieldPresets: {
         $all: Preset<D2DataElementGroupSetDimension, keyof D2DataElementGroupSetDimension>;
         $identifiable: Preset<D2DataElementGroupSetDimension, FieldPresets["identifiable"]>;
@@ -9901,7 +9903,7 @@ export interface D2OrganisationUnitSchema {
         favorite: boolean;
         favorites: string[];
         formName: string;
-        geometry: unknown;
+        geometry: D2Geometry;
         href: string;
         id: Id;
         image: D2FileResourceSchema;
@@ -10051,7 +10053,7 @@ export interface D2OrganisationUnitGroupSchema {
         favorites: string[];
         featureType: "NONE" | "MULTI_POLYGON" | "POLYGON" | "POINT" | "SYMBOL";
         formName: string;
-        geometry: unknown;
+        geometry: D2Geometry;
         groupSets: D2OrganisationUnitGroupSetSchema[];
         href: string;
         id: Id;
@@ -10245,7 +10247,7 @@ export interface D2OrganisationUnitGroupSetDimensionSchema {
     model: D2OrganisationUnitGroupSetDimension;
     fields: {
         organisationUnitGroupSet: D2OrganisationUnitGroupSetSchema;
-        organisationUnitGroups: unknown;
+        organisationUnitGroups: object;
     };
     fieldPresets: {
         $all: Preset<
@@ -10971,7 +10973,7 @@ export interface D2ProgramInstanceSchema {
         favorite: boolean;
         favorites: string[];
         followup: boolean;
-        geometry: unknown;
+        geometry: D2Geometry;
         href: string;
         id: Id;
         incidentDate: string;
@@ -11751,7 +11753,7 @@ export interface D2ProgramStageInstanceSchema {
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
-        geometry: unknown;
+        geometry: D2Geometry;
         href: string;
         id: Id;
         lastUpdated: string;
@@ -13130,7 +13132,7 @@ export interface D2TrackedEntityInstanceSchema {
         externalAccess: boolean;
         favorite: boolean;
         favorites: string[];
-        geometry: unknown;
+        geometry: D2Geometry;
         href: string;
         id: Id;
         inactive: boolean;
@@ -13142,7 +13144,7 @@ export interface D2TrackedEntityInstanceSchema {
         organisationUnit: D2OrganisationUnitSchema;
         potentialDuplicate: boolean;
         programInstances: D2ProgramInstanceSchema[];
-        programOwners: unknown[];
+        programOwners: D2ProgramOwnerSchema[];
         publicAccess: string;
         relationshipItems: unknown[];
         sharing: Sharing;

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -76,7 +76,7 @@ function applyFieldTransformers(key: string, value: any) {
     }
 }
 
-function getFieldsAsString(modelFields: FieldsSelector): string {
+export function getFieldsAsString(modelFields: FieldsSelector): string {
     return _(modelFields)
         .map((value0, key0: string) => {
             const { key, value } = applyFieldTransformers(key0, value0);

--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -34,11 +34,7 @@ export class Events {
         params: EventsPostParams,
         request: EventsPostRequest
     ): D2ApiResponse<HttpResponse<EventsPostResponse>> {
-        return this.d2Api.post<HttpResponse<EventsPostResponse>>(
-            "/events",
-            { ...params, async: false },
-            request
-        );
+        return this.d2Api.post<HttpResponse<EventsPostResponse>>("/events", params, request);
     }
 
     postAsync(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,12 @@
 export { D2ApiVersioned, D2ApiGeneric } from "./api/d2Api";
-export { Id, Ref } from "./schemas/base";
 export { D2ApiMock, getMockApiFromClass } from "./testing";
 
 export { ApiContext, useD2, useD2Api } from "./react/context";
 export { useD2ApiData, D2ApiDataHookQuery } from "./react/useD2ApiData";
 export { HttpError } from "./repositories/HttpClientRepository";
 export { Canceler, isCancel } from "./repositories/CancelableResponse";
+export * from "./api/events";
+
+export { CancelableResponse } from "./repositories/CancelableResponse";
+export { Id, Ref, D2Geometry } from "./schemas";
+export * from "./api/events";

--- a/src/schemas/base.ts
+++ b/src/schemas/base.ts
@@ -64,7 +64,8 @@ export type D2Coordinates = [number, number];
 
 export type D2Geometry =
     | { type: "Point"; coordinates: D2Coordinates }
-    | { type: "Polygon"; coordinates: Array<D2Coordinates[]> };
+    | { type: "Polygon"; coordinates: Array<D2Coordinates[]> }
+    | { type: "MultiPolygon"; coordinates: Array<Array<D2Coordinates[]>> };
 
 export interface D2Expression {
     expression: string;

--- a/src/schemas/base.ts
+++ b/src/schemas/base.ts
@@ -169,8 +169,16 @@ export interface D2AttributeValueGenericSchema<D2Attribute, D2AttributeSchema> {
 export type FieldPreset = "$all" | "$identifiable" | "$nameable" | "$persisted" | "$owner";
 
 export interface FieldPresets {
-    identifiable: "id" | "name" | "code" | "created" | "lastUpdated";
-    nameable: "id" | "name" | "shortName" | "code" | "description" | "created" | "lastUpdated";
+    identifiable: "id" | "name" | "code" | "created" | "lastUpdated" | "href";
+    nameable:
+        | "id"
+        | "name"
+        | "shortName"
+        | "code"
+        | "description"
+        | "created"
+        | "lastUpdated"
+        | "href";
 }
 
 export type Preset<Model, Properties> = OmitNever<

--- a/src/scripts/generate-schemas.ts
+++ b/src/scripts/generate-schemas.ts
@@ -61,6 +61,7 @@ const interfaceFromClass: _.Dictionary<string | { type: string; schema: string }
     "org.hisp.dhis.common.ObjectStyle": "D2Style",
     "org.hisp.dhis.common.DimensionalKeywords": "D2DimensionalKeywords",
     "com.vividsolutions.jts.geom.Geometry": "D2Geometry",
+    "org.locationtech.jts.geom.Geometry": "D2Geometry",
     "org.hisp.dhis.expression.Expression": "D2Expression",
     "org.hisp.dhis.period.PeriodType": "string",
     "org.hisp.dhis.chart.Series": "unknown",
@@ -98,6 +99,20 @@ const interfaceFromClass: _.Dictionary<string | { type: string; schema: string }
     "org.hisp.dhis.visualization.Axis": "D2Axis",
     "java.lang.Object": "object",
     "java.util.Map": "object",
+    "java.util.List": "object",
+    "org.hisp.dhis.common.DimensionItemKeywords": "unknown",
+    "org.hisp.dhis.common.ValueTypeOptions": "unknown",
+    "org.hisp.dhis.dashboard.design.ItemConfig": "unknown",
+    "org.hisp.dhis.dashboard.design.Layout": "unknown",
+    "org.hisp.dhis.program.UserInfoSnapshot": "unknown",
+    "org.hisp.dhis.scheduling.JobParameters": "unknown",
+    "org.hisp.dhis.security.apikey.ApiTokenAttribute": "unknown",
+    "org.hisp.dhis.visualization.AxisV2": "unknown",
+    "org.hisp.dhis.visualization.LegendDefinitions": "unknown",
+    "org.hisp.dhis.visualization.OutlierAnalysis": "unknown",
+    "org.hisp.dhis.visualization.Series": "unknown",
+    "org.hisp.dhis.visualization.SeriesKey": "unknown",
+    "org.hisp.dhis.visualization.VisualizationFontStyle": "unknown",
 };
 
 function getModelName(klass: string, suffix?: string): string {
@@ -260,7 +275,7 @@ async function generateSchema(instance: Instance) {
 
         import {
             Id, Ref, Preset, FieldPresets, D2SchemaProperties,
-            D2Access, D2Translation, D2Geometry,  D2Style,
+            D2Access, D2Translation, D2Geometry, D2Style,
             D2DimensionalKeywords, D2Expression,
             D2RelationshipConstraint, D2ReportingParams, D2Axis, Sharing,
             D2ProgramOwner, D2ProgramOwnerSchema,


### PR DESCRIPTION
Required by: https://app.clickup.com/t/1yyx3m4
May benefit: https://app.clickup.com/t/1yt6b2e

Implementation:

- v2.36 changed the fields that the events endpoint returned by default, which breaks apps. Since the endpoint now has full support for schema-able `fields`, we've made it compulsory (like we do when querying metadata or model objects) so apps will be forced to pass which specific `fields` are needed. 
- On the same line, apps will be probably using `Event` from the API, but now that's the global type and the specific type will depend on the fields. Good thing is that TS will force the dev to refactor it.
- Type `Event` has been renamed to `D2Event`. Reasons: 1) align with all other interface names from the API. 2) `Event` is a global interface name, it's bad practice to clobber them.
- Add missing fields to `D2Event`.
- Add missing Multipolygon to `D2Geometry`.
- Re-run schemas generation to current stable DHIS2 versions.

Example of usage:

```
const events$ = api.events.get({
    fields: {
        event: true,
        orgUnit: true,
        dataValues: { dataElement: true, value: true },
    }
})
```