### PR TITLE
Refine events endpoint (status values, 409 control, filter field)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@eyeseetea/d2-api",
     "description": "Typed wrapper over DHIS2 API",
-    "version": "1.12.1-beta.1",
+    "version": "1.12.1-beta.2",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "repository": {

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -209,3 +209,11 @@ export type AsyncPostResponse<Type extends TaskCategory> = HttpResponse<{
     jobType: Type;
     relativeNotifierEndpoint: string;
 }>;
+
+export function validate2xx(status: number): boolean {
+    return status >= 200 && status < 300;
+}
+
+export function validate404(status: number): boolean {
+    return validate2xx(status) || status === 404;
+}

--- a/src/api/d2Api.ts
+++ b/src/api/d2Api.ts
@@ -1,6 +1,6 @@
 import { AxiosHttpClientRepository } from "../data/AxiosHttpClientRepository";
 import { FetchHttpClientRepository } from "../data/FetchHttpClientRepository";
-import { HttpClientRepository } from "../repositories/HttpClientRepository";
+import { HttpClientRepository, HttpRequest } from "../repositories/HttpClientRepository";
 import { D2SchemaProperties } from "../schemas";
 import { cache, defineLazyCachedProperty } from "../utils/cache";
 import { joinPath } from "../utils/connection";
@@ -58,8 +58,8 @@ export class D2ApiGeneric {
         return this.request<T>({ method: "get", url, params });
     }
 
-    public post<T>(url: string, params?: Params, data?: object) {
-        return this.request<T>({ method: "post", url, params, data });
+    public post<T>(url: string, params?: Params, data?: object, request?: Partial<HttpRequest>) {
+        return this.request<T>({ method: "post", url, params, data, ...request });
     }
 
     public put<T>(url: string, params?: Params, data?: object) {

--- a/src/api/dataStore.ts
+++ b/src/api/dataStore.ts
@@ -1,4 +1,4 @@
-import { D2ApiResponse, HttpResponse } from "./common";
+import { D2ApiResponse, HttpResponse, validate2xx, validate404 } from "./common";
 import { HttpResponse as HttpClientResponse } from "../repositories/HttpClientRepository";
 import { D2ApiGeneric } from "./d2Api";
 
@@ -80,14 +80,6 @@ export class DataStore {
             })
             .map(response => (response.status === 404 ? false : response.data.status === "OK"));
     }
-}
-
-function validate2xx(status: number): boolean {
-    return status >= 200 && status < 300;
-}
-
-function validate404(status: number): boolean {
-    return validate2xx(status) || status === 404;
 }
 
 function validateResponse(response: HttpClientResponse<HttpResponse<unknown>>): undefined {


### PR DESCRIPTION
Required by https://app.clickup.com/t/29qy7bq

Notes:

- `/api/events` supports a custom `filter` param, see https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/tracker.html#webapi_events (not specifically documented for events)
- A 409 is considered a valid response, the caller can then inspect the response.
- Add WARNING as a possible status value for importSummaries.