### PR TITLE
Change tracker event status from SCHEDULED to SCHEDULE

### DIFF
--- a/src/api/trackerEvents.ts
+++ b/src/api/trackerEvents.ts
@@ -39,7 +39,7 @@ type UserInfo = {
     firstName: string;
     surname: string;
 };
-type EventStatus = "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULED" | "OVERDUE" | "SKIPPED";
+type EventStatus = "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";
 type IdScheme = string;
 
 interface D2TrackerEventBase {
@@ -99,7 +99,7 @@ interface EventsParamsBase {
     orgUnit?: Id;
     event?: Id;
     ouMode?: "SELECTED" | "CHILDREN" | "DESCENDANTS";
-    status?: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULED" | "OVERDUE" | "SKIPPED";
+    status?: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";
     occurredAfter?: IsoDate;
     occurredBefore?: IsoDate;
     scheduledAfter?: IsoDate;


### PR DESCRIPTION
According with the [documentation of the new Tracker API](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/tracker.html#events) :
- Change tracker event status `SCHEDULED` to `SCHEDULE`

Error creating an event with SCHEDULED status:
![Screenshot from 2024-02-14 10-57-11](https://github.com/EyeSeeTea/d2-api/assets/49402898/dd29be29-240a-4b32-b3d0-0a2061fc5130)

Correct status:
![Screenshot from 2024-02-13 15-00-52](https://github.com/EyeSeeTea/d2-api/assets/49402898/c76c1b13-5cf9-47b9-a776-6b71a8b423ee)

