### PR TITLE
[feature] Add extra console.logs on catch branch

### DIFF
--- a/src/data/AxiosHttpClientRepository.ts
+++ b/src/data/AxiosHttpClientRepository.ts
@@ -21,11 +21,25 @@ export class AxiosHttpClientRepository implements HttpClientRepository {
 
         const response: () => Promise<HttpClientResponse<Data>> = () => {
             const axiosResponse = this.instance({ ...options, cancelToken });
-            return axiosResponse.then(res => ({
-                status: res.status,
-                data: res.data as Data,
-                headers: res.headers as HttpClientResponse<Data>["headers"],
-            }));
+            return axiosResponse
+                .then(res => ({
+                    status: res.status,
+                    data: res.data as Data,
+                    headers: res.headers as HttpClientResponse<Data>["headers"],
+                }))
+                .catch(error => {
+                    if (axios.isAxiosError(error)) {
+                        const method = options.method;
+                        const fullUrl = options.url;
+                        const body = error.response?.data
+                        const msg = `[d2-api:request] ${method} ${fullUrl}`;
+                        console.error(`${msg}\n${JSON.stringify(body, null, 4)}`);
+                    } else {
+                        console.error('Unexpected Error:', JSON.stringify(error));
+                    }
+
+                    throw error;
+                });
         };
 
         return CancelableResponse.build({ cancel, response: response });

--- a/src/data/FetchHttpClientRepository.ts
+++ b/src/data/FetchHttpClientRepository.ts
@@ -69,6 +69,8 @@ export class FetchHttpClientRepository implements HttpClientRepository {
                     return { status: res.status, data: data as Data, headers };
                 })
                 .catch(error => {
+                    const msg = `[d2-api:request] ${method} ${fullUrl}`;
+                    console.debug(`${msg} \n${JSON.stringify(error, null, 4)}`);
                     if (error.request) throw error;
                     throw new HttpError(error.toString(), { request: options });
                 })


### PR DESCRIPTION
Detected on https://app.clickup.com/t/8697ycwm0 

When an HTTP error occurs and is logged using `console.error` in a Node.js environment, the thrown error is an object, which may result in incomplete output. 

- [x] Refactor fetch/Axios repositories to ensure the full response body is displayed in the console.