### PR TITLE
[tracker] Fix Enrollment.events type + create TEI-to-post type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@eyeseetea/d2-api",
     "description": "Typed wrapper over DHIS2 API",
-    "version": "1.13.1",
+    "version": "1.13.2-beta.1",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "repository": {

--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -93,25 +93,26 @@ type GetEvent<Fields> = SelectedPick<D2EventSchema, Fields>;
 
 export type EventStatus = "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULED" | "OVERDUE" | "SKIPPED";
 
-export interface EventsPostRequest {
-    events: Array<{
-        event?: string;
-        orgUnit: string;
-        program: string;
-        status: EventStatus;
-        eventDate: string;
-        coordinate?: {
-            latitude: number;
-            longitude: number;
-        };
-        attributeOptionCombo?: string;
-        trackedEntityInstance?: string;
-        programStage?: string;
-        dataValues: Array<{
-            dataElement: string;
-            value: string | number | boolean;
-        }>;
+export interface D2EventToPost {
+    event?: string;
+    orgUnit: string;
+    program: string;
+    status: EventStatus;
+    eventDate: string;
+    coordinate?: {
+        latitude: number;
+        longitude: number;
+    };
+    attributeOptionCombo?: string;
+    trackedEntityInstance?: string;
+    programStage?: string;
+    dataValues: Array<{
+        dataElement: string;
+        value: string | number | boolean;
     }>;
+}
+export interface EventsPostRequest {
+    events: D2EventToPost[];
 }
 
 export type EventsPostParams = Partial<{

--- a/src/api/trackedEntityInstances.ts
+++ b/src/api/trackedEntityInstances.ts
@@ -3,6 +3,7 @@ import { PartialBy } from "../utils/types";
 import { Id, Pager } from "./base";
 import { AsyncPostResponse, D2ApiResponse, HttpResponse } from "./common";
 import { D2ApiGeneric } from "./d2Api";
+import { D2Event, D2EventToPost } from "./events";
 
 export class TrackedEntityInstances {
     constructor(public d2Api: D2ApiGeneric) {}
@@ -62,10 +63,14 @@ interface TrackedEntityInstanceBase {
     programOwners: D2ProgramOwner[];
 }
 
-export type TrackedEntityInstanceToPost = PartialBy<
+type TeiPartial = PartialBy<
     TrackedEntityInstance,
     Exclude<keyof TrackedEntityInstance, "trackedEntityInstance" | "orgUnit">
 >;
+
+export interface TrackedEntityInstanceToPost extends Omit<TeiPartial, "enrollments"> {
+    enrollments: EnrollmentToPost[];
+}
 
 export type TrackedEntityInstance = TeiGeometryNone | TeiGeometryPoint | TeiGeometryPolygon;
 
@@ -115,7 +120,16 @@ export interface Enrollment {
     orgUnit: Id;
     enrollmentDate: string;
     incidentDate: string;
-    events?: Event[];
+    events?: D2Event[];
+}
+
+export interface EnrollmentToPost extends Omit<Enrollment, "events"> {
+    enrollment: Id;
+    program: Id;
+    orgUnit: Id;
+    enrollmentDate: string;
+    incidentDate: string;
+    events?: D2EventToPost[];
 }
 
 export interface AttributeValue {


### PR DESCRIPTION
This is a type-only improvement:

- Fix usage of `Event` in `Enrollment` type (was using the global DOM Event, not `D2Event`)
- Create `TrackedEntityInstanceToPost`.