### PR TITLE
[fix] Support all fields keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@eyeseetea/d2-api",
     "description": "Typed wrapper over DHIS2 API",
-    "version": "1.18.0-beta.1",
+    "version": "1.18.0-beta.3",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "repository": {

--- a/src/api/trackerEnrollments.ts
+++ b/src/api/trackerEnrollments.ts
@@ -1,11 +1,12 @@
 import { D2ApiGeneric } from "./d2Api";
 import { Id, Selector, D2ApiResponse, SelectedPick } from "./base";
 import { Preset } from "../schemas";
-import { getFieldsAsString, parseTrackerPager } from "./common";
+import { parseTrackerPager } from "./common";
 import { D2TrackerEvent, D2TrackerEventSchema, Note, D2TrackerEventToPost } from "./trackerEvents";
 import _ from "lodash";
 import { RequiredBy } from "../utils/types";
 import { TrackedPager } from "./trackerTrackedEntities";
+import { getTrackerFieldsParam } from "./tracker";
 
 export class TrackerEnrollments {
     constructor(public api: D2ApiGeneric) {}
@@ -16,7 +17,7 @@ export class TrackerEnrollments {
         return this.api
             .get<EnrollmentResponse<Fields>>("/tracker/enrollments", {
                 ..._.omit(params, ["fields"]),
-                fields: getFieldsAsString(params.fields),
+                fields: getTrackerFieldsParam(params.fields),
             })
             .map(({ data }) => {
                 return {
@@ -105,7 +106,7 @@ type TrackerEnrollmentsParamsBase = {
 type SemiColonDelimitedListOfUid = string;
 type CommaDelimitedListOfUid = string;
 
-interface TrackerEnrollmentsResponse<Fields> extends TrackedPager {
+export interface TrackerEnrollmentsResponse<Fields> extends TrackedPager {
     pager?: TrackedPager;
     instances: SelectedPick<D2TrackerEnrollmentSchema, Fields>[];
 }

--- a/src/api/trackerEvents.ts
+++ b/src/api/trackerEvents.ts
@@ -1,10 +1,11 @@
 import { D2ApiGeneric } from "./d2Api";
 import { Id, Selector, D2ApiResponse, SelectedPick } from "./base";
 import { Preset, D2Geometry } from "../schemas";
-import { getFieldsAsString, parseTrackerPager } from "./common";
+import { parseTrackerPager } from "./common";
 import _ from "lodash";
 import { RequiredBy } from "../utils/types";
 import { TrackedPager } from "./trackerTrackedEntities";
+import { getTrackerFieldsParam } from "./tracker";
 
 export class TrackerEvents {
     constructor(public api: D2ApiGeneric) {}
@@ -15,7 +16,7 @@ export class TrackerEvents {
         return this.api
             .get<EventsResponse<Fields>>("/tracker/events", {
                 ..._.omit(params, ["fields"]),
-                fields: getFieldsAsString(params.fields),
+                fields: getTrackerFieldsParam(params.fields),
             })
             .map(({ data }) => {
                 return {
@@ -32,7 +33,7 @@ export class TrackerEvents {
     ): D2ApiResponse<D2TrackerEvent> {
         return this.api.get<D2TrackerEvent>(`/tracker/events/${id}`, {
             ..._.omit(params, ["fields"]),
-            fields: getFieldsAsString(params.fields),
+            fields: getTrackerFieldsParam(params.fields),
         });
     }
 }

--- a/src/api/trackerTrackedEntities.ts
+++ b/src/api/trackerTrackedEntities.ts
@@ -185,11 +185,12 @@ export type TrackedOrderField = {
 };
 
 export type TrackedAttributesFields = { type: "trackedEntityAttributeId"; id: Id };
+
 export type TrackedPager = {
     page: number;
     pageSize: number;
-    // Only if requested with totalPages=true
-    pageCount?: boolean;
+    // These two fields are available only for requests with query "totalPages=true"
+    pageCount?: number;
     total?: number;
 };
 

--- a/src/api/trackerTrackedEntities.ts
+++ b/src/api/trackerTrackedEntities.ts
@@ -1,7 +1,7 @@
 import _ from "lodash";
 import { D2Geometry, Preset } from "../schemas";
 import { Id, Selector, SelectedPick } from "./base";
-import { D2ApiResponse, getFieldsAsString, parseTrackerPager } from "./common";
+import { D2ApiResponse, parseTrackerPager } from "./common";
 import { D2ApiGeneric } from "./d2Api";
 import {
     D2TrackerEnrollment,
@@ -9,6 +9,7 @@ import {
     D2TrackerEnrollmentToPost,
 } from "./trackerEnrollments";
 import { RequiredBy, Maybe } from "../utils/types";
+import { getTrackerFieldsParam } from "./tracker";
 
 export class TrackedEntities {
     constructor(public d2Api: D2ApiGeneric) {}
@@ -23,7 +24,7 @@ export class TrackedEntities {
         return this.d2Api
             .get<TrackerResponse<Fields>>("/tracker/trackedEntities", {
                 ...paramsToRequest,
-                fields: getFieldsAsString(fields),
+                fields: getTrackerFieldsParam(fields),
             })
             .map(({ data }) => {
                 return {

--- a/src/data/AxiosHttpClientRepository.ts
+++ b/src/data/AxiosHttpClientRepository.ts
@@ -31,11 +31,11 @@ export class AxiosHttpClientRepository implements HttpClientRepository {
                     if (axios.isAxiosError(error)) {
                         const method = options.method;
                         const fullUrl = options.url;
-                        const body = error.response?.data
+                        const body = error.response ? error.response.data : undefined;
                         const msg = `[d2-api:request] ${method} ${fullUrl}`;
                         console.error(`${msg}\n${JSON.stringify(body, null, 4)}`);
                     } else {
-                        console.error('Unexpected Error:', JSON.stringify(error));
+                        console.error("Unexpected Error:", JSON.stringify(error));
                     }
 
                     throw error;


### PR DESCRIPTION
Required by https://github.com/EyeSeeTea/d2-tools/pull/59

- [x] fields=:all is not supported for /tracker/... endpoints. Manually convert to "*"