### PR TITLE
DELETE document endpoint

### DIFF
--- a/src/api/files.ts
+++ b/src/api/files.ts
@@ -1,7 +1,15 @@
 import { generateUid } from "../utils/uid";
 import { Id, MetadataResponse } from "./base";
-import { D2ApiResponse } from "./common";
+import { D2ApiResponse, ErrorReport } from "./common";
 import { D2ApiGeneric } from "./d2Api";
+
+interface FileHttpResponse<Response> {
+    httpStatus: "OK" | "Conflict" | "Not Found";
+    httpStatusCode: number;
+    status: "OK" | "ERROR";
+    message?: string;
+    response?: Response;
+}
 
 export interface FileUploadParameters {
     id?: Id;
@@ -23,6 +31,13 @@ export interface FileUploadResult {
     fileResourceId: string;
     response: MetadataResponse;
 }
+
+type FileDeleteResponse = FileHttpResponse<{
+    responseType: "ObjectReport";
+    uid: string;
+    klass: string;
+    errorReports?: ErrorReport[];
+}>;
 
 export class Files {
     constructor(public d2Api: D2ApiGeneric) {}
@@ -76,5 +91,9 @@ export class Files {
                 .post<MetadataResponse>("/metadata", {}, { documents: [document] })
                 .map(({ data }) => ({ id, fileResourceId, response: data }));
         });
+    }
+
+    delete(id: string): D2ApiResponse<FileDeleteResponse> {
+        return this.d2Api.delete<FileDeleteResponse>(`/documents/${id}`);
     }
 }


### PR DESCRIPTION
Related task: [Implement documents deletion in d2-api and include it when deleting files in GLASS](https://app.clickup.com/t/860q9r9yx)

Consuming code:

/documents/<document-id> -> https://github.com/EyeSeeTea/glass-dev/pull/178/commits/3f13067d2160365b6ff7c75646dd933687acfb9b