### PR TITLE
fix(tracker): make D2TrackerEvent.enrollment optional, drop enrollmentStatus

### DIFF
--- a/src/api/trackerEvents.ts
+++ b/src/api/trackerEvents.ts
@@ -58,8 +58,7 @@ interface D2TrackerEventBase {
     status: EventStatus;
     program: Id;
     programStage: Id;
-    enrollment: Id;
-    enrollmentStatus: "ACTIVE" | "COMPLETED" | "CANCELLED";
+    enrollment?: Id;
     orgUnit: Id;
     orgUnitName: string;
     occurredAt: IsoDate;


### PR DESCRIPTION
## Problem

`D2TrackerEvent` (`src/api/trackerEvents.ts`) typed two fields incorrectly:

- `enrollment: Id` — **required**, but on DHIS2 **2.40** the tracker events **list** endpoint returns event-program (`WITHOUT_REGISTRATION`) events **without** an `enrollment`.
- `enrollmentStatus: "ACTIVE" | "COMPLETED" | "CANCELLED"` — **the tracker events endpoint never returns this field** on any tested version or endpoint.

Both `TrackerEvents.get()` (list, `/tracker/events`) and `TrackerEvents.getById()` (`/tracker/events/{id}`) return the same `D2TrackerEvent` type, so it must tolerate the missing field.

## Change

```diff
-    enrollment: Id;
-    enrollmentStatus: "ACTIVE" | "COMPLETED" | "CANCELLED";
+    enrollment?: Id;
```

`enrollment?` matches the existing `trackedEntity?: Id` escape-hatch already in the same interface.

## Verification (live, against play.im.dhis2.org)

Event program `eBAyeGv0exc` (Inpatient morbidity and mortality), tracker program `IpHINAT79UW` (Child Programme). Checked both the list endpoint (`GET /api/tracker/events?program=…`) and the single endpoint (`GET /api/tracker/events/{id}`).

**Event-program `enrollment` — by version and endpoint:**

| Version | list endpoint | single endpoint | `enrollmentStatus` (either) |
|---|---|---|---|
| **dev-2-40** (2.40.13) | **absent** (100/100 events) | present | never present |
| **dev-2-41** (2.41.9) | present | present | never present |
| **dev-2-42** (2.42.6) | present | present | never present |

Tracker-program (`IpHINAT79UW`) events return `enrollment` on every version/endpoint, and never `enrollmentStatus`.

**Key findings:**
- On **2.40**, the list exporter **omits `enrollment`** for event-program events while the single-event endpoint includes it — confirmed on the same event `WtUDEw3resf` (list → absent; single → `RiLEKhWHlxZ`). This is a DHIS2 2.40 quirk.
- From **2.41** the new tracker auto-generates a (hidden) enrollment for event programs, so the list endpoint populates `enrollment` too; the list-vs-single discrepancy is **2.40-only**.
- `enrollmentStatus` is **never** returned by the tracker events endpoint on any version or endpoint.

## Compatibility

- `enrollment?` is non-breaking for producers; consumers must now null-check (reflects reality on 2.40 `get()`).
- Removing `enrollmentStatus` is a minor breaking change only for code reading `event.enrollmentStatus`, which was already `undefined` at runtime.
- `D2TrackerEventSchema` and `D2TrackerEventToPost` derive from `D2TrackerEvent`, so the change propagates automatically; neither field is in `RequiredFieldsOnPost`. `tsc --noEmit` passes.

## TODO

- [ ] Create branches for v40/41/42