### PR TITLE
[feature] Add PATCH method to manual API requests

### DIFF
--- a/src/repositories/HttpClientRepository.ts
+++ b/src/repositories/HttpClientRepository.ts
@@ -6,7 +6,7 @@ export interface HttpClientRepository {
     getMockAdapter(): MockAdapter;
 }
 
-export type Method = "get" | "post" | "put" | "delete";
+export type Method = "get" | "post" | "put" | "delete" | "patch";
 
 export type ParamValue = string | number | boolean | undefined;
 


### PR DESCRIPTION
The DHIS2 Web API add supports PATCH Method for partial updates using the JSON Patch format. 

https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-240/metadata.html#webapi_partial_updates

I use it to edit disable user field.
[
  { "op": "replace", "path": "/disabled", "value": true }
]
to the endpoint /api/41/users/USER_ID using a PATCH request. Your d2-api usage is correct, but since  ttpClientRepository.d.ts lacked "patch" in its Method type, adding it manually like you did is fine. 


I need to set the Content-Type header to application/json-patch+json. 
Maybe that could be implemented in the d2-api in some way but I used this:

await this.api
    .request<string>({
        method: "patch",
        url: `/41/users/${userId}`,
        headers: { "Content-Type": "application/json-patch+json" },
        data: [{ op: "replace", path: "/disabled", value: true }],
    })
    .getData();
