### PR TITLE
[api.files] Add support for NodeJs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@eyeseetea/d2-api",
     "description": "Typed wrapper over DHIS2 API",
-    "version": "1.13.1",
+    "version": "1.13.2-beta.4",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "repository": {
@@ -38,6 +38,7 @@
         "d2": "^31.8.1",
         "dotenv": "^8.0.0",
         "express": "^4.17.1",
+        "form-data": "^4.0.0",
         "iconv-lite": "0.6.2",
         "isomorphic-fetch": "3.0.0",
         "lodash": "^4.17.15",

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -2,8 +2,10 @@
 set -e -u -o pipefail
 
 version=$(cat package.json | jq -r '.version')
-publish_opts=$(echo $version | grep -q beta && echo "--tag beta" || true)
-yarn publish $publish_opts --new-version $version build/
+publish_opts=$(if echo "$version" | grep -q beta; then echo "--tag beta"; fi)
 
-git tag v$version -f
+yarn build
+yarn publish $publish_opts --new-version "$version" build/
+
+git tag "v$version" -f
 git push --tags

--- a/src/api/files.ts
+++ b/src/api/files.ts
@@ -1,28 +1,8 @@
+import FormData from "form-data";
 import { generateUid } from "../utils/uid";
 import { Id, MetadataResponse } from "./base";
 import { D2ApiResponse } from "./common";
 import { D2ApiGeneric } from "./d2Api";
-
-export interface FileUploadParameters {
-    id?: Id;
-    name: string;
-    data: Blob;
-    ignoreDocument?: boolean;
-}
-
-interface PartialSaveResponse {
-    response?: {
-        fileResource?: {
-            id?: string;
-        };
-    };
-}
-
-export interface FileUploadResult {
-    id: string;
-    fileResourceId: string;
-    response: MetadataResponse;
-}
 
 export class Files {
     constructor(public d2Api: D2ApiGeneric) {}
@@ -77,4 +57,25 @@ export class Files {
                 .map(({ data }) => ({ id, fileResourceId, response: data }));
         });
     }
+}
+
+export interface FileUploadParameters {
+    id?: Id;
+    name: string;
+    data: Blob | Buffer; // Use Blob for browser, Buffer for node
+    ignoreDocument?: boolean;
+}
+
+interface PartialSaveResponse {
+    response?: {
+        fileResource?: {
+            id?: string;
+        };
+    };
+}
+
+export interface FileUploadResult {
+    id: string;
+    fileResourceId: string;
+    response: MetadataResponse;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1258,6 +1258,11 @@ async@^2.6.2:
   dependencies:
     lodash "^4.17.14"
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 atob@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
@@ -1554,6 +1559,13 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@^2.8.1, commander@^2.9.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
@@ -1753,6 +1765,11 @@ define-property@^2.0.2:
   dependencies:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 delegates@^1.0.0:
   version "1.0.0"
@@ -2287,6 +2304,15 @@ for-own@^0.1.4:
   integrity sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=
   dependencies:
     for-in "^1.0.1"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -3120,6 +3146,18 @@ mime-db@1.40.0:
   version "1.40.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.40.0.tgz#a65057e998db090f732a68f6c276d387d4126c32"
   integrity sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==
+
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
 
 mime-types@~2.1.24:
   version "2.1.24"


### PR DESCRIPTION
Required by https://app.clickup.com/t/865cqypkn

Implementation:

- Blob is not support for Node. Solution: allow to pass a `Buffer`.
- Class `FormData` is not implemented in Node. Solution: Add a wrapper package (form-data)