### PR TITLE
[feature] Support fetch+FormData for node 18 [backend: fetch]

### DIFF
--- a/src/api/files.ts
+++ b/src/api/files.ts
@@ -75,7 +75,6 @@ export class Files {
                 url: "/fileResources",
                 data: formData,
                 requestBodyType: "raw",
-                headers: formData.getHeaders(),
             })
             .map(({ data }) => {
                 if (

--- a/src/api/files.ts
+++ b/src/api/files.ts
@@ -75,6 +75,7 @@ export class Files {
                 url: "/fileResources",
                 data: formData,
                 requestBodyType: "raw",
+                headers: formData.getHeaders(),
             })
             .map(({ data }) => {
                 if (

--- a/src/data/FetchHttpClientRepository.ts
+++ b/src/data/FetchHttpClientRepository.ts
@@ -1,8 +1,7 @@
-import AbortController from "abort-controller";
 import MockAdapter from "axios-mock-adapter";
 import btoa from "btoa";
 import iconv from "iconv-lite";
-import "cross-fetch/polyfill";
+import fetch from "cross-fetch";
 import _ from "lodash";
 import qs from "qs";
 import { CancelableResponse } from "../repositories/CancelableResponse";
@@ -46,7 +45,7 @@ export class FetchHttpClientRepository implements HttpClientRepository {
             : {};
 
         const fetchOptions: RequestInit = {
-            method,
+            method: method,
             signal: controller.signal,
             body: getBody(requestBodyType, data),
             headers: { ...baseHeaders, ...authHeaders, ...extraHeaders },
@@ -110,7 +109,7 @@ function raiseHttpError(request: HttpRequest, response: Response, body: unknown)
     });
 }
 
-function getHeadersRecord(headers: Headers) {
+function getHeadersRecord(headers: Headers): Record<string, string> {
     return headers ? _.fromPairs(Array.from(headers.entries())) : {};
 }
 

--- a/src/data/FetchHttpClientRepository.ts
+++ b/src/data/FetchHttpClientRepository.ts
@@ -58,7 +58,7 @@ export class FetchHttpClientRepository implements HttpClientRepository {
         const timeoutId = timeout ? setTimeout(() => controller.abort(), timeout) : null;
 
         const response: () => Promise<HttpClientResponse<Data>> = () => {
-            const fetchResponse = fetch(fullUrl, fetchOptions);
+            const fetchResponse = fetchFn(fullUrl, fetchOptions);
             return fetchResponse
                 .then(async res => {
                     const headers = getHeadersRecord(res.headers);
@@ -145,3 +145,9 @@ async function getResponseData(
         return content;
     }
 }
+
+// Use global fetch in the browser to avoid "Illegal invocation" errors.
+// Use cross-fetch in Node.js to ensure compatibility with multipart/form-data,
+// since native fetch in Node 18 does not fully support multipart uploads with form-data.
+// (to investigate: use native FormData in browser and formdata-node)
+const fetchFn = typeof window === "undefined" ? fetch : globalThis.fetch;


### PR DESCRIPTION
https://app.clickup.com/t/8699x5zxj

Problem:

[backend: fetch]

After updating d2-tools to Node v18, file uploads with fetch using multipart form data stopped working (response from DHIS2: `org.springframework.web.multipart.MultipartException: Current request is not a multipart request`).

This was unexpected, as Node 18 added native support for fetch. The issue is that this fetch implementation does not handle FormData the same way browsers do.

Solution:

- [x] Use cross-fetch, which is a no-op in a browser but returns a fetch compatible with FileData in Node 18+

Tested:

- [x] d2-tools with node 18
- [x] Browser: CPR (UPG file upload)

Notes:

There exists https://www.npmjs.com/package/formdata-node, which should, in principle, fix the problems with native Node fetch and FileData. However, it's a Node-only module, so we cannot directly use it. In principle, it should be possible with some manual imports, but as the cross-fetch solution is simple enough, I think the gain would be minimal.