### PR TITLE
add support for tracker v41

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,31 @@ const data = await api.tracker.trackedEntities
 console.log(data.instances);
 ```
 
+Adding the `totalPages` param will include a pager object:
+
+```ts
+const data = await api.tracker.trackedEntities
+    .get({
+        fields: {
+            orgUnit: true,
+        },
+        ouMode: "ALL",
+        program: "program_id",
+        totalPages: true,
+    })
+    .getData();
+
+console.log(data.pager);
+/*
+{
+    page: 1;
+    pageSize: 50;
+    pageCount: 10;
+    total: 500;
+}
+*/
+```
+
 ### Emails
 
 Send a test email:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@eyeseetea/d2-api",
     "description": "Typed wrapper over DHIS2 API",
-    "version": "1.16.1",
+    "version": "v1.17.0-beta.2",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@eyeseetea/d2-api",
     "description": "Typed wrapper over DHIS2 API",
-    "version": "v1.17.0-beta.2",
+    "version": "1.17.0-beta.4",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@eyeseetea/d2-api",
     "description": "Typed wrapper over DHIS2 API",
-    "version": "1.17.0-beta.5",
+    "version": "1.18.0-beta.1",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "repository": {

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -7,5 +7,5 @@ publish_opts=$(if echo "$version" | grep -q beta; then echo "--tag beta"; fi)
 yarn build
 yarn publish $publish_opts --new-version "$version" build/
 
-git tag "v$version" -f
+git tag "v$version" -f -m "Bump version"
 git push --tags

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -1,4 +1,5 @@
 import _ from "lodash";
+import { EmptyObject } from "../utils/types";
 import { Ref } from "./../schemas/base";
 import { D2ModelSchemaBase, Selector } from "./inference";
 import { TaskCategory } from "./system";
@@ -220,16 +221,16 @@ export function validate404(status: number): boolean {
 }
 
 export function parseTrackerPager(data: ParamTracker) {
-    return data.pager
-        ? data.pager
-        : {
-              page: data.page,
-              pageSize: data.pageSize,
-              total: data.total,
-              pageCount: data.pageCount,
-          };
+    return (
+        data.pager || {
+            page: data.page,
+            pageSize: data.pageSize,
+            total: data.total,
+            pageCount: data.pageCount,
+        }
+    );
 }
 
 interface ParamTracker extends TrackedPager {
-    pager: TrackedPager;
+    pager?: TrackedPager;
 }

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -3,6 +3,7 @@ import { Ref } from "./../schemas/base";
 import { D2ModelSchemaBase, Selector, SelectedPick } from "./inference";
 import { TaskCategory } from "./system";
 import { HttpClientResponse } from "../repositories/HttpClientRepository";
+import { TrackedPager } from "./trackerTrackedEntities";
 
 export interface GetOptionValue<
     D2ApiDefinition extends D2ApiDefinitionBase,
@@ -219,27 +220,42 @@ export function validate404(status: number): boolean {
     return validate2xx(status) || status === 404;
 }
 
-export function parseTrackerResponse<T, M extends D2ModelSchemaBase, Fields>(
-    response: HttpClientResponse<T>,
-    trackerKey: TrackedKeys
-) {
-    const { data } = response as HttpClientResponse<
-        T & {
-            instances?: SelectedPick<M, Fields>[];
-            trackedEntities?: SelectedPick<M, Fields>[];
-            events?: SelectedPick<M, Fields>[];
-            enrollments?: SelectedPick<M, Fields>[];
-        }
-    >;
+type TrackedKey = "trackedEntities" | "enrollments" | "events";
 
-    const responseData = _(data)
-        .omit([trackerKey])
-        .value();
+export type InternalTrackerResponse<M extends D2ModelSchemaBase, Fields, Key extends TrackedKey> = {
+    instances?: SelectedPick<M, Fields>[];
+    pager: TrackedPager;
+    page: number;
+    pageSize: number;
+    // Only if requested with totalPages=true
+    total?: number;
+    pageCount?: boolean;
+} & Record<Key, SelectedPick<M, Fields>[] | undefined>;
+
+export type PublicTrackerResponse<M extends D2ModelSchemaBase, Fields> = {
+    instances: SelectedPick<M, Fields>[];
+    pager: TrackedPager;
+};
+
+export function parseTrackerResponse<M extends D2ModelSchemaBase, Fields, Key extends TrackedKey>(
+    response: HttpClientResponse<InternalTrackerResponse<M, Fields, Key>>,
+    trackerKey: Key
+): PublicTrackerResponse<M, Fields> {
+    const { data } = response;
+
+    const pager = data.pager || {
+        page: data.page,
+        pageSize: data.pageSize,
+        total: data.total,
+        pageCount: data.pageCount,
+    };
 
     return {
-        ...responseData,
-        instances: data.instances || data[trackerKey],
+        ..._.omit(data, [trackerKey]),
+        pager,
+        // I tried to use the nullish coalescing operator to avoid the explicit cast
+        // but looks like we cannot use it in this project because babel version is too old
+        // TODO: upgrade babel
+        instances: (data.instances || data[trackerKey] || []) as SelectedPick<M, Fields>[],
     };
 }
-
-type TrackedKeys = "trackedEntities" | "enrollments" | "events";

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -223,7 +223,7 @@ export function parseTrackerResponse<T, M extends D2ModelSchemaBase, Fields>(
     response: HttpClientResponse<T>,
     trackerKey: TrackedKeys
 ) {
-    const { data } = (response as unknown) as HttpClientResponse<
+    const { data } = response as HttpClientResponse<
         T & {
             instances?: SelectedPick<M, Fields>[];
             trackedEntities?: SelectedPick<M, Fields>[];

--- a/src/api/trackerEnrollments.ts
+++ b/src/api/trackerEnrollments.ts
@@ -1,7 +1,7 @@
 import { D2ApiGeneric } from "./d2Api";
 import { Id, Selector, D2ApiResponse, SelectedPick } from "./base";
-import { Preset, FieldPresets } from "../schemas";
-import { getFieldsAsString } from "./common";
+import { Preset } from "../schemas";
+import { getFieldsAsString, parseTrackerResponse } from "./common";
 import { D2TrackerEvent, D2TrackerEventSchema, Note, D2TrackerEventToPost } from "./trackerEvents";
 import _ from "lodash";
 import { RequiredBy } from "../utils/types";
@@ -12,10 +12,18 @@ export class TrackerEnrollments {
     get<Fields extends D2TrackerEnrollmentFields>(
         params: TrackerEnrollmentsParams<Fields>
     ): D2ApiResponse<TrackerEnrollmentsResponse<Fields>> {
-        return this.api.get<TrackerEnrollmentsResponse<Fields>>("/tracker/enrollments", {
-            ..._.omit(params, ["fields"]),
-            fields: getFieldsAsString(params.fields),
-        });
+        return this.api
+            .get<TrackerEnrollmentsResponse<Fields>>("/tracker/enrollments", {
+                ..._.omit(params, ["fields"]),
+                fields: getFieldsAsString(params.fields),
+            })
+            .map(response => {
+                return parseTrackerResponse<
+                    TrackerEnrollmentsResponse<Fields>,
+                    D2TrackerEnrollmentSchema,
+                    Fields
+                >(response, "enrollments");
+            });
     }
 }
 

--- a/src/api/trackerEnrollments.ts
+++ b/src/api/trackerEnrollments.ts
@@ -1,7 +1,12 @@
 import { D2ApiGeneric } from "./d2Api";
 import { Id, Selector, D2ApiResponse, SelectedPick } from "./base";
 import { Preset } from "../schemas";
-import { getFieldsAsString, parseTrackerResponse } from "./common";
+import {
+    getFieldsAsString,
+    parseTrackerResponse,
+    PublicTrackerResponse,
+    InternalTrackerResponse,
+} from "./common";
 import { D2TrackerEvent, D2TrackerEventSchema, Note, D2TrackerEventToPost } from "./trackerEvents";
 import _ from "lodash";
 import { RequiredBy } from "../utils/types";
@@ -11,18 +16,14 @@ export class TrackerEnrollments {
 
     get<Fields extends D2TrackerEnrollmentFields>(
         params: TrackerEnrollmentsParams<Fields>
-    ): D2ApiResponse<TrackerEnrollmentsResponse<Fields>> {
+    ): D2ApiResponse<PublicTrackerResponse<D2TrackerEnrollmentSchema, Fields>> {
         return this.api
-            .get<TrackerEnrollmentsResponse<Fields>>("/tracker/enrollments", {
+            .get<EnrollmentsResponse<Fields>>("/tracker/enrollments", {
                 ..._.omit(params, ["fields"]),
                 fields: getFieldsAsString(params.fields),
             })
             .map(response => {
-                return parseTrackerResponse<
-                    TrackerEnrollmentsResponse<Fields>,
-                    D2TrackerEnrollmentSchema,
-                    Fields
-                >(response, "enrollments");
+                return parseTrackerResponse(response, "enrollments");
             });
     }
 }
@@ -129,3 +130,8 @@ export interface D2TrackerEnrollmentSchema {
 }
 
 type D2TrackerEnrollmentFields = Selector<D2TrackerEnrollmentSchema>;
+type EnrollmentsResponse<Fields> = InternalTrackerResponse<
+    D2TrackerEnrollmentSchema,
+    Fields,
+    "enrollments"
+>;

--- a/src/api/trackerEnrollments.ts
+++ b/src/api/trackerEnrollments.ts
@@ -105,8 +105,8 @@ type TrackerEnrollmentsParamsBase = {
 type SemiColonDelimitedListOfUid = string;
 type CommaDelimitedListOfUid = string;
 
-export interface TrackerEnrollmentsResponse<Fields> extends TrackedPager {
-    pager: TrackedPager;
+interface TrackerEnrollmentsResponse<Fields> extends TrackedPager {
+    pager?: TrackedPager;
     instances: SelectedPick<D2TrackerEnrollmentSchema, Fields>[];
 }
 

--- a/src/api/trackerEvents.ts
+++ b/src/api/trackerEvents.ts
@@ -153,7 +153,7 @@ export interface DataValue {
 }
 
 export interface TrackerEventsResponse<Fields> extends TrackedPager {
-    pager: TrackedPager;
+    pager?: TrackedPager;
     instances: SelectedPick<D2TrackerEventSchema, Fields>[];
 }
 

--- a/src/api/trackerEvents.ts
+++ b/src/api/trackerEvents.ts
@@ -1,7 +1,12 @@
 import { D2ApiGeneric } from "./d2Api";
 import { Id, Selector, D2ApiResponse, SelectedPick } from "./base";
 import { Preset, D2Geometry } from "../schemas";
-import { getFieldsAsString, parseTrackerResponse } from "./common";
+import {
+    getFieldsAsString,
+    parseTrackerResponse,
+    PublicTrackerResponse,
+    InternalTrackerResponse,
+} from "./common";
 import _ from "lodash";
 import { RequiredBy } from "../utils/types";
 
@@ -10,18 +15,14 @@ export class TrackerEvents {
 
     get<Fields extends D2TrackerEventFields>(
         params: EventsParams<Fields>
-    ): D2ApiResponse<TrackerEventsResponse<Fields>> {
+    ): D2ApiResponse<PublicTrackerResponse<D2TrackerEventSchema, Fields>> {
         return this.api
-            .get<TrackerEventsResponse<Fields>>("/tracker/events", {
+            .get<EventsResponse<Fields>>("/tracker/events", {
                 ..._.omit(params, ["fields"]),
                 fields: getFieldsAsString(params.fields),
             })
             .map(response => {
-                return parseTrackerResponse<
-                    TrackerEventsResponse<Fields>,
-                    D2TrackerEventSchema,
-                    Fields
-                >(response, "events");
+                return parseTrackerResponse(response, "events");
             });
     }
 
@@ -174,3 +175,4 @@ export interface D2TrackerEventSchema {
 }
 
 type D2TrackerEventFields = Selector<D2TrackerEventSchema>;
+type EventsResponse<Fields> = InternalTrackerResponse<D2TrackerEventSchema, Fields, "events">;

--- a/src/api/trackerTrackedEntities.ts
+++ b/src/api/trackerTrackedEntities.ts
@@ -1,7 +1,13 @@
 import _ from "lodash";
 import { D2Geometry, Preset } from "../schemas";
 import { Id, Selector, SelectedPick } from "./base";
-import { D2ApiResponse, getFieldsAsString, parseTrackerResponse } from "./common";
+import {
+    D2ApiResponse,
+    getFieldsAsString,
+    parseTrackerResponse,
+    InternalTrackerResponse,
+    PublicTrackerResponse,
+} from "./common";
 import { D2ApiGeneric } from "./d2Api";
 import {
     D2TrackerEnrollment,
@@ -15,22 +21,19 @@ export class TrackedEntities {
 
     get<Fields extends D2TrackerTrackedEntityFields>(
         params: TrackerTrackedEntitiesParams<Fields>
-    ): D2ApiResponse<TrackedEntitiesGetResponse<Fields>> {
+    ): D2ApiResponse<PublicTrackerResponse<D2TrackerTrackedEntitySchema, Fields>> {
         const { fields, order, ...rest } = params;
         const orderParam = this.buildOrderParams(order);
         const paramsToRequest = { ...rest, order: orderParam };
 
         return this.d2Api
-            .get<TrackedEntitiesGetResponse<Fields>>("/tracker/trackedEntities", {
+            .get<TrackerEntitiesResponse<Fields>>("/tracker/trackedEntities", {
                 ...paramsToRequest,
                 fields: getFieldsAsString(fields),
             })
             .map(response => {
-                return parseTrackerResponse<
-                    TrackedEntitiesGetResponse<Fields>,
-                    D2TrackerTrackedEntitySchema,
-                    Fields
-                >(response, "trackedEntities");
+                console.log("Tracker response", response);
+                return parseTrackerResponse(response, "trackedEntities");
             });
     }
 
@@ -195,7 +198,7 @@ export type TrackedPager = {
     total?: number;
 };
 
-export interface TrackedEntitiesGetResponse<Fields> {
+export interface TrackedEntitiesGetResponse<Fields> extends TrackedPager {
     pager: TrackedPager;
     page: number;
     pageSize: number;
@@ -223,3 +226,9 @@ export interface D2TrackerTrackedEntitySchema {
 }
 
 type D2TrackerTrackedEntityFields = Selector<D2TrackerTrackedEntitySchema>;
+
+type TrackerEntitiesResponse<Fields> = InternalTrackerResponse<
+    D2TrackerTrackedEntitySchema,
+    Fields,
+    "trackedEntities"
+>;

--- a/src/api/trackerTrackedEntities.ts
+++ b/src/api/trackerTrackedEntities.ts
@@ -196,7 +196,7 @@ export type TrackedPager = {
 };
 
 export interface TrackedEntitiesGetResponse<Fields> extends TrackedPager {
-    pager: TrackedPager;
+    pager?: TrackedPager;
     instances: SelectedPick<D2TrackerTrackedEntitySchema, Fields>[];
 }
 


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/86964a9ua

### :memo: Implementation

- In v41 the tracker endpoints `/tracker/trackedEntities`, `/tracker/events` and `/tracker/enrollments` no longer returns the data in an `instances` array anymore. Now they are using a key named after the plural of the returned entity.

`/tracker/trackedEntities`

```json
{
  "trackedEntities": [...]
}
```

`/tracker/events`

```json
{
  "events": [...]
}
```

`/tracker/enrollments`

```json
{
  "enrollments": [...]
}
```

In order to keep backwards compatibility and to avoid breaking changes in `d2-api` we'll keep the `instances` attribute checking for an `instances` array and if there's none we fall back to `trackedEntities`, `events` or `enrollments` according to the requested endpoint.

- Also now the pagination information is included in a `pager` object:

```json
{
  "pager": {
    "page": 3,    
    "pageSize": 2,
    "total": 373570,
    "pageCount": 186785,
  },
  "page": 3,
  "pageSize": 2,
  "total": 373570,
  "pageCount": 186785,
}
```

They are also keeping the pagination information outside the object for now, but it will be removed in a future release.

### :video_camera: Screenshots/Screen capture

### :fire: Notes to the tester

Can you help me with a beta version, please? @adrianq 

#86964a9ua