### PR TITLE
[feature] [email] Use POST body on email notification message

### DIFF
--- a/src/api/email.ts
+++ b/src/api/email.ts
@@ -1,5 +1,6 @@
 import { D2ApiGeneric } from "./d2Api";
 import { D2ApiResponse } from "./common";
+import { D2ApiRequest } from "./types";
 
 /* https://docs.dhis2.org/master/en/developer/html/webapi_email.html */
 
@@ -11,13 +12,8 @@ export class Email {
     }
 
     sendMessage(message: OutboundMessage): D2ApiResponse<void> {
-        const params = {
-            recipients: message.recipients,
-            subject: message.subject,
-            message: message.text,
-        };
-
-        return this.d2Api.post("/email/notification", params);
+        const requestOptions = getSendEmailRequestOptions(message);
+        return this.d2Api.post("/email/notification", undefined, undefined, requestOptions);
     }
 
     sendTestMessage(): D2ApiResponse<void> {
@@ -25,12 +21,59 @@ export class Email {
     }
 }
 
-export interface OutboundMessage {
+export type OutboundMessage = {
     recipients: string[];
     subject?: string;
     text: string;
-}
-export interface NotificationMessage {
+};
+
+export type NotificationMessage = {
     subject: string;
     text: string;
+};
+
+/*
+Outbound emails
+
+The "Outbound emails" section in the documentation shows sending an email via
+query string parameters:
+
+curl "http://localhost/api/33/email/notification?recipients=xyz%40abc.com&message=sample%20email&subject=Test%20Email" \
+  -X POST -u admin:district
+
+Problem: using query strings quickly hits 414 "URI Too Long" when the message is
+large. This endpoint does not support a JSON body.
+
+Solution: send the message in the POST body as application/x-www-form-urlencoded.
+Verified with curl:
+
+curl -u user:pass -X POST http://localhost:8080/api/email/notification \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "recipients=EMAIL1,EMAIL2" \
+  --data-urlencode "subject=test" \
+  --data-urlencode "message=contents"
+
+Implementation: in JavaScript, replicate the same by building a URL-encoded
+string for the request body and setting the appropriate headers. d2Api.post is
+generic enough to handle this; provide the encoded body and headers.
+*/
+
+function toFormBody(entries: Record<string, string>): string {
+    return Object.entries(entries)
+        .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+        .join("&");
+}
+
+function getSendEmailRequestOptions(
+    message: OutboundMessage
+): Omit<D2ApiRequest, "method" | "url"> {
+    return {
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        requestBodyType: "raw",
+        data: toFormBody({
+            recipients: message.recipients.join(","),
+            subject: message.subject || "",
+            message: message.text,
+        }),
+    };
 }


### PR DESCRIPTION
Closes https://app.clickup.com/t/869a3bqez

- [ ] Use header x-www-form-urlencoded + message in post body, instead of query strings.
- [ ] Open JIRA issue

## Technical details

Documentation for Email -> Outbound email states:

https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/email.html#outbound-emails 

```shell
$ curl "localhost/api/33/email/notification?recipients=xyz%40abc.com&message=sample%20email&subject=Test%20Email"
  -X POST -u admin:district
```

That works, but it’s not optimal. Since the message is passed as a query string, it will quickly hit the URL length limit on the server (414), typically around 8 KB. Instead, send the message in the POST body, which does not have that limit.

```shell
curl -u admin:district -X POST 'http://localhost/api/33/email/notification' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  --data-urlencode 'recipients=xyz@abc.com' \
  --data-urlencode 'subject=Test Email' \
  --data-urlencode 'message=sample email'
```shell

The equivalent for JS: pass the header + body as escaped "key=value&...".