### PR TITLE
New tracker endpoints: /events & /trackedEntities

### DIFF
--- a/src/api/tracker.ts
+++ b/src/api/tracker.ts
@@ -1,7 +1,7 @@
 import { cache } from "../utils/cache";
 import { D2TrackerEnrollment, TrackerEnrollments } from "./trackerEnrollments";
 import { D2ApiResponse } from "./base";
-import { AsyncPostResponse, HttpResponse } from "./common";
+import { AsyncPostResponse } from "./common";
 import { D2ApiGeneric } from "./d2Api";
 import { D2TrackerEvent, TrackerEvents } from "./trackerEvents";
 import { TrackedEntities } from "./trackerTrackedEntities";
@@ -26,8 +26,8 @@ export class Tracker {
     post(
         params: TrackerPostParams,
         request: TrackerPostRequest
-    ): D2ApiResponse<HttpResponse<TrackerPostResponse>> {
-        return this.d2Api.post<HttpResponse<TrackerPostResponse>>(
+    ): D2ApiResponse<TrackerPostResponse> {
+        return this.d2Api.post<TrackerPostResponse>(
             "/tracker",
             { ...params, async: false },
             request

--- a/src/api/tracker.ts
+++ b/src/api/tracker.ts
@@ -3,13 +3,24 @@ import { D2TrackerEnrollment, TrackerEnrollments } from "./trackerEnrollments";
 import { D2ApiResponse } from "./base";
 import { AsyncPostResponse, HttpResponse } from "./common";
 import { D2ApiGeneric } from "./d2Api";
+import { D2TrackerEvent, TrackerEvents } from "./trackerEvents";
+import { TrackedEntities } from "./trackerTrackedEntities";
+import { D2TrackerTrackedEntity } from "./trackerTrackedEntities";
 
 export class Tracker {
     constructor(public d2Api: D2ApiGeneric) {}
 
     @cache()
+    get trackedEntities() {
+        return new TrackedEntities(this.d2Api);
+    }
+    @cache()
     get enrollments() {
         return new TrackerEnrollments(this.d2Api);
+    }
+    @cache()
+    get events() {
+        return new TrackerEvents(this.d2Api);
     }
 
     post(
@@ -36,14 +47,9 @@ export class Tracker {
 }
 
 export interface TrackerPostRequest {
-    trackedEntities: TrackedEntity[];
-}
-
-export interface TrackedEntity {
-    orgUnit: string;
-    trackedEntity: string;
-    trackedEntityType: string;
+    trackedEntities?: D2TrackerTrackedEntity[];
     enrollments?: D2TrackerEnrollment[];
+    events?: D2TrackerEvent[];
 }
 
 type SchemeOptions = "UID" | "CODE" | "NAME" | "ATTRIBUTE";

--- a/src/api/trackerEnrollments.ts
+++ b/src/api/trackerEnrollments.ts
@@ -2,6 +2,7 @@ import { D2ApiGeneric } from "./d2Api";
 import { Id, Selector, D2ApiResponse, SelectedPick } from "./base";
 import { Preset, FieldPresets } from "../schemas";
 import { getFieldsAsString } from "./common";
+import { D2TrackerEvent } from "./trackerEvents";
 import _ from "lodash";
 
 export class TrackerEnrollments {
@@ -40,7 +41,7 @@ export interface D2TrackerEnrollment {
     followUp: boolean;
     deleted: boolean;
     storedBy: Username;
-    events: D2TrackerEnrollmentEvent[];
+    events: D2TrackerEvent[];
     relationships: [];
     attributes: D2TrackerEnrollmentAttribute[];
     notes: [];
@@ -49,15 +50,6 @@ export interface D2TrackerEnrollment {
 export interface D2TrackerEnrollmentAttribute {
     attribute: string;
     value: Date | string | number;
-}
-
-export interface D2TrackerEnrollmentEvent {
-    program: string;
-    event: string;
-    programStage: string;
-    orgUnit: string;
-    dataValues: { dataElement: string; value: string | number }[];
-    occurredAt: string;
 }
 
 type TrackerEnrollmentsParams<Fields> = Params & { fields: Fields } & Partial<{

--- a/src/api/trackerEvents.ts
+++ b/src/api/trackerEvents.ts
@@ -1,0 +1,125 @@
+import { D2ApiGeneric } from "./d2Api";
+import { Id, Selector, D2ApiResponse } from "./base";
+import { Preset, FieldPresets } from "../schemas";
+import { getFieldsAsString } from "./common";
+import { D2Relationship, D2RelationshipSchema } from "../2.36";
+import { D2EventDataValueSchema, EventStatus, IdScheme } from "./events";
+import _ from "lodash";
+
+export class TrackerEvents {
+    constructor(public api: D2ApiGeneric) {}
+
+    get<Fields extends D2TrackerEventFields>(
+        params: EventsParams<Fields>
+    ): D2ApiResponse<TrackerEventsResponse> {
+        return this.api.get<TrackerEventsResponse>("/tracker/events", {
+            ..._.omit(params, ["fields"]),
+            fields: getFieldsAsString(params.fields),
+        });
+    }
+}
+
+type ProgramStatus = "ACTIVE" | "COMPLETED" | "CANCELLED";
+type IsoDate = string;
+type Username = string;
+type CommaDelimitedListOfUid = string;
+type CommaDelimitedListOfAttributeFilter = string;
+type CommaDelimitedListOfDataElementFilter = string;
+
+export interface D2TrackerEvent {
+    event: Id;
+    status: EventStatus;
+    program: Id;
+    programStage: Id;
+    enrollment: Id;
+    orgUnit: Id;
+    orgUnitName: string;
+    relationships: D2Relationship[];
+    occurredAt: IsoDate;
+    scheduledAt: IsoDate;
+    storedBy: Username;
+    followup: boolean;
+    deleted: boolean;
+    createdAt: IsoDate;
+    updatedAt: IsoDate;
+    attributeOptionCombo: Id;
+    attributeCategoryOptions: Id;
+    updatedBy: Username;
+    dataValues: DataValue[];
+    notes: string;
+}
+
+export interface EventsParams<Fields> {
+    fields: Fields;
+    program?: Id;
+    programStage?: Id;
+    programStatus?: ProgramStatus;
+    filter?: CommaDelimitedListOfDataElementFilter;
+    filterAttributes?: CommaDelimitedListOfAttributeFilter;
+    followUp?: boolean;
+    trackedEntity?: Id;
+    orgUnit?: Id;
+    event?: string;
+    ouMode?: "SELECTED" | "CHILDREN" | "DESCENDANTS";
+    status?: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULED" | "OVERDUE" | "SKIPPED";
+    occurredAfter?: IsoDate;
+    occurredBefore?: IsoDate;
+    scheduledAfter?: IsoDate;
+    scheduledBefore?: IsoDate;
+    updatedAt?: IsoDate;
+    updatedAfter?: IsoDate;
+    updatedBefore?: IsoDate;
+    updatedWithin?: IsoDate;
+    enrollmentEnrolledAfter?: IsoDate;
+    enrollmentEnrolledBefore?: IsoDate;
+    enrollmentOccurredAfter?: IsoDate;
+    enrollmentOccurredBefore?: IsoDate;
+    skipMeta?: boolean;
+    dataElementIdScheme?: IdScheme;
+    categoryOptionComboIdScheme?: IdScheme;
+    orgUnitIdScheme?: IdScheme;
+    programIdScheme?: IdScheme;
+    programStageIdScheme?: IdScheme;
+    idScheme?: IdScheme;
+    order?: CommaDelimitedListOfUid;
+    skipEventId?: boolean;
+    attributeCc?: string;
+    attributeCos?: string;
+    includeDeleted?: boolean;
+    assignedUserMode?: "CURRENT" | "PROVIDED" | "NONE" | "ANY";
+    assignedUser?: CommaDelimitedListOfUid;
+}
+
+interface DataValue {
+    updatedAt: IsoDate;
+    storedBy?: Username;
+    createdAt: IsoDate;
+    dataElement: Id;
+    value: string | number | boolean;
+    providedElsewhere: boolean;
+}
+
+export interface TrackerEventsResponse {
+    page: number;
+    pageSize: number;
+    instances: D2TrackerEvent[];
+    total?: number; // Only if requested with totalPages=true
+}
+
+interface D2TrackerEventSchema {
+    name: "D2TrackerEvent";
+    model: D2TrackerEvent;
+    fields: D2TrackerEvent & {
+        dataValues: D2EventDataValueSchema[];
+        relationships: D2RelationshipSchema[];
+    };
+    fieldPresets: {
+        $all: Preset<D2TrackerEvent, keyof D2TrackerEvent>;
+        $identifiable: Preset<D2TrackerEvent, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2TrackerEvent, FieldPresets["nameable"]>;
+        $persisted: Preset<D2TrackerEvent, never>;
+        $owner: Preset<D2TrackerEvent, never>;
+    };
+}
+
+type D2TrackerEventFields = Selector<D2TrackerEventSchema>;

--- a/src/api/trackerEvents.ts
+++ b/src/api/trackerEvents.ts
@@ -2,8 +2,6 @@ import { D2ApiGeneric } from "./d2Api";
 import { Id, Selector, D2ApiResponse } from "./base";
 import { Preset, FieldPresets, D2Geometry } from "../schemas";
 import { getFieldsAsString } from "./common";
-import { D2Relationship, D2RelationshipSchema } from "../2.36";
-import { D2EventDataValueSchema, EventStatus, IdScheme } from "./events";
 import _ from "lodash";
 
 export class TrackerEvents {
@@ -25,6 +23,14 @@ type Username = string;
 type CommaDelimitedListOfUid = string;
 type CommaDelimitedListOfAttributeFilter = string;
 type CommaDelimitedListOfDataElementFilter = string;
+type UserInfo = {
+    uid: Id;
+    username: string;
+    firstName: string;
+    surname: string;
+};
+type EventStatus = "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULED" | "OVERDUE" | "SKIPPED";
+type IdScheme = string;
 
 interface D2TrackerEventBase {
     event: Id;
@@ -32,9 +38,10 @@ interface D2TrackerEventBase {
     program: Id;
     programStage?: Id;
     enrollment?: Id;
+    enrollmentStatus?: "ACTIVE" | "COMPLETED" | "CANCELLED";
     orgUnit: Id;
     orgUnitName?: string;
-    relationships?: D2Relationship[];
+    relationships?: [];
     occurredAt: IsoDate;
     scheduledAt?: IsoDate;
     storedBy?: Username;
@@ -42,11 +49,13 @@ interface D2TrackerEventBase {
     deleted?: boolean;
     createdAt?: IsoDate;
     updatedAt?: IsoDate;
+    createdBy?: UserInfo;
     attributeOptionCombo?: Id;
     attributeCategoryOptions?: Id;
-    updatedBy?: Username;
+    updatedBy?: UserInfo;
     dataValues: DataValue[];
-    notes?: string;
+    notes?: string[];
+    trackedEntity?: Id;
 }
 
 export type D2TrackerEvent = TrackedEntityGeometryPoint | TrackedEntityGeometryPolygon;
@@ -109,6 +118,19 @@ interface EventsParamsBase {
     assignedUser?: CommaDelimitedListOfUid;
 }
 
+interface D2EventDataValueSchema {
+    name: "D2DataValue";
+    model: DataValue;
+    fields: DataValue;
+    fieldPresets: {
+        $all: Preset<DataValue, keyof DataValue>;
+        $identifiable: Preset<DataValue, FieldPresets["identifiable"]>;
+        $nameable: Preset<DataValue, FieldPresets["nameable"]>;
+        $persisted: Preset<DataValue, keyof DataValue>;
+        $owner: Preset<DataValue, keyof DataValue>;
+    };
+}
+
 export interface DataValue {
     updatedAt?: IsoDate;
     storedBy?: Username;
@@ -130,7 +152,6 @@ interface D2TrackerEventSchema {
     model: D2TrackerEvent;
     fields: D2TrackerEvent & {
         dataValues: D2EventDataValueSchema[];
-        relationships: D2RelationshipSchema[];
     };
     fieldPresets: {
         $all: Preset<D2TrackerEvent, keyof D2TrackerEvent>;

--- a/src/api/trackerEvents.ts
+++ b/src/api/trackerEvents.ts
@@ -1,6 +1,6 @@
 import { D2ApiGeneric } from "./d2Api";
 import { Id, Selector, D2ApiResponse } from "./base";
-import { Preset, FieldPresets } from "../schemas";
+import { Preset, FieldPresets, D2Geometry } from "../schemas";
 import { getFieldsAsString } from "./common";
 import { D2Relationship, D2RelationshipSchema } from "../2.36";
 import { D2EventDataValueSchema, EventStatus, IdScheme } from "./events";
@@ -26,28 +26,42 @@ type CommaDelimitedListOfUid = string;
 type CommaDelimitedListOfAttributeFilter = string;
 type CommaDelimitedListOfDataElementFilter = string;
 
-export interface D2TrackerEvent {
+interface D2TrackerEventBase {
     event: Id;
     status: EventStatus;
     program: Id;
-    programStage: Id;
-    enrollment: Id;
+    programStage?: Id;
+    enrollment?: Id;
     orgUnit: Id;
-    orgUnitName: string;
-    relationships: D2Relationship[];
+    orgUnitName?: string;
+    relationships?: D2Relationship[];
     occurredAt: IsoDate;
-    scheduledAt: IsoDate;
-    storedBy: Username;
-    followup: boolean;
-    deleted: boolean;
-    createdAt: IsoDate;
-    updatedAt: IsoDate;
-    attributeOptionCombo: Id;
-    attributeCategoryOptions: Id;
-    updatedBy: Username;
+    scheduledAt?: IsoDate;
+    storedBy?: Username;
+    followup?: boolean;
+    deleted?: boolean;
+    createdAt?: IsoDate;
+    updatedAt?: IsoDate;
+    attributeOptionCombo?: Id;
+    attributeCategoryOptions?: Id;
+    updatedBy?: Username;
     dataValues: DataValue[];
-    notes: string;
+    notes?: string;
 }
+
+export type D2TrackerEvent = TrackedEntityGeometryPoint | TrackedEntityGeometryPolygon;
+
+interface GeometryPoint {
+    geometry?: Extract<D2Geometry, { type: "Point" }>;
+}
+
+interface GeometryPolygon {
+    geometry?: Extract<D2Geometry, { type: "Polygon" }>;
+}
+
+type TrackedEntityGeometryPoint = D2TrackerEventBase & GeometryPoint;
+
+type TrackedEntityGeometryPolygon = D2TrackerEventBase & GeometryPolygon;
 
 type EventsParams<Fields> = EventsParamsBase & { fields: Fields } & Partial<{
         totalPages: boolean;
@@ -95,13 +109,13 @@ interface EventsParamsBase {
     assignedUser?: CommaDelimitedListOfUid;
 }
 
-interface DataValue {
-    updatedAt: IsoDate;
+export interface DataValue {
+    updatedAt?: IsoDate;
     storedBy?: Username;
-    createdAt: IsoDate;
+    createdAt?: IsoDate;
     dataElement: Id;
     value: string | number | boolean;
-    providedElsewhere: boolean;
+    providedElsewhere?: boolean;
 }
 
 export interface TrackerEventsResponse {

--- a/src/api/trackerEvents.ts
+++ b/src/api/trackerEvents.ts
@@ -15,6 +15,17 @@ export class TrackerEvents {
             fields: getFieldsAsString(params.fields),
         });
     }
+
+    getById<Fields extends D2TrackerEventFields>(
+        id: string,
+        params: EventsParams<Fields>
+    ): D2ApiResponse<D2TrackerEvent> {
+        console.log("params", params);
+        return this.api.get<D2TrackerEvent>(`/tracker/events/${id}`, {
+            ..._.omit(params, ["fields"]),
+            fields: getFieldsAsString(params.fields),
+        });
+    }
 }
 
 type ProgramStatus = "ACTIVE" | "COMPLETED" | "CANCELLED";

--- a/src/api/trackerEvents.ts
+++ b/src/api/trackerEvents.ts
@@ -54,7 +54,7 @@ interface D2TrackerEventBase {
     attributeCategoryOptions?: Id;
     updatedBy?: UserInfo;
     dataValues: DataValue[];
-    notes?: string[];
+    notes?: [];
     trackedEntity?: Id;
 }
 

--- a/src/api/trackerEvents.ts
+++ b/src/api/trackerEvents.ts
@@ -20,7 +20,6 @@ export class TrackerEvents {
         id: string,
         params: EventsParams<Fields>
     ): D2ApiResponse<D2TrackerEvent> {
-        console.log("params", params);
         return this.api.get<D2TrackerEvent>(`/tracker/events/${id}`, {
             ..._.omit(params, ["fields"]),
             fields: getFieldsAsString(params.fields),
@@ -98,7 +97,7 @@ interface EventsParamsBase {
     followUp?: boolean;
     trackedEntity?: Id;
     orgUnit?: Id;
-    event?: string;
+    event?: Id;
     ouMode?: "SELECTED" | "CHILDREN" | "DESCENDANTS";
     status?: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULED" | "OVERDUE" | "SKIPPED";
     occurredAfter?: IsoDate;
@@ -147,7 +146,7 @@ export interface DataValue {
     storedBy?: Username;
     createdAt?: IsoDate;
     dataElement: Id;
-    value: string | number | boolean;
+    value: string;
     providedElsewhere?: boolean;
 }
 

--- a/src/api/trackerEvents.ts
+++ b/src/api/trackerEvents.ts
@@ -49,8 +49,13 @@ export interface D2TrackerEvent {
     notes: string;
 }
 
-export interface EventsParams<Fields> {
-    fields: Fields;
+type EventsParams<Fields> = EventsParamsBase & { fields: Fields } & Partial<{
+        totalPages: boolean;
+        page: number;
+        pageSize: number;
+    }>;
+
+interface EventsParamsBase {
     program?: Id;
     programStage?: Id;
     programStatus?: ProgramStatus;

--- a/src/api/trackerTrackedEntities.ts
+++ b/src/api/trackerTrackedEntities.ts
@@ -1,0 +1,155 @@
+import _ from "lodash";
+import { FieldPresets, Preset } from "../schemas";
+import { Id, Selector } from "./base";
+import { D2ApiResponse, getFieldsAsString } from "./common";
+import { D2ApiGeneric } from "./d2Api";
+import { D2TrackerEnrollment } from "./trackerEnrollments";
+import { D2TrackerEvent } from "./trackerEvents";
+
+export class TrackedEntities {
+    constructor(public d2Api: D2ApiGeneric) {}
+
+    get<Fields extends D2TrackerTrackedEntityFields>(
+        params: TrackerTrackedEntitiesParams<Fields>
+    ): D2ApiResponse<TrackedEntitiesGetResponse> {
+        return this.d2Api.get<TrackedEntitiesGetResponse>("/tracker/trackedEntities", {
+            ..._.omit(params, ["fields"]),
+            fields: getFieldsAsString(params.fields),
+        });
+    }
+}
+
+type ProgramStatus = "ACTIVE" | "COMPLETED" | "CANCELLED";
+type IsoDate = string;
+type SemiColonDelimitedListOfUid = string;
+type CommaDelimitedListOfUid = string;
+type CommaDelimitedListOfAttributeFilter = string;
+
+export interface D2TrackerTrackedEntity {
+    trackedEntity?: Id;
+    trackedEntityType?: string;
+    createdAt?: IsoDate;
+    createdAtClient?: IsoDate;
+    updatedAt?: IsoDate;
+    orgUnit?: string;
+    inactive?: boolean;
+    deleted?: boolean;
+    relationships?: Relationship[];
+    attributes?: Attribute[];
+    enrollments?: D2TrackerEnrollment[];
+    events?: D2TrackerEvent[];
+    programOwners?: ProgramOwner[];
+}
+
+interface ProgramOwner {
+    ownerOrgUnit: Id;
+    program: Id;
+    trackedEntity: Id;
+}
+
+export interface Relationship {
+    relationship: Id;
+    relationshipType: Id;
+    relationshipName: string;
+    from: RelationshipItem;
+    to: RelationshipItem;
+}
+
+export interface RelationshipItem {
+    trackedEntity?: {
+        trackedEntity: Id;
+    };
+    event?: { event: Id };
+}
+
+export interface Enrollment {
+    enrollment: Id;
+    program: Id;
+    orgUnit: Id;
+    enrollmentDate: string;
+    incidentDate: string;
+    events?: Event[];
+}
+
+export interface AttributeValue {
+    attribute: Attribute;
+    value: string;
+    optionId?: Id;
+}
+
+export interface Attribute {
+    attribute: Id;
+    valueType?: string;
+    value: string;
+}
+
+export type TrackedEntitiesOuRequest =
+    | { ouMode?: "ACCESSIBLE" | "CAPTURE" | "ALL"; ou?: never[] }
+    | { ouMode?: "SELECTED" | "CHILDREN" | "DESCENDANTS"; ou: Id[] };
+
+type TrackerTrackedEntitiesParams<Fields> = Params & { fields: Fields } & Partial<{
+        totalPages: boolean;
+        page: number;
+        pageSize: number;
+    }>;
+
+type Params =
+    | (TrackedEntitiesParamsBase["orgUnit"] & PartialParams)
+    | ({ ouMode: "ALL" } & PartialParams)
+    | (Pick<TrackedEntitiesParamsBase, "programStatus" | "program"> & PartialParams)
+    | (Pick<TrackedEntitiesParamsBase, "followUp" | "program"> & PartialParams)
+    | (Pick<TrackedEntitiesParamsBase, "enrollmentEnrolledAfter"> & PartialParams)
+    | (Pick<TrackedEntitiesParamsBase, "enrollmentEnrolledBefore"> & PartialParams);
+
+type PartialParams = Partial<TrackedEntitiesParamsBase>;
+
+export type TrackedEntitiesParamsBase = TrackedEntitiesOuRequest & {
+    query: string;
+    attribute: CommaDelimitedListOfUid;
+    filter: CommaDelimitedListOfAttributeFilter;
+    orgUnit: SemiColonDelimitedListOfUid;
+    program: Id;
+    programStatus: ProgramStatus;
+    programStage: Id;
+    followUp: boolean;
+    updatedAfter: IsoDate;
+    updatedBefore: IsoDate;
+    updatedWithin: IsoDate;
+    enrollmentEnrolledAfter: IsoDate;
+    enrollmentEnrolledBefore: IsoDate;
+    enrollmentOccurredAfter: IsoDate;
+    enrollmentOccurredBefore: IsoDate;
+    trackedEntityType: Id;
+    trackedEntity: SemiColonDelimitedListOfUid;
+    assignedUserMode: "CURRENT" | "PROVIDED" | "NONE" | "ANY";
+    assignedUser: SemiColonDelimitedListOfUid;
+    eventStatus: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";
+    eventOccurredAfter: IsoDate;
+    eventOccurredBefore: IsoDate;
+    skipMeta: boolean;
+    includeDeleted: boolean;
+    includeAllAttributes: boolean;
+    potentialDuplicate: boolean;
+};
+
+export interface TrackedEntitiesGetResponse {
+    page: number;
+    pageSize: number;
+    instances: D2TrackerTrackedEntity[];
+    total?: number; // Only if requested with totalPages=true
+}
+
+export interface D2TrackerTrackedEntitySchema {
+    name: "D2TrackerTrackedEntity";
+    model: D2TrackerTrackedEntity;
+    fields: D2TrackerTrackedEntity;
+    fieldPresets: {
+        $all: Preset<D2TrackerTrackedEntity, keyof D2TrackerTrackedEntity>;
+        $identifiable: Preset<D2TrackerTrackedEntity, FieldPresets["identifiable"]>;
+        $nameable: Preset<D2TrackerTrackedEntity, FieldPresets["nameable"]>;
+        $persisted: Preset<D2TrackerTrackedEntity, never>;
+        $owner: Preset<D2TrackerTrackedEntity, never>;
+    };
+}
+
+type D2TrackerTrackedEntityFields = Selector<D2TrackerTrackedEntitySchema>;

--- a/src/api/trackerTrackedEntities.ts
+++ b/src/api/trackerTrackedEntities.ts
@@ -27,11 +27,11 @@ type CommaDelimitedListOfAttributeFilter = string;
 
 export interface D2TrackerTrackedEntity {
     trackedEntity?: Id;
-    trackedEntityType?: string;
+    trackedEntityType?: Id;
     createdAt?: IsoDate;
     createdAtClient?: IsoDate;
     updatedAt?: IsoDate;
-    orgUnit?: string;
+    orgUnit?: SemiColonDelimitedListOfUid;
     inactive?: boolean;
     deleted?: boolean;
     relationships?: Relationship[];
@@ -66,8 +66,8 @@ export interface Enrollment {
     enrollment: Id;
     program: Id;
     orgUnit: Id;
-    enrollmentDate: string;
-    incidentDate: string;
+    enrollmentDate: IsoDate;
+    incidentDate: IsoDate;
     events?: Event[];
 }
 
@@ -94,12 +94,12 @@ type TrackerTrackedEntitiesParams<Fields> = Params & { fields: Fields } & Partia
     }>;
 
 type Params =
-    | (TrackedEntitiesParamsBase["orgUnit"] & PartialParams)
+    | ({ orgUnit: SemiColonDelimitedListOfUid } & PartialParams)
     | ({ ouMode: "ALL" } & PartialParams)
     | (Pick<TrackedEntitiesParamsBase, "programStatus" | "program"> & PartialParams)
     | (Pick<TrackedEntitiesParamsBase, "followUp" | "program"> & PartialParams)
-    | (Pick<TrackedEntitiesParamsBase, "enrollmentEnrolledAfter"> & PartialParams)
-    | (Pick<TrackedEntitiesParamsBase, "enrollmentEnrolledBefore"> & PartialParams);
+    | (Pick<TrackedEntitiesParamsBase, "enrollmentEnrolledAfter" | "program"> & PartialParams)
+    | (Pick<TrackedEntitiesParamsBase, "enrollmentEnrolledBefore" | "program"> & PartialParams);
 
 type PartialParams = Partial<TrackedEntitiesParamsBase>;
 


### PR DESCRIPTION
Related task: [Implement d2-api usage for EGASP (so it uses the new tracker endpoint)](https://app.clickup.com/t/865cua9zv)

Consuming code:
- `/tracker/events` -> https://github.com/EyeSeeTea/glass-dev/pull/176/files#diff-24915276d1e44c612c0e09d97ff50433136ee8d977768353f5f2a6c6a9eea181
- `/tracker/trackedEntities` ->  https://github.com/EyeSeeTea/glass-dev/pull/176/files#diff-e085a45593ebd7b2ceff539ece77a1afd0c1b37160a3624cb1f75a6975d5be5cL108