### PR TITLE
Add data property to access if schema is dataShareable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@eyeseetea/d2-api",
     "description": "Typed wrapper over DHIS2 API",
-    "version": "1.12.0",
+    "version": "1.12.1-beta.1",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "repository": {

--- a/src/2.35/schemas.ts
+++ b/src/2.35/schemas.ts
@@ -7,6 +7,7 @@ import {
     FieldPresets,
     D2SchemaProperties,
     D2Access,
+    D2AccessWithData,
     D2Translation,
     D2Geometry,
     D2Style,
@@ -290,7 +291,7 @@ export type D2CategoryDimension = {
 };
 
 export type D2CategoryOption = {
-    access: D2Access;
+    access: D2AccessWithData;
     aggregationType:
         | "SUM"
         | "AVERAGE"
@@ -1206,7 +1207,7 @@ export type D2DataInputPeriod = {
 };
 
 export type D2DataSet = {
-    access: D2Access;
+    access: D2AccessWithData;
     aggregationType:
         | "SUM"
         | "AVERAGE"
@@ -2861,7 +2862,7 @@ export type D2PredictorGroup = {
 };
 
 export type D2Program = {
-    access: D2Access;
+    access: D2AccessWithData;
     accessLevel: "OPEN" | "AUDITED" | "PROTECTED" | "CLOSED";
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     categoryCombo: D2CategoryCombo;
@@ -3345,7 +3346,7 @@ export type D2ProgramSection = {
 };
 
 export type D2ProgramStage = {
-    access: D2Access;
+    access: D2AccessWithData;
     allowGenerateNextVisit: boolean;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     autoGenerateEvent: boolean;
@@ -3745,7 +3746,7 @@ export type D2Relationship = {
 };
 
 export type D2RelationshipType = {
-    access: D2Access;
+    access: D2AccessWithData;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     bidirectional: boolean;
     code: Id;
@@ -4289,7 +4290,7 @@ export type D2TrackedEntityProgramIndicatorDimension = {
 };
 
 export type D2TrackedEntityType = {
-    access: D2Access;
+    access: D2AccessWithData;
     allowAuditLog: boolean;
     attributeValues: D2AttributeValueGeneric<D2Attribute>[];
     code: Id;
@@ -5364,7 +5365,7 @@ export interface D2CategoryOptionSchema {
     name: "D2CategoryOption";
     model: D2CategoryOption;
     fields: {
-        access: D2Access;
+        access: D2AccessWithData;
         aggregationType:
             | "SUM"
             | "AVERAGE"
@@ -6962,7 +6963,7 @@ export interface D2DataSetSchema {
     name: "D2DataSet";
     model: D2DataSet;
     fields: {
-        access: D2Access;
+        access: D2AccessWithData;
         aggregationType:
             | "SUM"
             | "AVERAGE"
@@ -10510,7 +10511,7 @@ export interface D2ProgramSchema {
     name: "D2Program";
     model: D2Program;
     fields: {
-        access: D2Access;
+        access: D2AccessWithData;
         accessLevel: "OPEN" | "AUDITED" | "PROTECTED" | "CLOSED";
         attributeValues: D2AttributeValueGenericSchema<D2Attribute, D2AttributeSchema>[];
         categoryCombo: D2CategoryComboSchema;
@@ -11508,7 +11509,7 @@ export interface D2ProgramStageSchema {
     name: "D2ProgramStage";
     model: D2ProgramStage;
     fields: {
-        access: D2Access;
+        access: D2AccessWithData;
         allowGenerateNextVisit: boolean;
         attributeValues: D2AttributeValueGenericSchema<D2Attribute, D2AttributeSchema>[];
         autoGenerateEvent: boolean;
@@ -12375,7 +12376,7 @@ export interface D2RelationshipTypeSchema {
     name: "D2RelationshipType";
     model: D2RelationshipType;
     fields: {
-        access: D2Access;
+        access: D2AccessWithData;
         attributeValues: D2AttributeValueGenericSchema<D2Attribute, D2AttributeSchema>[];
         bidirectional: boolean;
         code: Id;
@@ -13419,7 +13420,7 @@ export interface D2TrackedEntityTypeSchema {
     name: "D2TrackedEntityType";
     model: D2TrackedEntityType;
     fields: {
-        access: D2Access;
+        access: D2AccessWithData;
         allowAuditLog: boolean;
         attributeValues: D2AttributeValueGenericSchema<D2Attribute, D2AttributeSchema>[];
         code: Id;

--- a/src/2.36/schemas.ts
+++ b/src/2.36/schemas.ts
@@ -7,6 +7,7 @@ import {
     FieldPresets,
     D2SchemaProperties,
     D2Access,
+    D2AccessWithData,
     D2Translation,
     D2Geometry,
     D2Style,
@@ -305,7 +306,7 @@ export type D2CategoryDimension = {
 };
 
 export type D2CategoryOption = {
-    access: D2Access;
+    access: D2AccessWithData;
     aggregationType:
         | "SUM"
         | "AVERAGE"
@@ -1256,7 +1257,7 @@ export type D2DataInputPeriod = {
 };
 
 export type D2DataSet = {
-    access: D2Access;
+    access: D2AccessWithData;
     aggregationType:
         | "SUM"
         | "AVERAGE"
@@ -2985,7 +2986,7 @@ export type D2PredictorGroup = {
 };
 
 export type D2Program = {
-    access: D2Access;
+    access: D2AccessWithData;
     accessLevel: "OPEN" | "AUDITED" | "PROTECTED" | "CLOSED";
     attributeValues: D2AttributeValue[];
     categoryCombo: D2CategoryCombo;
@@ -3489,7 +3490,7 @@ export type D2ProgramSection = {
 };
 
 export type D2ProgramStage = {
-    access: D2Access;
+    access: D2AccessWithData;
     allowGenerateNextVisit: boolean;
     attributeValues: D2AttributeValue[];
     autoGenerateEvent: boolean;
@@ -3910,7 +3911,7 @@ export type D2Relationship = {
 };
 
 export type D2RelationshipType = {
-    access: D2Access;
+    access: D2AccessWithData;
     attributeValues: D2AttributeValue[];
     bidirectional: boolean;
     code: Id;
@@ -4240,7 +4241,7 @@ export type D2Section = {
 };
 
 export type D2SqlView = {
-    access: D2Access;
+    access: D2AccessWithData;
     attributeValues: D2AttributeValue[];
     cacheStrategy:
         | "NO_CACHE"
@@ -4474,7 +4475,7 @@ export type D2TrackedEntityProgramIndicatorDimension = {
 };
 
 export type D2TrackedEntityType = {
-    access: D2Access;
+    access: D2AccessWithData;
     allowAuditLog: boolean;
     attributeValues: D2AttributeValue[];
     code: Id;
@@ -5588,7 +5589,7 @@ export interface D2CategoryOptionSchema {
     name: "D2CategoryOption";
     model: D2CategoryOption;
     fields: {
-        access: D2Access;
+        access: D2AccessWithData;
         aggregationType:
             | "SUM"
             | "AVERAGE"
@@ -7184,7 +7185,7 @@ export interface D2DataSetSchema {
     name: "D2DataSet";
     model: D2DataSet;
     fields: {
-        access: D2Access;
+        access: D2AccessWithData;
         aggregationType:
             | "SUM"
             | "AVERAGE"
@@ -10742,7 +10743,7 @@ export interface D2ProgramSchema {
     name: "D2Program";
     model: D2Program;
     fields: {
-        access: D2Access;
+        access: D2AccessWithData;
         accessLevel: "OPEN" | "AUDITED" | "PROTECTED" | "CLOSED";
         attributeValues: D2AttributeValueSchema[];
         categoryCombo: D2CategoryComboSchema;
@@ -11750,7 +11751,7 @@ export interface D2ProgramStageSchema {
     name: "D2ProgramStage";
     model: D2ProgramStage;
     fields: {
-        access: D2Access;
+        access: D2AccessWithData;
         allowGenerateNextVisit: boolean;
         attributeValues: D2AttributeValueSchema[];
         autoGenerateEvent: boolean;
@@ -12632,7 +12633,7 @@ export interface D2RelationshipTypeSchema {
     name: "D2RelationshipType";
     model: D2RelationshipType;
     fields: {
-        access: D2Access;
+        access: D2AccessWithData;
         attributeValues: D2AttributeValueSchema[];
         bidirectional: boolean;
         code: Id;
@@ -13180,7 +13181,7 @@ export interface D2SqlViewSchema {
     name: "D2SqlView";
     model: D2SqlView;
     fields: {
-        access: D2Access;
+        access: D2AccessWithData;
         attributeValues: D2AttributeValueSchema[];
         cacheStrategy:
             | "NO_CACHE"
@@ -13676,7 +13677,7 @@ export interface D2TrackedEntityTypeSchema {
     name: "D2TrackedEntityType";
     model: D2TrackedEntityType;
     fields: {
-        access: D2Access;
+        access: D2AccessWithData;
         allowAuditLog: boolean;
         attributeValues: D2AttributeValueSchema[];
         code: Id;

--- a/src/2.37/schemas.ts
+++ b/src/2.37/schemas.ts
@@ -7,6 +7,7 @@ import {
     FieldPresets,
     D2SchemaProperties,
     D2Access,
+    D2AccessWithData,
     D2Translation,
     D2Geometry,
     D2Style,
@@ -333,7 +334,7 @@ export type D2CategoryDimension = {
 };
 
 export type D2CategoryOption = {
-    access: D2Access;
+    access: D2AccessWithData;
     aggregationType:
         | "SUM"
         | "AVERAGE"
@@ -1153,7 +1154,7 @@ export type D2DataInputPeriod = {
 };
 
 export type D2DataSet = {
-    access: D2Access;
+    access: D2AccessWithData;
     aggregationType:
         | "SUM"
         | "AVERAGE"
@@ -2890,7 +2891,7 @@ export type D2PredictorGroup = {
 };
 
 export type D2Program = {
-    access: D2Access;
+    access: D2AccessWithData;
     accessLevel: "OPEN" | "AUDITED" | "PROTECTED" | "CLOSED";
     attributeValues: D2AttributeValue[];
     categoryCombo: D2CategoryCombo;
@@ -3398,7 +3399,7 @@ export type D2ProgramSection = {
 };
 
 export type D2ProgramStage = {
-    access: D2Access;
+    access: D2AccessWithData;
     allowGenerateNextVisit: boolean;
     attributeValues: D2AttributeValue[];
     autoGenerateEvent: boolean;
@@ -3819,7 +3820,7 @@ export type D2Relationship = {
 };
 
 export type D2RelationshipType = {
-    access: D2Access;
+    access: D2AccessWithData;
     attributeValues: D2AttributeValue[];
     bidirectional: boolean;
     code: Id;
@@ -4042,7 +4043,7 @@ export type D2Section = {
 };
 
 export type D2SqlView = {
-    access: D2Access;
+    access: D2AccessWithData;
     attributeValues: D2AttributeValue[];
     cacheStrategy:
         | "NO_CACHE"
@@ -4279,7 +4280,7 @@ export type D2TrackedEntityProgramIndicatorDimension = {
 };
 
 export type D2TrackedEntityType = {
-    access: D2Access;
+    access: D2AccessWithData;
     allowAuditLog: boolean;
     attributeValues: D2AttributeValue[];
     code: Id;
@@ -5457,7 +5458,7 @@ export interface D2CategoryOptionSchema {
     name: "D2CategoryOption";
     model: D2CategoryOption;
     fields: {
-        access: D2Access;
+        access: D2AccessWithData;
         aggregationType:
             | "SUM"
             | "AVERAGE"
@@ -6910,7 +6911,7 @@ export interface D2DataSetSchema {
     name: "D2DataSet";
     model: D2DataSet;
     fields: {
-        access: D2Access;
+        access: D2AccessWithData;
         aggregationType:
             | "SUM"
             | "AVERAGE"
@@ -10480,7 +10481,7 @@ export interface D2ProgramSchema {
     name: "D2Program";
     model: D2Program;
     fields: {
-        access: D2Access;
+        access: D2AccessWithData;
         accessLevel: "OPEN" | "AUDITED" | "PROTECTED" | "CLOSED";
         attributeValues: D2AttributeValueSchema[];
         categoryCombo: D2CategoryComboSchema;
@@ -11498,7 +11499,7 @@ export interface D2ProgramStageSchema {
     name: "D2ProgramStage";
     model: D2ProgramStage;
     fields: {
-        access: D2Access;
+        access: D2AccessWithData;
         allowGenerateNextVisit: boolean;
         attributeValues: D2AttributeValueSchema[];
         autoGenerateEvent: boolean;
@@ -12380,7 +12381,7 @@ export interface D2RelationshipTypeSchema {
     name: "D2RelationshipType";
     model: D2RelationshipType;
     fields: {
-        access: D2Access;
+        access: D2AccessWithData;
         attributeValues: D2AttributeValueSchema[];
         bidirectional: boolean;
         code: Id;
@@ -12810,7 +12811,7 @@ export interface D2SqlViewSchema {
     name: "D2SqlView";
     model: D2SqlView;
     fields: {
-        access: D2Access;
+        access: D2AccessWithData;
         attributeValues: D2AttributeValueSchema[];
         cacheStrategy:
             | "NO_CACHE"
@@ -13315,7 +13316,7 @@ export interface D2TrackedEntityTypeSchema {
     name: "D2TrackedEntityType";
     model: D2TrackedEntityType;
     fields: {
-        access: D2Access;
+        access: D2AccessWithData;
         allowAuditLog: boolean;
         attributeValues: D2AttributeValueSchema[];
         code: Id;

--- a/src/schemas/base.ts
+++ b/src/schemas/base.ts
@@ -15,6 +15,13 @@ export interface D2Access {
     manage: boolean;
 }
 
+export interface D2AccessWithData extends D2Access {
+    data: {
+        read: boolean;
+        write: boolean;
+    };
+}
+
 type GetDefaultSchema<Model> = {
     fields: Model;
     fieldPresets: {


### PR DESCRIPTION
Required by https://app.clickup.com/t/2amhvhn

Currently, the property "access" did not contain "data", but `dataShareable`-models do have this property: add dynamically depending on the schema.