### PR TITLE
add agent support for fetch backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@eyeseetea/d2-api",
     "description": "Typed wrapper over DHIS2 API",
-    "version": "1.19.1",
+    "version": "1.20.0-beta.4",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "repository": {

--- a/src/data/FetchHttpClientRepository.ts
+++ b/src/data/FetchHttpClientRepository.ts
@@ -53,13 +53,14 @@ export class FetchHttpClientRepository implements HttpClientRepository {
             credentials: auth ? "omit" : ("include" as const),
         };
 
+        const optionsWithAgent = this.getAgentOptions(fetchOptions);
         const fullUrl = joinPath(baseUrl, url) + getQueryStrings(params);
 
         // Fetch API has no timeout mechanism, implement with a setTimeout + controller.abort
         const timeoutId = timeout ? setTimeout(() => controller.abort(), timeout) : null;
 
         const response: () => Promise<HttpClientResponse<Data>> = () => {
-            const fetchResponse = fetch(fullUrl, fetchOptions);
+            const fetchResponse = fetch(fullUrl, optionsWithAgent);
             return fetchResponse
                 .then(async res => {
                     const headers = getHeadersRecord(res.headers);
@@ -82,6 +83,24 @@ export class FetchHttpClientRepository implements HttpClientRepository {
 
     getMockAdapter(): MockAdapter {
         throw new Error("Not implemented");
+    }
+
+    private getAgentOptions(options: RequestInit) {
+        if (typeof window !== "undefined") return options;
+
+        // In Node.js, native fetch is based on undici and expects the `dispatcher` option
+        // to be an instance of `undici.Dispatcher`. We validate that the provided agent
+        // has a `dispatch` method to ensure compatibility
+        const isDispatcher = typeof (this.options.agent as any).dispatch === "function";
+
+        if (isDispatcher) {
+            return { ...options, dispatcher: this.options.agent };
+        } else {
+            console.warn(
+                "[FetchHttpClientRepository] 'agent' is not compatible with fetch (Node.js Dispatcher expected). Ignoring."
+            );
+            return options;
+        }
     }
 }
 


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/8698pp7e5

### :memo: Implementation

- [x] Ignore agent option if environment is not NODE
- [x] validate agent has a dispatch function (required by fetch implementation)

#### Testing:

- Create a socks proxy

```shell
ssh -D 9500 localhost
```

- Test using d2-api

```ts
import { socksDispatcher } from "fetch-socks";

const proxyAgent = socksDispatcher({
    type: 5,
    host: "::1",
    port: 9500,
});

const api = new D2Api({
  baseUrl: "https://play.im.dhis2.org/stable-2-42-1/",
  agent: proxyAgent,
  backend: "fetch",
  auth: {
    password: "district",
    username: "admin",
  },
});

const info = await api.system.info.getData();
console.debug(info);
```

### :fire: Notes for the reviewer

Can you please help me with a new beta version on npm?

### :art: Screenshots

#8698pp7e5